### PR TITLE
v0.3.4 - Code mode plus Agent upgrade

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,6 @@ Thumbs.db
 # Config (may contain API keys)
 config.json
 .npmrc
+
+# Local development files
+oc-dev/

--- a/README.md
+++ b/README.md
@@ -1,199 +1,274 @@
-# Jiva - Versatile Autonomous AI Agent
+# Jiva
 
-[![npm version](https://img.shields.io/npm/v/jiva-core.svg)](https://www.npmjs.com/package/jiva-core) [![License](https://img.shields.io/github/license/KarmaloopAI/Jiva.svg)](LICENSE) [![GitHub stars](https://img.shields.io/github/stars/KarmaloopAI/Jiva.svg?style=social&label=Star)](https://github.com/KarmaloopAI/Jiva)
+[![npm version](https://img.shields.io/npm/v/jiva-core.svg)](https://www.npmjs.com/package/jiva-core)
+[![License](https://img.shields.io/github/license/KarmaloopAI/Jiva.svg)](LICENSE)
+[![GitHub stars](https://img.shields.io/github/stars/KarmaloopAI/Jiva.svg?style=social&label=Star)](https://github.com/KarmaloopAI/Jiva)
 
-Jiva is a powerful autonomous AI agent with a three-agent architecture (Manager, Worker, Client) powered by gpt-oss-120b with full MCP (Model Context Protocol) support. Deploy as a CLI tool or scale to production on Google Cloud Run.
-
-## Quick Links
-
-- **[Quick Start Guide](docs/guides/QUICKSTART.md)** - Get up and running in 30 seconds
-- **[Cloud Run Deployment](docs/deployment/CLOUD_RUN_DEPLOYMENT.md)** - Deploy to production
-- **[Configuration Guide](docs/guides/CONFIGURATION.md)** - Detailed configuration and provider setup
-- **[Documentation](docs/README.md)** - Complete documentation index
-- **[Build Instructions](docs/guides/BUILD.md)** - Detailed setup and development workflow
-- **[Troubleshooting](docs/guides/TROUBLESHOOTING.md)** - Common issues and solutions
+Jiva is an autonomous AI agent for the terminal and cloud. It works with any OpenAI-compatible model provider and supports two execution modes — a general-purpose two-agent system (Manager + Worker) for complex tasks, and a code-optimized single-loop engine with LSP integration for software engineering.
 
 ## Demo
 
 ![Demo](jiva-new-demo.gif)
 
-## Features
-
-### Core Capabilities
-- **Three-Agent Architecture**: Manager for planning, Worker for execution, Client for quality validation
-- **Adaptive Quality Control**: Client agent uses tiered validation (MINIMAL→STANDARD→THOROUGH) based on task complexity
-- **Unjustified Failure Detection**: LLM-powered analysis catches agents giving up without trying
-- **Cloud-Ready Deployment**: Run on Google Cloud Run with auto-scaling, WebSocket support, and GCS storage
-- **Multi-Tenancy**: Per-tenant isolation with authenticated session management
-- **Provider Agnostic**: Works with Krutrim, Groq, OpenAI, Ollama, and any OpenAI-compatible API
-- **MCP Integration**: Seamless integration with Model Context Protocol servers for extensible tooling
-- **Smart Conversations**: Auto-save, restore, and AI-generated titles for all conversations
-- **Directive-Based**: Orient agent behavior with custom `jiva-directive.md` files
-- **Storage Abstraction**: Local filesystem or cloud storage (GCS, future: S3, Redis)
-
-### v0.3.1 Features
-- **Production Deployment**: One-command Cloud Run deployment with GCS persistence
-- **Client Agent**: Intelligent validation that ensures work quality and catches false failures
-- **HTTP/WebSocket API**: RESTful endpoints and real-time bidirectional communication
-- **Authentication**: Firebase Auth, custom JWT, or development mode
-- **Session Management**: Auto-scaling agent instances with idle timeout and cleanup
-- **Container Orchestration**: Multi-stage Docker builds, health probes, graceful shutdown
-- **Personas & Skills**: 100% compatible with Claude's Skills/Plugins system - extend Jiva with domain-specific capabilities
-
-### Personas (Skills & Plugins)
-
-Jiva supports persona-based skill management, fully compatible with Claude's Skills/Plugins system:
-
-```bash
-# List available personas
-jiva persona list
-
-# Activate a persona
-jiva persona activate data-analyst
-
-# Create your own skill
-jiva persona create-skill my-skill \
-  --description "Custom functionality" \
-  --author "Your Name"
-
-# Package and distribute
-jiva persona package-skill my-skill
-```
-
-**Key Features:**
-- **Progressive Disclosure**: Skills load only what's needed (L1→L2→L3)
-- **Automatic Routing**: Agent selects skills based on user request
-- **Composable**: Bundle skills, commands, agents, and MCP servers
-- **Portable**: Same .skill files work on Claude and Jiva
-
-See **[Personas Guide](docs/guides/PERSONAS.md)** for complete documentation.
-
-### v0.3.23 Bug Fixes
-- **Linux Path Fix**: Resolved startup errors on Linux where Jiva was reading from the wrong directory — new `platform.ts` utility ensures correct path resolution across all platforms
-- **Punycode Deprecation**: Eliminated `[DEP0040] DeprecationWarning` by lazy-loading `@google-cloud/storage` so the deprecated built-in `punycode` module is never loaded during CLI-only sessions
-- **Type Safety**: Fixed a `mustUseTools` type error in the Client agent
-- **Dev Publishing**: Added CI workflow to auto-publish `dev`-tagged npm releases on every merge to `develop`
-
-### v0.3.22 Maintenance
-- **Security Updates**: Upgraded `glob` and `tr46` via npm `overrides` to resolve known vulnerabilities
-- **CI/CD**: Added GitHub Actions workflow to automatically publish releases to npm
-
-### v0.3.2 Bug Fixes & Quality Improvements
-**Bug Fixes:**
-- **Persona Isolation**: Sub-agents now use ephemeral personas that don't overwrite parent agent configuration
-- **Context Propagation**: Workspace directory automatically injected into all sub-agent task messages
-- **Enhanced Logging**: Persona context included in all log messages for better multi-agent debugging
-- **Reduced Hallucination**: Temperature lowered from 0.3-0.7 to 0.1-0.2 for more deterministic, fact-based behavior
-
-**HTTP/Cloud Compatibility:**
-- **🚨 Per-Tenant Persona Config** (CRITICAL): Fixed cross-tenant persona configuration leakage - each tenant's settings now isolated in GCS
-- **Session-Scoped Logging**: Fixed persona context race conditions in concurrent HTTP sessions
-- **Cloud-Aware Orchestration**: Orchestration logs now persist to cloud storage (GCS/S3) instead of ephemeral filesystem
-
-**Quality Improvements:**
-- **LLM-Based Validation**: Client agent uses semantic analysis instead of keyword matching for involvement level detection
-- **Coherence Checking**: Detects when Worker fabricates accomplishments not supported by actual tool usage
-- **Robust Plan Parsing**: Manager agent parsing with JSON format, LLM cleanup fallback, and garbage filtering
-- **Client Logging**: Full orchestration traceability for validation decisions and quality control
-
-**⚠️ CRITICAL:** If running in HTTP/Cloud mode (v0.3.1+), **upgrade immediately**:
-- v0.3.1 has cross-tenant configuration leakage (security issue)
-- v0.3.2 fixes multi-tenant isolation with per-tenant storage
-
-### v0.2.1 Features
-- **Dual-Agent System**: Separate Manager and Worker agents for better task focus and reliability
-- **Chain-of-Thought Logging**: Transparent reasoning at INFO level with clean ASCII formatting
-- **Robust Error Recovery**: Automatic retry with error feedback for API and tool failures
-- **Workspace-Aware Operations**: Smart path resolution for file operations
-- **Slash Commands**: Use `/help`, `/load`, `/save`, `/list` for easy conversation management
-- **Smart Tool Format Detection**: Auto-detects Harmony vs Standard OpenAI tool calling format
-
-See [release notes](docs/release_notes/) for detailed version history.
+---
 
 ## Installation
 
-### Global Install (Recommended)
-
 ```bash
 npm install -g jiva-core
-```
-
-After installation, run the setup wizard:
-
-```bash
 jiva setup
 ```
 
-### Development Install
+The setup wizard prompts for your API endpoint, key, and model name. Jiva works with Krutrim, Groq, OpenAI, Ollama, and any OpenAI-compatible provider.
+
+### Development install
 
 ```bash
 git clone https://github.com/KarmaloopAI/Jiva.git
-cd jCLI Mode (Local Development)
-
-#### 1. Install Jiva
-
-```bash
-npm install -g jiva-core
-```
-
-#### 2. First-Time Setup
-
-Run the interactive setup wizard:
-
-```bash
+cd Jiva
+npm install && npm run build && npm link
 jiva setup
 ```
 
-You'll be prompted for:
-- Krutrim API endpoint (default: `https://cloud.olakrutrim.com/v1/chat/completions`)
-- API key for gpt-oss-120b ([Get your API key](https://cloud.olakrutrim.com))
-- Optional multimodal model (Llama-4-Maverick-17B)
-- MCP server configuration
+---
 
-#### 3. Start Chatting
-
-Launch interactive mode:
+## Quick Start
 
 ```bash
+# General-purpose interactive session
 jiva chat
+
+# Code mode — optimized for software engineering tasks
+jiva chat --code
+
+# Code mode with plan-then-approve flow
+jiva chat --code --plan
+
+# Single prompt
+jiva run "What changed in the last 5 commits?"
+
+# Single prompt in code mode
+jiva run "Add error handling to the database module" --code
 ```
 
-**Try these commands:**
+### REPL commands
+
+| Command | Description |
+|---------|-------------|
+| `/help` | Show available commands |
+| `/tools` | List active tools |
+| `/servers` | Show MCP server status |
+| `/save` | Save current conversation |
+| `/load` | Resume a saved conversation |
+| `/list` | Browse all saved conversations |
+| `/reset` | Clear conversation history |
+| `/exit` | Exit Jiva |
+
+---
+
+## Execution Modes
+
+### General mode (default)
+
+A two-agent pipeline designed for complex, multi-step tasks:
+
+```
+User Request
+    ↓
+Manager Agent    — plans, decomposes, and synthesizes
+    ↓
+Worker Agent     — executes subtasks with MCP tools
+    ↓
+Response
+```
+
+The Worker has access to any configured MCP server (filesystem, browser automation, shell commands, etc.). The Manager synthesizes results from all subtasks into a final coherent response. Simple conversational messages are answered directly without executing subtasks.
+
+### Code mode (`--code`)
+
+A single streaming loop optimized for coding tasks:
+
+```
+User Request
+    ↓
+CodeAgent
+    loop until done:
+        LLM call with tool definitions
+        ↓
+        Tool execution (in-process, no subprocess)
+        ↓
+        LSP feedback after file edits
+    ↓
+Response
+```
+
+Code mode reduces latency by eliminating inter-agent overhead and running all file tools directly in the Node.js process. It includes a multi-strategy edit engine that reliably handles indentation drift and whitespace inconsistencies.
+
+**Available tools in code mode:**
+
+| Tool | Description |
+|------|-------------|
+| `read_file` | Read files with line numbers, list directories |
+| `edit_file` | Multi-strategy string replacement (9 strategies) |
+| `write_file` | Create or overwrite files |
+| `glob` | Find files by pattern |
+| `grep` | Regex content search |
+| `bash` | Run shell commands |
+| `spawn_code_agent` | Delegate a sub-task to a child agent |
+
+**LSP integration:** After each file edit, Jiva notifies the appropriate language server and appends any compiler errors to the tool result. Language servers are auto-detected from your PATH. If none is installed for a given language, the tool continues silently.
+
 ```bash
-You: /help                    # Show all available commands
-You: /servers                 # Check MCP server status
-You: /tools                   # List all available tools
-You: List files in this directory
-You: /save                    # Save this conversation
-You: /list                    # View all saved conversations
+# Install language servers (optional but recommended for code mode)
+npm install -g typescript-language-server typescript   # TypeScript / JavaScript
+pip install python-lsp-server                          # Python
+go install golang.org/x/tools/gopls@latest             # Go
+rustup component add rust-analyzer                     # Rust
 ```
 
-### Cloud Run Mode (Production)
+For a complete technical reference see [Code Mode Architecture](docs/architecture/CODE_MODE.md).
 
-Deploy Jiva as an auto-scaling HTTP/WebSocket service:
+---
 
-#### 1. Prerequisites
+## Configuration
 
-- Google Cloud account with billing enabled
-- `gcloud` CLI installed and configured
-- Docker installed (for local testing)
+```bash
+# Run setup wizard
+jiva setup
 
-#### 2. One-Command Deployment
+# View or update settings interactively
+jiva config
+
+# View current configuration and file path
+jiva config --show
+```
+
+Configuration is stored at `~/.config/jiva-nodejs/config.json` (Linux/macOS) or `%APPDATA%\jiva-nodejs\config.json` (Windows).
+
+### Provider examples
+
+**Krutrim (gpt-oss-120b)**
+```json
+{
+  "models": {
+    "reasoning": {
+      "endpoint": "https://cloud.olakrutrim.com/v1/chat/completions",
+      "apiKey": "kr-...",
+      "model": "gpt-oss-120b",
+      "type": "reasoning",
+      "useHarmonyFormat": true
+    }
+  }
+}
+```
+
+**Groq**
+```json
+{
+  "models": {
+    "reasoning": {
+      "endpoint": "https://api.groq.com/openai/v1/chat/completions",
+      "apiKey": "gsk_...",
+      "model": "openai/gpt-oss-20b",
+      "type": "reasoning"
+    }
+  }
+}
+```
+
+**Ollama (local)**
+```json
+{
+  "models": {
+    "reasoning": {
+      "endpoint": "http://localhost:11434/v1/chat/completions",
+      "apiKey": "not-needed",
+      "model": "llama3.1",
+      "type": "reasoning"
+    }
+  }
+}
+```
+
+### Code mode configuration
+
+```json
+{
+  "codeMode": {
+    "enabled": true,
+    "lsp": { "enabled": true },
+    "maxIterations": 50
+  }
+}
+```
+
+Full configuration reference: [Configuration Guide](docs/guides/CONFIGURATION.md)
+
+---
+
+## Directive Files
+
+Create a `jiva-directive.md` in your project root to orient the agent to your codebase:
+
+```markdown
+# Purpose
+Code review assistant for a Django web application.
+
+# Tasks
+- Scan for security vulnerabilities (SQLi, XSS, CSRF)
+- Identify performance bottlenecks
+- Suggest modern Python best practices
+
+# Constraints
+- Only analyze .py files
+- Do not modify files without explicit approval
+
+# Context
+PostgreSQL backend, GDPR-sensitive user data.
+```
+
+Jiva searches for directive files automatically:
+1. Path given via `--directive`
+2. `jiva-directive.md` in the workspace root
+3. `.jiva/directive.md` in the workspace root
+
+---
+
+## MCP Servers (general mode)
+
+General mode uses MCP servers to extend the agent's capabilities. Jiva ships with the filesystem server enabled; additional servers can be added via `jiva config`.
+
+### Recommended servers
+
+**Playwright** — browser automation, web scraping, screenshot capture
+
+```bash
+jiva config
+# MCP Servers > Add Server
+# Name: playwright  Command: npx  Args: @playwright/mcp@latest
+```
+
+**Desktop Commander** — shell command execution, process management
+
+```bash
+# Name: desktop-commander  Command: npx  Args: -y desktop-commander
+```
+
+Other popular servers: GitHub, Postgres, Slack, Google Maps — see [modelcontextprotocol/servers](https://github.com/modelcontextprotocol/servers).
+
+---
+
+## Cloud Deployment
+
+Jiva can be deployed as a stateless, auto-scaling HTTP/WebSocket service on Google Cloud Run with GCS-backed session persistence and multi-tenant isolation.
 
 ```bash
 git clone https://github.com/KarmaloopAI/Jiva.git
-cd jiva
+cd Jiva
 ./deploy.sh YOUR_PROJECT_ID us-central1
 ```
 
-The script automatically:
-- Enables required GCP APIs
-- Creates GCS bucket for state storage
-- Configures service account and IAM roles
-- Builds and deploys container to Cloud Run
-- Outputs service URL
-
-#### 3. Test Deployment
+The deployment script enables required GCP APIs, creates the GCS bucket, configures IAM roles, and deploys the container. After deployment:
 
 ```bash
 SERVICE_URL=$(gcloud run services describe jiva --region=us-central1 --format='value(status.url)')
@@ -201,509 +276,106 @@ SERVICE_URL=$(gcloud run services describe jiva --region=us-central1 --format='v
 # Health check
 curl $SERVICE_URL/health
 
-# Chat endpoint (with auth bypass for testing)
+# Chat via REST
 curl -X POST $SERVICE_URL/api/chat \
   -H "Content-Type: application/json" \
-  -H "X-Session-Id: test-session" \
+  -H "X-Session-Id: my-session" \
   -d '{"message": "Hello, Jiva!"}'
 ```
 
-**Full deployment guide:** [Cloud Run Deployment](docs/deployment/CLOUD_RUN_DEPLOYMENT.md)ry these commands:**
-```bash
-You: /help                    # Show all available commands
-You: /servers                 # Check MCP server status
-You: /tools                   # List all available tools
-You: List files in this directory
-You: /save                    # Save this conversation
-You: /list                    # View all saved conversations
-```
-
-### 4. Advanced Usage
-
-**View current configuration:**
-```bash
-jiva config --show
-```
-
-**Use a custom configuration file:**
-```bash
-jiva chat --config ./my-project-config.json
-jiva run "analyze code" --config ./team-config.json
-```
-
-**Custom workspace and directive:**
-```bash
-jiva chat --workspace /path/to/project --directive ./project-directive.md
-```
-
-**Single command execution:**
-```bash
-jiva run "Analyze the code in this directory and suggest improvements"
-```
-
-**Enable debug mode:**
-```bash
-jiva chat --debug
-```
-
-### 5. Example Workflows
-
-**Code Review:**
-```bash
-You: Review all TypeScript files and identify potential bugs
-Jiva: *Uses filesystem to read files, analyzes code, provides detailed review*
-```
-
-**Web Research:**
-```bash
-You: Open Hacker News and summarize the top 5 articles
-Jiva: *Uses playwright to navigate, scrape content, and summarize*
-```
-
-**System Administration:**
-```bash
-You: Check disk usage and list the 10 largest directories
-Jiva: *Uses desktop-commander to run du commands and analyze output*
-```
-
-**Conversation Management:**
-```bash
-You: /list                    # Browse previous conversations
-You: /load                    # Resume a conversation
-# Select from interactive menu with arrow keys
-You: Continue where we left off
-```
-
-## Configuration
-
-Configuration is stored in your system's config directory (managed by `conf` package).
-
-### View Configuration Location
+**Code mode in the cloud:**
 
 ```bash
-jiva config
+gcloud run services update jiva \
+  --set-env-vars JIVA_CODE_MODE=true \
+  --region us-central1
 ```
 
-### Manual Configuration
+Full guide: [Cloud Run Deployment](docs/deployment/CLOUD_RUN_DEPLOYMENT.md)
 
-You can also manually edit the config file. Location varies by OS:
-- macOS: `~/Library/Preferences/jiva-nodejs/`
-- Linux: `~/.config/jiva-nodejs/`
-- Windows: `%APPDATA%\jiva-nodejs\`
+---
 
-## Directive Files
+## Personas and Skills
 
-Jiva can be oriented with a `jiva-directive.md` file that defines its purpose, tasks, and constraints.
-
-### Example Directive
-
-Create a file called `jiva-directive.md`:
-
-```markdown
-# Purpose
-
-You are a code review assistant focused on identifying security vulnerabilities
-and suggesting performance improvements in Python projects.
-
-# Tasks
-
-- Scan Python files for common security issues (SQL injection, XSS, etc.)
-- Identify performance bottlenecks
-- Suggest modern Python best practices
-- Check for outdated dependencies
-
-# Constraints
-
-- Only analyze Python files (.py)
-- Do not modify code without explicit approval
-- Prioritize security issues over style improvements
-
-# Context
-
-This project is a Django web application with a PostgreSQL database.
-It handles sensitive user data and must comply with GDPR.
-```
-
-Jiva will automatically look for this file in:
-1. Path specified with `--directive` flag
-2. `jiva-directive.md` in workspace root
-3. `.jiva/directive.md` in workspace root
-
-## MCP Servers
-
-Jiva leverages the Model Context Protocol (MCP) to provide extensible tooling. It comes pre-configured with the Filesystem server and makes it easy to add more.
-
-### Default Server: Filesystem
-
-Provides comprehensive file operations across user directories (subject to OS permissions).
-
-- **Status:** ✅ Enabled by default
-- **Package:** `@modelcontextprotocol/server-filesystem`
-- **Access:** `/Users` (macOS/Linux) or `C:\Users` (Windows)
-- **Tools:** read_file, write_file, list_directory, create_directory, and more
-- **Details:** See [FILESYSTEM_ACCESS.md](docs/architecture/FILESYSTEM_ACCESS.md)
-
-### Recommended Additional Servers
-
-#### 1. Playwright MCP - Browser Automation
-
-Control real browsers, take screenshots, scrape web content, and automate web interactions.
+Jiva supports persona-based skill management, compatible with Claude's Skills/Plugins format:
 
 ```bash
-# Add Playwright MCP server
-jiva config
-# Select "MCP Servers" > "Add Server"
-# Name: playwright
-# Command: npx
-# Args: @playwright/mcp@latest
-# Enabled: true
+jiva persona list
+jiva persona activate data-analyst
+jiva persona create-skill my-skill --description "Custom capability" --author "Your Name"
 ```
 
-**Capabilities:**
-- 🌐 Navigate to URLs and interact with web pages
-- 📸 Take screenshots and extract page content
-- 🤖 Automate web forms and workflows
-- 🔍 Scrape data from websites
-- 📝 Fill forms and click buttons
+Skills bundle MCP servers, directives, and model behavior overrides into portable `.skill` files. See [Personas Guide](docs/guides/PERSONAS.md).
 
-**Example usage:**
-```
-You: Open LinkedIn and take a screenshot
-Jiva: *Uses playwright to open LinkedIn, waits for load, captures screenshot*
-```
-
-#### 2. Desktop Commander - Shell Command Execution
-
-Execute shell commands, manage processes, and interact with the terminal.
-
-```bash
-# Add Desktop Commander MCP server
-jiva config
-# Select "MCP Servers" > "Add Server"
-# Name: desktop-commander
-# Command: npx
-# Args: -y desktop-commander
-# Enabled: true
-```
-
-**Capabilities:**
-- 💻 Execute shell commands (ls, grep, git, etc.)
-- 🔄 Start and manage background processes
-- 📊 Read process output with timeout control
-- 🎯 Session management for long-running commands
-
-**Example usage:**
-```
-You: Run npm test and show me the results
-Jiva: *Uses desktop-commander to execute tests and parse output*
-```
-
-**⚠️ Security Note:** Desktop Commander can execute any shell command. Only enable if you understand the security implications and trust the agent.
-
-### Other Available MCP Servers
-
-The MCP ecosystem offers many more servers:
-
-- **GitHub** (`@modelcontextprotocol/server-github`) - Repository management, issues, PRs
-- **Google Maps** (`@modelcontextprotocol/server-google-maps`) - Location data and mapping
-- **Slack** (`@modelcontextprotocol/server-slack`) - Team communication
-- **Postgres** (`@modelcontextprotocol/server-postgres`) - Database operations
-- **Git** (`@modelcontextprotocol/server-git`) - Version control operations
-- And more at [MCP Servers Repository](https://github.com/modelcontextprotocol/servers)
-
-### Adding MCP Servers
-
-#### Via Interactive Config
-
-```bash
-jiva config
-# Navigate: MCP Servers > Add Server
-# Fill in: name, command, args, enabled
-```
-
-#### Via Manual Config Edit
-
-Edit your config file at `~/.config/jiva-nodejs/config.json` (Linux) or `~/Library/Preferences/jiva-nodejs/config.json` (macOS):
-
-```json
-{
-  "mcpServers": {
-    "playwright": {
-      "command": "npx",
-      "args": ["@playwright/mcp@latest"],
-      "enabled": true
-    },
-    "desktop-commander": {
-      "command": "npx",
-      "args": ["-y", "desktop-commander"],
-      "enabled": true
-    }
-  }
-}
-```
-
-#### Programmatically
-
-```typescript
-### Three-Agent System (v0.3.1)
-
-Jiva uses a three-agent architecture for intelligent task execution:
-
-```
-User Request
-     ↓
-┌────────────────┐
-│ Manager Agent  │  Plans subtasks, coordinates workflow
-└────────┬───────┘
-         ↓
-┌────────────────┐
-│ Worker Agent   │  Executes subtasks with MCP tools
-└────────┬───────┘
-         ↓
-┌────────────────┐
-│ Client Agent   │  Validates outputs, ensures quality
-└────────┬───────┘
-         ↓
-    Final Response
-```
-
-**Manager Agent**: High-level planning and task decomposition  
-**Worker Agent**: Tool execution and information gathering  
-**Client Agent**: Adaptive validation and quality control (new in v0.3.1)
-
-The Client agent uses tiered involvement levels to balance quality with efficiency:
-- **MINIMAL**: Information requests → metadata validation only
-- **STANDARD**: Creation tasks → file exists + basic checks
-- **THOROUGH**: Complex tasks or after failures → full E2E validation
-
-### Project Structure
-
-```
-jiva/
-├── src/
-│   ├── core/              # Three-agent system
-│   │   ├── dual-agent.ts        # Main orchestrator
-│   │   ├── manager-agent.ts     # Planning & coordination
-│   │   ├── worker-agent.ts      # Tool execution
-│   │   └── client-agent.ts      # Quality validation (v0.3.1)
-│   ├── models/            # Model integrations and Harmony format
-│   ├── mcp/               # MCP client and server management
-│   ├── storage/           # Storage abstraction (v0.3.1)
-│   │   ├── local-provider.ts    # Filesystem storage
-│   │   └── gcp-bucket-provider.ts # Cloud storage
-│   ├── interfaces/        # CLI and HTTP interfaces
-│   │   ├── cli/           # CLI interface
-│   │   └── http/          # Cloud Run HTTP/WebSocket (v0.3.1)
-│   └── utils/             # Utilities and helpers
-```
-
-### Key Components
-
-1. **DualAgent**: Main orchestrator coordinating Manager, Worker, and Client agents
-2. **ManagerAgent**: High-level planning, task breakdown, and result synthesis
-3. **WorkerAgent**: Focused tool execution and information gathering
-4. **ClientAgent**: Adaptive validation with unjustified failure detection
-5. **ModelOrchestrator**: Manages multi-model coordination (reasoning + multimodal)
-6. **MCPServerManager**: Handles MCP server lifecycle and tool discovery
-7. **StorageProvider**: Unified interface for local/cloud persistence
-8. **SessionManager**: Manages DualAgent lifecycle in cloud deployments
-
-**Troubleshooting MCP Issues:** See [TROUBLESHOOTING.md](docs/guides/TROUBLESHOOTING.md#mcp-server-issues)
-
-### CLI/Library Mode
-
-```typescript
-import {
-  DualAgent,
-  createKrutrimModel,
-  ModelOrchestrator,
-  MCPServerManager,
-  WorkspaceManager,
-  ConversationManager,
-  createStorageProvider,
-} from 'jiva-core';
-
-// Create storage provider (auto-detects local/cloud)
-const storageProvider = await createStorageProvider();
-
-// Create models
-const reasoningModel = createKrutrimModel({
-  endpoint: 'https://cloud.olakrutrim.com/v1/chat/completions',
-  apiKey: 'your-api-key',
-  model: 'gpt-oss-120b',
-  type: 'reasoning',
-});
-
-// Create orchestrator
-const orchestrator = new ModelOrchestrator({ reasoningModel });
-
-// Initialize MCP
-const mcpManager = new MCPServerManager();
-await mcpManager.initialize({
-  filesystem: {
-    command: 'npx',
-    args: ['-y', '@modelcontextprotocol/server-filesystem', process.cwd()],
-    enabled: true,
-  },
-});
-
-// Initialize workspace
-const workspace = new WorkspaceManager(storageProvider);
-await workspace.initialize();
-
-// Initialize conversation manager
-const conversationManager = new ConversationManager(storageProvider);
-
-// Create three-agent system
-const agent = new DualAgent({
-  orchestrator,
-  mcpManager,
-  workspace,
-  conversationManager,
-  maxSubtasks: 20,        // Manager's subtask limit
-  maxIterations: 10,      // Worker's iteration limit per subtask
-});
-
-// Use agent
-const response = await agent.chat('Hello, Jiva!');
-console.log(response.content);
-console.log(`Plan: ${response.plan?.subtasks.join(', ')}`);
-console.log(`Tools used: ${response.toolsUsed.join(', ')}`);
-
-// Cleanup
-await agent.cleanup();
-```
-
-### Cloud Mode (HTTP/WebSocket)
-
-For cloud deployments, see the [HTTP interface documentation](docs/deployment/CLOUD_RUN_IMPLEMENTATION.md) and [example programs](examples/).
-
-**Key difference:** Cloud mode uses `SessionManager` to handle multiple concurrent agent instances with per-tenant isolation.
-## Development
-
-### Build
-
-```bash
-npm run build
-```
-
-### Development Mode
-
-```bash
-npm run dev
-```
-
-### Type Checking
-
-```bash
-npm run type-check
-```
+---
 
 ## Programmatic Usage
 
-Jiva can also be used programmatically:
-
 ```typescript
-import {
-  DualAgent,
-  createKrutrimModel,
-  ModelOrchestrator,
-  MCPServerManager,
-  WorkspaceManager,
-  ConversationManager,
-} from 'jiva';
+import { DualAgent, CodeAgent, createKrutrimModel, ModelOrchestrator,
+         MCPServerManager, WorkspaceManager, ConversationManager,
+         createStorageProvider } from 'jiva-core';
 
-// Create models
 const reasoningModel = createKrutrimModel({
-  endpoint: 'https://cloud.olakrutrim.com/v1/chat/completions',
-  apiKey: 'your-api-key',
-  model: 'gpt-oss-120b',
+  endpoint: 'https://api.groq.com/openai/v1/chat/completions',
+  apiKey: process.env.API_KEY!,
+  model: 'openai/gpt-oss-20b',
   type: 'reasoning',
 });
-
-// Create orchestrator
 const orchestrator = new ModelOrchestrator({ reasoningModel });
+const storageProvider = await createStorageProvider();
+const workspace = new WorkspaceManager(storageProvider);
+await workspace.initialize();
+const conversationManager = new ConversationManager(storageProvider);
 
-// Initialize MCP
+// General mode
 const mcpManager = new MCPServerManager();
 await mcpManager.initialize({
-  filesystem: {
-    command: 'npx',
-    args: ['-y', '@modelcontextprotocol/server-filesystem', process.cwd()],
-    enabled: true,
-  },
+  filesystem: { command: 'npx', args: ['-y', '@modelcontextprotocol/server-filesystem', process.cwd()], enabled: true },
 });
-
-// Initialize workspace
-const workspace = new WorkspaceManager({
-  workspaceDir: process.cwd(),
-});
-await workspace.initialize();
-
-// Initialize conversation manager (optional)
-const conversationManager = new ConversationManager();
-await conversationManager.initialize();
-
-// Create dual-agent
-const agent = new DualAgent({
-  orchestrator,
-  mcpManager,
-  workspace,
-  conversationManager,
-  maxSubtasks: 10,
-});
-
-// Use agent
-const response = await agent.chat('Hello, Jiva!');
+const agent = new DualAgent({ orchestrator, mcpManager, workspace, conversationManager });
+const response = await agent.chat('What files are in this directory?');
 console.log(response.content);
-console.log(`Plan: ${response.plan?.subtasks.join(', ')}`);
-console.log(`Tools used: ${response.toolsUsed.join(', ')}`);
-
-// Cleanup
 await agent.cleanup();
+
+// Code mode
+const codeAgent = new CodeAgent({ orchestrator, workspace, conversationManager, maxIterations: 50, lspEnabled: true });
+const codeResponse = await codeAgent.chat('Refactor the auth module to use async/await');
+console.log(codeResponse.content);
+await codeAgent.cleanup();
 ```
 
-## Troubleshooting
+Both `DualAgent` and `CodeAgent` implement the `IAgent` interface and are interchangeable in application code.
 
-### Tool Calls Not Working
+---
 
-The gpt-oss-120b model has known issues with tool calling reliability. Jiva implements several workarounds:
-
-1. **Retry Logic**: Automatically retries malformed tool calls
-2. **JSON Fixing**: Attempts to fix common JSON formatting issues
-3. **Validation**: Validates tool calls against available tools
-4. **Logging**: Enable debug mode to see detailed tool call information
+## Development
 
 ```bash
-jiva chat --debug
+npm run build        # compile TypeScript
+npm run dev          # watch mode
+npm run type-check   # type-check without emit
 ```
 
-### MCP Server Connection Issues
+---
 
-Check server status:
+## Documentation
 
-```bash
-jiva chat
-# Then type: servers
-```
+| Document | Description |
+|----------|-------------|
+| [Quick Start](docs/guides/QUICKSTART.md) | Get running in 30 seconds |
+| [Configuration Guide](docs/guides/CONFIGURATION.md) | All config options and provider examples |
+| [Code Mode Architecture](docs/architecture/CODE_MODE.md) | How code mode works internally |
+| [Cloud Run Deployment](docs/deployment/CLOUD_RUN_DEPLOYMENT.md) | Production deployment guide |
+| [Personas Guide](docs/guides/PERSONAS.md) | Skills and persona system |
+| [Troubleshooting](docs/guides/TROUBLESHOOTING.md) | Common issues and fixes |
+| [Release Notes](docs/release_notes/) | Version history |
 
-View logs:
-
-```bash
-jiva chat --debug
-```
-
-## API Documentation
-
-For detailed API documentation, see the TypeScript definitions in `src/`.
+---
 
 ## Contributing
 
-Contributions are welcome! Please ensure:
-
-1. Code follows TypeScript best practices
-2. All new features include proper error handling
-3. Documentation is updated
+Contributions are welcome. Please ensure new features include error handling and that documentation is updated. Open a PR against the `develop` branch.
 
 ## License
 
@@ -715,13 +387,3 @@ MIT
 - [Harmony Response Format](https://github.com/openai/harmony)
 - [Model Context Protocol](https://modelcontextprotocol.io/)
 - [Krutrim Cloud API](https://cloud.olakrutrim.com/)
-
-## Sources
-
-This implementation is based on research from:
-
-- [OpenAI Harmony GitHub Repository](https://github.com/openai/harmony)
-- [MCP with OpenAI gpt-oss](https://github.com/Vaibhavs10/mcp-with-openai-gpt-oss)
-- [OpenAI Cookbook - Harmony Format](https://cookbook.openai.com/articles/openai-harmony)
-- [MCP Best Practices](https://modelcontextprotocol.info/docs/best-practices/)
-- [vLLM GPT-OSS Documentation](https://docs.vllm.ai/projects/recipes/en/latest/OpenAI/GPT-OSS.html)

--- a/docs/README.md
+++ b/docs/README.md
@@ -31,7 +31,7 @@ Step-by-step guides for common tasks:
 
 Deep dives into Jiva's design:
 
-- **[Three-Agent Architecture](architecture/NEW_FEATURES.md)** - Manager, Worker, and Client agents
+- **[Architecture Overview](architecture/NEW_FEATURES.md)** - Manager and Worker agents
 - **[Implementation Summary](architecture/IMPLEMENTATION_SUMMARY.md)** - Core design decisions
 - **[Improvements Summary](architecture/IMPROVEMENTS_SUMMARY.md)** - Evolution of the architecture
 - **[Filesystem Access](architecture/FILESYSTEM_ACCESS.md)** - MCP filesystem server details
@@ -39,11 +39,12 @@ Deep dives into Jiva's design:
 
 ## Release Notes
 
-- **[v0.3.23](release_notes/v0.3.23.md)** - Current release (Linux support fix + dependency updates)
+- **[v0.3.4](release_notes/v0.3.4.md)** - Code mode + two-agent system
+- **[v0.3.23](release_notes/v0.3.23.md)** - Linux support fix + dependency updates (legacy)
 - **[v0.3.22](release_notes/v0.3.22.md)** - Security updates & CI automation
 - **[v0.3.21](release_notes/v0.3.21.md)** - Bug fixes
 - **[v0.3.2](release_notes/v0.3.2.md)** - Bug fixes & quality improvements
-- **[v0.3.1](release_notes/v0.3.1.md)** - Cloud deployment + three-agent architecture
+- **[v0.3.1](release_notes/v0.3.1.md)** - Cloud deployment + three-agent (legacy)
 - **[v0.2.1](release_notes/v0.2.1.md)** - Dual-agent system
 
 ## Quick Links by Use Case
@@ -68,8 +69,9 @@ Deep dives into Jiva's design:
 → [GitHub Issues](https://github.com/KarmaloopAI/Jiva/issues)
 
 #### Understand the Architecture
-→ [Three-Agent Architecture](architecture/NEW_FEATURES.md)  
-→ [Implementation Summary](architecture/IMPLEMENTATION_SUMMARY.md)  
+→ [Architecture Overview](architecture/NEW_FEATURES.md)
+→ [Code Mode Architecture](architecture/CODE_MODE.md)
+→ [Implementation Summary](architecture/IMPLEMENTATION_SUMMARY.md)
 → [Cloud Run Implementation](deployment/CLOUD_RUN_IMPLEMENTATION.md)
 
 ## Documentation Structure
@@ -89,17 +91,19 @@ docs/
 │   ├── CLOUD_RUN_IMPLEMENTATION.md      # Technical implementation
 │   └── CLOUD_RUN_DEPLOYMENT_SUMMARY.md  # Example deployment
 ├── architecture/
-│   ├── NEW_FEATURES.md            # Three-agent architecture
+│   ├── CODE_MODE.md               # Code mode architecture
+│   ├── NEW_FEATURES.md            # General mode architecture (Manager + Worker)
 │   ├── IMPLEMENTATION_SUMMARY.md  # Design overview
 │   ├── IMPROVEMENTS_SUMMARY.md    # Evolution history
 │   ├── FILESYSTEM_ACCESS.md       # MCP filesystem details
 │   └── MAXTOKEN_FIX.md           # Token management
 └── release_notes/
-    ├── v0.3.23.md                 # Current release
+    ├── v0.3.4.md                  # Current release (code mode + two-agent)
+    ├── v0.3.23.md                 # Linux support fix
     ├── v0.3.22.md                 # Security updates & CI
     ├── v0.3.21.md                 # Bug fixes
     ├── v0.3.2.md                  # Bug fixes & quality
-    ├── v0.3.1.md                  # Cloud + three-agent
+    ├── v0.3.1.md                  # Cloud + three-agent (legacy)
     └── v0.2.1.md                  # Dual-agent system
 ```
 
@@ -110,7 +114,8 @@ docs/
 | Interactive Chat | ✅ | ✅ | Stable |
 | Conversation Saving | ✅ | ✅ | Stable |
 | MCP Server Support | ✅ | ✅ | Stable |
-| Three-Agent Architecture | ✅ | ✅ | Stable |
+| Two-Agent System (Manager + Worker) | ✅ | ✅ | Stable |
+| Code Mode (single-loop + LSP) | ✅ | ✅ | Stable |
 | Local File Storage | ✅ | ⚠️ | Stable |
 | GCS Storage | ➖ | ✅ | Beta |
 | WebSocket API | ➖ | ✅ | Stable |
@@ -123,8 +128,8 @@ Legend: ✅ Supported | ⚠️ Partial | ➖ Not applicable | 🚧 In developmen
 
 ## Version Information
 
-**Current Version:** 0.3.23  
-**Release Date:** February 27, 2026  
+**Current Version:** 0.3.4
+**Release Date:** March 2026
 **Node Version Required:** 20.0.0+
 
 ## Support

--- a/docs/architecture/AGENT_SPAWNING_IMPLEMENTATION.md
+++ b/docs/architecture/AGENT_SPAWNING_IMPLEMENTATION.md
@@ -277,7 +277,7 @@ Watch logs for:
 
 **Memory Usage:**
 - Each spawned agent: ~50-100MB
-- 3-agent collaboration: ~200-300MB total
+- 2-agent collaboration: ~100-200MB total
 
 **Iteration Budget:**
 - Parent: configurable maxIterations

--- a/docs/architecture/CODE_MODE.md
+++ b/docs/architecture/CODE_MODE.md
@@ -1,0 +1,347 @@
+# Code Mode Architecture
+
+Code mode is a single-loop execution engine optimized for software engineering tasks. It replaces the Manager → Worker → Client orchestration chain with a direct model → tools → model loop that has lower latency, no inter-agent message overhead, and tight LSP integration for immediate compiler feedback.
+
+## Activation
+
+**CLI**
+
+```bash
+# Interactive session
+jiva chat --code
+
+# Single prompt
+jiva run "refactor auth module" --code
+
+# Disable LSP (useful if no language servers are installed)
+jiva chat --code --no-lsp
+
+# Plan-then-approve mode (see below)
+jiva chat --code --plan
+```
+
+**Config file (persistent)**
+
+```json
+{
+  "codeMode": {
+    "enabled": true,
+    "lsp": { "enabled": true },
+    "maxIterations": 50
+  }
+}
+```
+
+**Cloud / HTTP deployment**
+
+```bash
+JIVA_CODE_MODE=true          # activate code mode
+JIVA_CODE_LSP=false          # optional: disable LSP servers
+```
+
+---
+
+## Architecture Comparison
+
+### General mode (DualAgent)
+
+```
+User
+  └─► Manager (plan)
+         └─► Worker × N (execute MCP tools)
+                └─► Client (validate)
+                       └─► Response
+```
+
+Three separate LLM calls per turn, tool execution via MCP subprocesses.
+
+### Code mode (CodeAgent)
+
+```
+User
+  └─► CodeAgent
+         loop until done or maxIterations:
+           └─► LLM (with tool definitions in JSON Schema)
+                 └─► Tool execution (in-process, no subprocess)
+                       └─► Result injected into message history
+         └─► Response
+```
+
+One LLM endpoint per loop iteration, tools run inside the same Node.js process.
+
+---
+
+## Plan Mode (`--plan`)
+
+When `--plan` is passed alongside `--code`, each user message goes through a two-phase flow before any file is modified:
+
+```
+User message
+    │
+    ▼ Phase 1 — Plan (read-only, no side effects)
+CodeAgent.plan()
+    ├─ glob / grep / read_file  (exploration, up to 12 iterations)
+    └─ model outputs structured plan (no edit/write/bash allowed)
+    │
+    ▼ REPL shows plan + prompts "Implement this plan? [Y/n]"
+    │
+    ├─ n → message discarded, user can refine and retry
+    │
+    └─ Y → Phase 2 — Implement
+       CodeAgent.chat(original message + approved plan as context)
+           ├─ Full tool set available (edit, write, bash, …)
+           └─ Model knows it is implementing an approved plan
+```
+
+### Plan output format
+
+The model is instructed to produce:
+
+```markdown
+## Summary
+1–2 sentence overview of the approach
+
+## Files to Change
+| File | Action | What changes |
+|------|--------|--------------|
+| src/auth/index.ts | edit | Extract token validation into validateToken() |
+| src/auth/tokens.ts | create | New module with token utilities |
+
+## Implementation Steps
+1. Read src/auth/index.ts to understand current shape
+2. Extract the inline validation block into a standalone function
+…
+
+## Risks & Considerations
+- The existing test suite mocks the inline logic; mock locations will shift
+```
+
+### Exploration tools available during planning
+
+Only read-only tools are allowed in the plan phase. Attempts to call `edit_file`, `write_file`, or `bash` return an error message explaining the restriction.
+
+| Tool | Allowed in plan phase |
+|------|-----------------------|
+| `read_file` | Yes |
+| `glob` | Yes |
+| `grep` | Yes |
+| `edit_file` | No |
+| `write_file` | No |
+| `bash` | No |
+| `spawn_code_agent` | No |
+
+### Relationship to general mode planning
+
+DualAgent's ManagerAgent also produces a plan before execution, but it is internal — the user never sees it and cannot veto it. Code mode's `--plan` flag makes the plan visible and gates execution behind explicit approval.
+
+---
+
+## Source Map
+
+```
+src/code/
+├── agent.ts              # CodeAgent — the main entry point
+├── file-lock.ts          # Per-path async mutex for concurrent edits
+├── tools/
+│   ├── index.ts          # ICodeTool interface + registry
+│   ├── read.ts           # read_file / list_directory
+│   ├── edit.ts           # Multi-strategy string replacement + LSP
+│   ├── write.ts          # write_file (create/overwrite) + LSP
+│   ├── glob.ts           # glob — file pattern matching
+│   ├── grep.ts           # grep — regex content search
+│   ├── bash.ts           # bash — shell command execution
+│   └── spawn.ts          # spawn_code_agent — sub-agent delegation
+└── lsp/
+    ├── language.ts       # File extension → LSP language ID (60+ extensions)
+    ├── server.ts         # Spawn language server process from PATH
+    ├── client.ts         # JSON-RPC LSP client (vscode-jsonrpc)
+    └── manager.ts        # LspManager: lazy init, one client per language
+```
+
+---
+
+## CodeAgent Loop
+
+```typescript
+class CodeAgent {
+  async chat(userMessage: string): Promise<AgentChatResponse> {
+    messages = [...history, userMessage]
+    for (i = 0; i < maxIterations; i++) {
+      if (isLastStep) {
+        // Inject stop message, send no tools → force final text response
+      }
+      response = orchestrator.chatWithFallback({ messages, tools })
+      if (!response.toolCalls.length) return response.content   // done
+      for each toolCall:
+        result = executeCodeTool(toolCall)
+        messages.push(toolResult)
+      doomLoopCheck()   // 3× same call → inject warning
+    }
+  }
+}
+```
+
+**Iteration budget:** 50 by default (vs 10 per subtask in general mode).
+**Last-step mechanic:** At 80% of `maxIterations`, a stop message is injected and tools are withheld, forcing the model to emit a final answer rather than starting another tool call.
+
+---
+
+## Tool Execution
+
+All tools implement `ICodeTool`:
+
+```typescript
+interface ICodeTool {
+  name: string
+  description: string
+  parameters: object            // JSON Schema
+  execute(args, ctx: CodeToolContext): Promise<string>
+}
+
+interface CodeToolContext {
+  workspaceDir: string
+  lsp: LspManager
+  signal: AbortSignal
+}
+```
+
+Tools run **in-process** — no MCP subprocess, no JSON serialization overhead, direct Node.js `fs` access.
+
+### Tool Reference
+
+| Tool | Parameters | Notes |
+|------|-----------|-------|
+| `read_file` | `path`, `offset?`, `limit?` | Max 2000 lines, 50 KB cap. Returns `cat -n` style output. |
+| `list_directory` | `path` | Lists with `[FILE]`/`[DIR]` prefix. |
+| `edit_file` | `file_path`, `old_string`, `new_string`, `replace_all?` | 9 replacement strategies (see below). Calls LSP after edit. |
+| `write_file` | `file_path`, `content` | Creates or overwrites. Calls LSP after write. |
+| `glob` | `pattern`, `cwd?` | Standard glob patterns relative to workspace. |
+| `grep` | `pattern`, `path?`, `include_pattern?` | Regex, recursive, max 100 matches. |
+| `bash` | `command`, `timeout_ms?` | Max 300 s. Runs in workspace dir. Returns stdout + stderr + exit code. |
+| `spawn_code_agent` | `task`, `context?` | Creates a child `CodeAgent` (depth limited to 2 levels). |
+
+### Multi-Strategy Edit
+
+The `edit_file` tool applies 9 replacement strategies in order, stopping at the first match. This handles whitespace drift and indentation inconsistencies that trip up simpler string-replace approaches:
+
+1. `SimpleReplacer` — exact match
+2. `LineTrimmedReplacer` — trim each line before comparing
+3. `BlockAnchorReplacer` — anchor on first/last line, fuzzy middle
+4. `WhitespaceNormalizedReplacer` — collapse whitespace runs
+5. `IndentationFlexibleReplacer` — ignore indentation differences
+6. `EscapeNormalizedReplacer` — normalize escape sequences
+7. `TrimmedBoundaryReplacer` — trim leading/trailing whitespace on block
+8. `ContextAwareReplacer` — Levenshtein-distance fuzzy match
+9. `MultiOccurrenceReplacer` — handle blocks appearing multiple times
+
+If `old_string` is empty, `edit_file` delegates to `write_file` (create new file).
+
+After every edit or write, the tool calls `lsp.touchFile()` and appends any LSP errors to the tool result.
+
+---
+
+## LSP Integration
+
+Language Server Protocol support gives the agent compiler-level feedback after each file change — the same feedback a developer sees in their editor.
+
+### How It Works
+
+1. After `edit_file` or `write_file`, `LspManager.touchFile(path)` is called.
+2. `LspManager` detects the language from the file extension.
+3. If no server is running for that language, it spawns one from PATH (lazy init).
+4. The LSP client sends `textDocument/didOpen` or `textDocument/didChange`.
+5. The client waits up to 3 seconds for `textDocument/publishDiagnostics`.
+6. Any errors are formatted and appended to the tool's return value.
+
+### Language Server Detection
+
+The manager auto-detects servers from PATH by trying known command names:
+
+| Language | Server command |
+|---------|---------------|
+| TypeScript/JavaScript | `typescript-language-server --stdio` |
+| Python | `pylsp` or `pyright-langserver --stdio` |
+| Go | `gopls` |
+| Rust | `rust-analyzer` |
+| C/C++ | `clangd` |
+| Others | Detected lazily |
+
+If no server is found for a language, the tool continues silently — LSP support degrades gracefully.
+
+### Installing Language Servers
+
+```bash
+# TypeScript / JavaScript
+npm install -g typescript-language-server typescript
+
+# Python
+pip install python-lsp-server        # or: pip install pyright
+
+# Go
+go install golang.org/x/tools/gopls@latest
+
+# Rust
+rustup component add rust-analyzer
+```
+
+---
+
+## File Locking
+
+`FileLock` (`src/code/file-lock.ts`) is a per-path async mutex. When the model emits multiple tool calls in a single response that target the same file, they are serialized through the lock to prevent interleaved writes.
+
+```typescript
+// All edits to the same path are queued automatically
+await fileLock.withLock(filePath, async () => {
+  // read → modify → write
+});
+```
+
+---
+
+## Sub-Agent Spawning
+
+`spawn_code_agent` creates a child `CodeAgent` with a focused task:
+
+```
+Parent CodeAgent
+  └─► spawn_code_agent("write unit tests for auth.ts")
+         └─► Child CodeAgent (depth=1, shared LspManager)
+               └─► reads auth.ts
+               └─► writes auth.test.ts
+               └─► runs tests via bash
+         └─► returns child's final response
+```
+
+Child agents share the parent's `LspManager` so LSP servers are not restarted. Nesting is limited to 2 levels (parent → child, no grandchild) to prevent runaway recursion.
+
+---
+
+## Doom Loop Detection
+
+If the model calls the same tool with the same arguments 3 times in a row, CodeAgent injects a correction message:
+
+```
+[System] You are repeating the same action without progress.
+Stop and reassess. Try a different approach or report what you've found so far.
+```
+
+---
+
+## Context Compaction
+
+When the conversation history approaches the model's context limit (configurable threshold), `ConversationManager.condense()` is called automatically. The condensed history replaces the raw turn-by-turn messages and the loop continues. This mirrors general mode's compaction behavior.
+
+---
+
+## Relationship to General Mode
+
+The `IAgent` interface (`src/core/agent-interface.ts`) is satisfied by both `DualAgent` and `CodeAgent`. The CLI REPL, HTTP session manager, and chat routes are all agent-agnostic — they program to `IAgent`.
+
+```
+IAgent
+├── DualAgent   (general mode — Manager/Worker/Client + MCP)
+└── CodeAgent   (code mode   — single loop + in-process tools + LSP)
+```
+
+Switching between modes requires only a flag or environment variable; no application-layer code changes are needed.

--- a/docs/architecture/IMPLEMENTATION_SUMMARY.md
+++ b/docs/architecture/IMPLEMENTATION_SUMMARY.md
@@ -88,27 +88,25 @@ src/
 
 ### Dual-Agent System
 
-**New in v0.2.1:** Jiva now uses a two-agent architecture for better separation of concerns:
+**Updated in v0.3.4:** Jiva uses a streamlined two-agent architecture:
 
 1. **DualAgent** (`src/core/dual-agent.ts`)
    - Orchestrates Manager and Worker agents
    - Implements three-phase execution: Planning → Execution → Synthesis
+   - Routes simple conversational messages directly (no Worker subtasks)
    - Manages conversation history and auto-save
-   - Coordinates task breakdown and result aggregation
 
 2. **ManagerAgent** (`src/core/manager-agent.ts`)
-   - **Role:** High-level planning and coordination
-   - Creates execution plans by breaking down user requests
-   - Reviews Worker results and decides next actions
+   - **Role:** High-level planning, coordination, and synthesis
+   - Creates execution plans by decomposing user requests into subtasks
    - Synthesizes final responses from all subtask results
+   - Answers simple conversational messages directly (without Worker)
    - Does NOT execute tools directly
 
 3. **WorkerAgent** (`src/core/worker-agent.ts`)
    - **Role:** Focused tool execution
    - Executes specific subtasks assigned by Manager
-   - Uses MCP tools to gather information
-   - Limited to 5 iterations per subtask (prevents wandering)
-   - Includes automatic error recovery and retry logic
+   - Uses MCP tools to gather information and perform actions
    - Reports results back to Manager
 
 ### Supporting Components

--- a/docs/architecture/PERSONAS_IMPLEMENTATION.md
+++ b/docs/architecture/PERSONAS_IMPLEMENTATION.md
@@ -63,9 +63,6 @@ A complete Skills and Personas system with 100% compatibility with Claude's Skil
 - Sees available skills during execution
 - Reads SKILL.md files on demand via `view` tool
 
-**Client Agent:**
-- No direct persona integration (focuses on validation)
-
 ### CLI Commands
 
 ```bash

--- a/docs/guides/CONFIGURATION.md
+++ b/docs/guides/CONFIGURATION.md
@@ -539,6 +539,58 @@ cp ~/.config/jiva-nodejs/config.json ./my-config-template.json
 nano my-config-template.json
 ```
 
+## Code Mode Configuration
+
+Code mode activates a single-loop `CodeAgent` optimized for software engineering tasks. It replaces the Manager/Worker/Client chain with direct tool execution and optional LSP integration.
+
+### Activating Code Mode
+
+**Via CLI flag (per-session):**
+```bash
+jiva chat --code
+jiva run "refactor auth.ts" --code
+jiva chat --code --no-lsp    # disable LSP servers
+```
+
+**Via config file (persistent):**
+```json
+{
+  "codeMode": {
+    "enabled": true,
+    "lsp": { "enabled": true },
+    "maxIterations": 50
+  }
+}
+```
+
+**Via environment variable (cloud/container deployments):**
+```bash
+JIVA_CODE_MODE=true          # activate code mode
+JIVA_CODE_LSP=false          # optional: disable LSP
+```
+
+### LSP Language Servers
+
+Code mode optionally starts language servers (from PATH) after each file edit to surface compiler errors in the tool result. Servers are started lazily and silently skipped if not installed.
+
+```bash
+# TypeScript / JavaScript
+npm install -g typescript-language-server typescript
+
+# Python
+pip install python-lsp-server
+
+# Go
+go install golang.org/x/tools/gopls@latest
+
+# Rust
+rustup component add rust-analyzer
+```
+
+For the full reference see [Code Mode Architecture](../architecture/CODE_MODE.md).
+
+---
+
 ## Cloud Run Configuration
 
 For Cloud Run deployments, configuration is loaded dynamically from GCS bucket using the StorageProvider. See [CLOUD_RUN_DEPLOYMENT.md](./CLOUD_RUN_DEPLOYMENT.md) for details.

--- a/docs/guides/QUICKSTART.md
+++ b/docs/guides/QUICKSTART.md
@@ -52,11 +52,17 @@ You'll be prompted for:
 ### Start Using
 
 ```bash
-# Interactive mode
+# Interactive mode (general-purpose)
 jiva chat
+
+# Code mode — optimized for software engineering tasks
+jiva chat --code
 
 # Single command
 jiva run "What files are in this directory?"
+
+# Single command in code mode
+jiva run "Refactor the auth module to use async/await" --code
 
 # With custom workspace
 jiva chat --workspace ~/myproject
@@ -133,13 +139,15 @@ npm link
 
 ---
 
-## 📋 Common Commands
+## Common Commands
 
 | Task | Command |
 |------|---------|
 | Setup Jiva | `jiva setup` |
 | Interactive chat | `jiva chat` |
+| Code mode (software tasks) | `jiva chat --code` |
 | Run single prompt | `jiva run "your prompt"` |
+| Run prompt in code mode | `jiva run "refactor X" --code` |
 | Update config | `jiva config` |
 | Debug mode | `jiva chat --debug` |
 | Custom workspace | `jiva chat --workspace /path` |

--- a/docs/release_notes/v0.3.4.md
+++ b/docs/release_notes/v0.3.4.md
@@ -6,7 +6,7 @@
 
 ## Summary
 
-v0.3.4 is a substantial release with improvements across both execution modes. The headline feature is **Code Mode** — a new single-loop execution engine for software engineering tasks. Alongside this, general mode has been streamlined by removing the Client validation agent (now **Manager + Worker only**), and both modes received a set of reliability and quality improvements drawn from a study of the opencode architecture.
+v0.3.4 is a substantial release with improvements across both execution modes. The headline feature is **Code Mode** — a new single-loop execution engine for software engineering tasks. Alongside this, general mode has been streamlined by removing the Client validation agent (now **Manager + Worker only**), and both modes received a set of reliability and quality improvements.
 
 ---
 
@@ -22,7 +22,7 @@ Activate with `jiva chat --code` or `jiva run "..." --code`. The mode remains of
 - Single model call per iteration — tool results inject directly back into the context window
 - All file tools run in-process (no MCP subprocess for basic I/O)
 - Up to 50 iterations per turn
-- Two-phase iteration limit: 85% → "continue" nudge (tools kept); 95% → wrap-up (tools stripped, max-steps.txt-style message)
+- Two-phase iteration limit: 85% → "continue" nudge (tools kept); 95% → structured wrap-up message (tools stripped)
 - Doom-loop detection: 3 identical tool calls in a row triggers a correction injection
 - In-loop context compaction: when `promptTokens` approaches the model's context limit, conversation history is automatically summarised and replaced with a structured context message
 
@@ -42,7 +42,7 @@ Seven tools available in code mode, all running inside the Jiva process:
 
 ### Multi-Strategy Edit Engine
 
-The `edit_file` tool applies nine replacement strategies in order. Earlier strategies match exactly; later ones tolerate indentation and whitespace drift that is common when a model copies code from its context window with slight reformatting. This is the same approach used in opencode and cline.
+The `edit_file` tool applies nine replacement strategies in order. Earlier strategies match exactly; later ones tolerate indentation and whitespace drift that is common when a model copies code from its context window with slight reformatting.
 
 ### LSP Integration
 
@@ -104,9 +104,9 @@ CLI defaults: reasoning model → `"high"`, tool-calling model → `"medium"`. C
 
 ---
 
-## Reliability Improvements (from OpenCode Study)
+## Reliability Improvements
 
-A systematic study of the opencode architecture identified four areas where Jiva's code mode could be improved. All four have been implemented.
+Four areas in Jiva's code mode have been identified and improved.
 
 ### Bash Output Truncation
 
@@ -119,14 +119,14 @@ Truncation messages tell the model to redirect output to a file if it needs the 
 `CodeAgent` now tracks `response.usage.promptTokens` after each model call. When the token count exceeds `compactionThreshold` (default: 90 000 — safe for a 128 K context model), the in-flight message history is compressed:
 
 1. The system prompt and the most recent 10 messages are kept intact.
-2. The middle section is summarised by a separate model call using the structured opencode template (see below).
+2. The middle section is summarised by a separate model call using the structured compaction template (see below).
 3. The summary replaces the middle section; the loop continues from the compacted context.
 
 Compaction fires at most once per `chat()` turn to avoid thrashing.
 
 ### Structured Compaction Format
 
-`ConversationManager.condenseConversation()` (used for cross-turn compaction and in-loop compaction) now uses the structured opencode compaction template instead of a generic summary prompt:
+`ConversationManager.condenseConversation()` (used for cross-turn compaction and in-loop compaction) now uses a structured compaction format instead of a generic summary prompt:
 
 ```
 ## Goal
@@ -149,7 +149,7 @@ This makes summaries actionable — a resumed session can immediately understand
 
 ### System Prompt — Persistence and Pre-Tool Narration
 
-The `CodeAgent` system prompt now includes a **PERSISTENCE AND COMPLETION** section adapted from opencode's `beast.txt`:
+The `CodeAgent` system prompt now includes a **PERSISTENCE AND COMPLETION** section:
 
 - *"Keep going until the user's query is completely resolved."*
 - *"You MUST iterate and keep going until the problem is solved."*
@@ -158,7 +158,7 @@ The `CodeAgent` system prompt now includes a **PERSISTENCE AND COMPLETION** sect
 - If the user says "resume / continue / try again", check conversation history and continue from the last incomplete step.
 - Verify changes — run tests or the build after making changes when appropriate.
 
-The 95% iteration wrap-up message is now based on `max-steps.txt` from opencode, explicitly prohibiting tool calls and requiring a structured summary with accomplished work, remaining tasks, and recommendations.
+The 95% iteration wrap-up message explicitly prohibits tool calls and requires a structured summary with accomplished work, remaining tasks, and recommendations.
 
 ### edit_file Tool: Clearer Description and Targeted Error Recovery
 
@@ -166,7 +166,7 @@ Two improvements to prevent the common failure mode where gpt-oss-120b generates
 
 1. **Improved description**: The tool description now opens with a **REQUIRED PARAMETERS** block listing all three required fields explicitly, with the note: *"Omitting new_string will fail with a validation error. new_string is never optional."*
 
-2. **Specific correction message**: When the API rejects a call with `"missing properties: 'new_string'"`, the correction injection now names the missing field explicitly — matching the precision of opencode's Zod validation errors — instead of the previous generic message.
+2. **Specific correction message**: When the API rejects a call with `"missing properties: 'new_string'"`, the correction injection now names the missing field explicitly — instead of the previous generic message.
 
 ---
 
@@ -201,7 +201,7 @@ Two improvements to prevent the common failure mode where gpt-oss-120b generates
 | `src/core/manager-agent.ts` | Conversational short-circuit support (`directReply()`); improved synthesis prompts |
 | `src/core/worker-agent.ts` | Adjusted to operate without Client validation layer |
 | `src/core/config.ts` | Added `codeMode` config schema (`enabled`, `lsp.enabled`, `maxIterations`) |
-| `src/core/conversation-manager.ts` | `condenseConversation()` now uses structured opencode compaction template |
+| `src/core/conversation-manager.ts` | `condenseConversation()` now uses structured compaction format |
 | `src/index.ts` | Exports `CodeAgent`, `LspManager`, `IAgent`, `AgentChatResponse` |
 | `src/interfaces/cli/index.ts` | Added `--code` and `--no-lsp` flags; `reasoning_effort` defaults; `process.exit(0)` after REPL exits |
 | `src/interfaces/cli/repl.ts` | Re-exports `IAgent` from core; parameters typed as `IAgent` |
@@ -216,7 +216,7 @@ Two improvements to prevent the common failure mode where gpt-oss-120b generates
 - **HTTP mode tool results**: `role: 'tool'` messages were forwarded to Groq without a `tools` array in HTTP mode. Fixed in `formatMessagesForHarmony` — they are now converted to user-role `<tool_result>` messages as Harmony requires.
 - **Rate limit backoff**: Previously used fixed exponential backoff. Now parses the actual retry-after duration from Groq error messages and waits accordingly.
 - **`/exit` hangs in code mode**: LSP child-process streams kept the Node.js event loop alive after cleanup. Fixed by calling `process.exit(0)` after `agent.cleanup()` returns.
-- **`edit_file` missing `new_string`**: Targeted correction message now names the missing field explicitly, matching opencode's Zod validation precision.
+- **`edit_file` missing `new_string`**: Targeted correction message now names the missing field explicitly instead of using a generic error message.
 
 ---
 

--- a/docs/release_notes/v0.3.4.md
+++ b/docs/release_notes/v0.3.4.md
@@ -1,0 +1,263 @@
+# Release Notes — v0.3.4
+
+**Released:** 2026-03-13
+
+---
+
+## Summary
+
+v0.3.4 is a substantial release with improvements across both execution modes. The headline feature is **Code Mode** — a new single-loop execution engine for software engineering tasks. Alongside this, general mode has been streamlined by removing the Client validation agent (now **Manager + Worker only**), and both modes received a set of reliability and quality improvements drawn from a study of the opencode architecture.
+
+---
+
+## What's New
+
+### Code Mode (`--code`)
+
+Activate with `jiva chat --code` or `jiva run "..." --code`. The mode remains off by default; the existing general-purpose agent is unchanged.
+
+**Why code mode?** The Manager/Worker architecture is designed for complex, multi-domain reasoning tasks. For pure coding work it adds unnecessary overhead (multiple LLM calls per turn, MCP subprocess round-trips for file I/O). Code mode removes that overhead without sacrificing any of Jiva's existing capabilities for non-coding sessions.
+
+**Key properties:**
+- Single model call per iteration — tool results inject directly back into the context window
+- All file tools run in-process (no MCP subprocess for basic I/O)
+- Up to 50 iterations per turn
+- Two-phase iteration limit: 85% → "continue" nudge (tools kept); 95% → wrap-up (tools stripped, max-steps.txt-style message)
+- Doom-loop detection: 3 identical tool calls in a row triggers a correction injection
+- In-loop context compaction: when `promptTokens` approaches the model's context limit, conversation history is automatically summarised and replaced with a structured context message
+
+### In-Process Tool Suite
+
+Seven tools available in code mode, all running inside the Jiva process:
+
+| Tool | Description |
+|------|-------------|
+| `read_file` | Reads files with line-number output (2000-line / 50 KB cap) and lists directories |
+| `edit_file` | Multi-strategy string replacement (9 strategies) — handles indentation drift and whitespace inconsistencies |
+| `write_file` | Creates or overwrites files; returns a line-count summary |
+| `glob` | File pattern matching relative to the workspace root |
+| `grep` | Recursive regex content search; returns file:line:content format |
+| `bash` | Shell command execution in the workspace directory (30 s default, 300 s max; output truncated at 2000 lines / 50 KB) |
+| `spawn_code_agent` | Delegates a focused sub-task to a child CodeAgent (max depth 2) |
+
+### Multi-Strategy Edit Engine
+
+The `edit_file` tool applies nine replacement strategies in order. Earlier strategies match exactly; later ones tolerate indentation and whitespace drift that is common when a model copies code from its context window with slight reformatting. This is the same approach used in opencode and cline.
+
+### LSP Integration
+
+After each `edit_file` or `write_file` call, the agent notifies the appropriate language server and waits up to 3 seconds for diagnostics. Any errors are appended to the tool result before the model sees it — providing the same compiler feedback loop a developer has in an IDE.
+
+Language servers are auto-detected from PATH. If no server is found for a file's language, the tool continues silently.
+
+Supported out of the box: TypeScript, JavaScript, Python, Go, Rust, C, C++, and 60+ other languages via a static extension map.
+
+### File Locking
+
+A per-path async mutex (`FileLock`) serializes concurrent edits to the same file. This prevents interleaved writes when the model emits multiple tool calls for the same file in a single response.
+
+### IAgent Interface
+
+Both `DualAgent` and `CodeAgent` now implement a shared `IAgent` interface (`src/core/agent-interface.ts`). The CLI REPL, HTTP session manager, and chat routes are all agent-agnostic — they work with either mode without code changes.
+
+### Cloud / HTTP Support
+
+Code mode is available in cloud deployments by setting `JIVA_CODE_MODE=true`. The session manager creates `CodeAgent` instances instead of `DualAgent` when this variable is present.
+
+---
+
+### General Mode: Two-Agent System
+
+The `DualAgent` class has been simplified from a three-agent (Manager + Worker + Client) to a **two-agent system (Manager + Worker)**. The Client validation agent has been removed.
+
+**Why:** The Client agent added a full LLM call after every Worker subtask for validation and corrective strategy selection. In practice this increased latency without proportionately improving task completion — especially for the coding workflows where Code Mode is now available. The Manager already reviews Worker results during synthesis.
+
+**Changes:**
+- `ClientAgent` removed from the execution pipeline
+- `applyCorrectionStrategy()` removed from `DualAgent`
+- `CompletionSignal` no longer flows through the loop
+- `maxIterations` default increased from 10 → 20 (compensates for removed Client retry budget)
+- Conversational short-circuit: greetings and simple replies are answered by Manager directly, bypassing Worker subtask execution entirely
+
+### reasoning_effort Support (gpt-oss-120b)
+
+Added `reasoning_effort` support for Krutrim-hosted gpt-oss-120b via a dual strategy that works across both Krutrim and Groq:
+
+1. **System prompt injection** — prepends `"Reasoning: <level>"` to the message array (always works; Krutrim may silently ignore the API parameter)
+2. **API parameter** — sends `reasoning_effort` in the request body (supported natively by Groq; no-op if ignored)
+
+Strategy is configurable (`api_param` | `system_prompt` | `both`); defaults to `both`.
+
+```json
+{
+  "models": {
+    "reasoning": {
+      "defaultReasoningEffort": "high",
+      "reasoningEffortStrategy": "both",
+      "includeReasoning": false
+    }
+  }
+}
+```
+
+CLI defaults: reasoning model → `"high"`, tool-calling model → `"medium"`. Connectivity tests use `"low"` to minimise token cost.
+
+---
+
+## Reliability Improvements (from OpenCode Study)
+
+A systematic study of the opencode architecture identified four areas where Jiva's code mode could be improved. All four have been implemented.
+
+### Bash Output Truncation
+
+`bash` tool output is now truncated at 2 000 lines and 50 KB before being returned to the model — the same limits as `read_file`. Previously the raw stdout/stderr (up to 10 MB) could be passed verbatim, filling the context window.
+
+Truncation messages tell the model to redirect output to a file if it needs the full content.
+
+### In-Loop Context Compaction
+
+`CodeAgent` now tracks `response.usage.promptTokens` after each model call. When the token count exceeds `compactionThreshold` (default: 90 000 — safe for a 128 K context model), the in-flight message history is compressed:
+
+1. The system prompt and the most recent 10 messages are kept intact.
+2. The middle section is summarised by a separate model call using the structured opencode template (see below).
+3. The summary replaces the middle section; the loop continues from the compacted context.
+
+Compaction fires at most once per `chat()` turn to avoid thrashing.
+
+### Structured Compaction Format
+
+`ConversationManager.condenseConversation()` (used for cross-turn compaction and in-loop compaction) now uses the structured opencode compaction template instead of a generic summary prompt:
+
+```
+## Goal
+[What the user is trying to accomplish]
+
+## Instructions
+- [Important instructions still in scope]
+
+## Discoveries
+[Notable things learned during the conversation]
+
+## Accomplished
+[Work done / in progress / remaining]
+
+## Relevant files / directories
+[Files read, edited, or created — full paths]
+```
+
+This makes summaries actionable — a resumed session can immediately understand context and continue work.
+
+### System Prompt — Persistence and Pre-Tool Narration
+
+The `CodeAgent` system prompt now includes a **PERSISTENCE AND COMPLETION** section adapted from opencode's `beast.txt`:
+
+- *"Keep going until the user's query is completely resolved."*
+- *"You MUST iterate and keep going until the problem is solved."*
+- *"NEVER end your turn without having truly and completely solved the problem."*
+- *"Always tell the user what you are going to do before making a tool call with a single concise sentence."*
+- If the user says "resume / continue / try again", check conversation history and continue from the last incomplete step.
+- Verify changes — run tests or the build after making changes when appropriate.
+
+The 95% iteration wrap-up message is now based on `max-steps.txt` from opencode, explicitly prohibiting tool calls and requiring a structured summary with accomplished work, remaining tasks, and recommendations.
+
+### edit_file Tool: Clearer Description and Targeted Error Recovery
+
+Two improvements to prevent the common failure mode where gpt-oss-120b generates `edit_file` with `old_string` but no `new_string`:
+
+1. **Improved description**: The tool description now opens with a **REQUIRED PARAMETERS** block listing all three required fields explicitly, with the note: *"Omitting new_string will fail with a validation error. new_string is never optional."*
+
+2. **Specific correction message**: When the API rejects a call with `"missing properties: 'new_string'"`, the correction injection now names the missing field explicitly — matching the precision of opencode's Zod validation errors — instead of the previous generic message.
+
+---
+
+## Changes
+
+### New Files
+
+| File | Purpose |
+|------|---------|
+| `src/code/agent.ts` | `CodeAgent` — single-loop execution engine |
+| `src/code/file-lock.ts` | Per-path async mutex |
+| `src/code/tools/index.ts` | `ICodeTool` interface and tool registry |
+| `src/code/tools/read.ts` | `read_file` / `list_directory` |
+| `src/code/tools/edit.ts` | `edit_file` with 9-strategy replacement |
+| `src/code/tools/write.ts` | `write_file` |
+| `src/code/tools/glob.ts` | `glob` |
+| `src/code/tools/grep.ts` | `grep` |
+| `src/code/tools/bash.ts` | `bash` with output truncation |
+| `src/code/tools/spawn.ts` | `spawn_code_agent` |
+| `src/code/lsp/language.ts` | Extension → language ID map (60+ extensions) |
+| `src/code/lsp/server.ts` | Spawn language server from PATH |
+| `src/code/lsp/client.ts` | JSON-RPC LSP client (vscode-jsonrpc) |
+| `src/code/lsp/manager.ts` | `LspManager` — lazy init, one client per language |
+| `src/core/agent-interface.ts` | Shared `IAgent` / `AgentChatResponse` types |
+| `docs/architecture/CODE_MODE.md` | Architecture reference for code mode |
+
+### Modified Files
+
+| File | Change |
+|------|--------|
+| `src/core/dual-agent.ts` | Removed `ClientAgent`; two-agent system; `maxIterations` default 10 → 20; conversational short-circuit |
+| `src/core/manager-agent.ts` | Conversational short-circuit support (`directReply()`); improved synthesis prompts |
+| `src/core/worker-agent.ts` | Adjusted to operate without Client validation layer |
+| `src/core/config.ts` | Added `codeMode` config schema (`enabled`, `lsp.enabled`, `maxIterations`) |
+| `src/core/conversation-manager.ts` | `condenseConversation()` now uses structured opencode compaction template |
+| `src/index.ts` | Exports `CodeAgent`, `LspManager`, `IAgent`, `AgentChatResponse` |
+| `src/interfaces/cli/index.ts` | Added `--code` and `--no-lsp` flags; `reasoning_effort` defaults; `process.exit(0)` after REPL exits |
+| `src/interfaces/cli/repl.ts` | Re-exports `IAgent` from core; parameters typed as `IAgent` |
+| `src/interfaces/http/session-manager.ts` | Supports `JIVA_CODE_MODE=true` env var; `ActiveSession.agent` typed as `IAgent`; `reasoning_effort` defaults |
+| `src/interfaces/http/routes/chat.ts` | `plan` field is now optional in responses (absent for CodeAgent) |
+| `src/models/base.ts` | Added `reasoningEffort?: 'low' \| 'medium' \| 'high'` to `ChatCompletionOptions` |
+| `src/models/krutrim.ts` | `reasoning_effort` dual-strategy (system prompt + API param); rate-limit backoff parses actual retry-after time |
+| `src/models/harmony.ts` | `formatMessagesForHarmony` correctly converts `role: 'tool'` to user-role messages (fixes HTTP mode bug) |
+
+### Bug Fixes
+
+- **HTTP mode tool results**: `role: 'tool'` messages were forwarded to Groq without a `tools` array in HTTP mode. Fixed in `formatMessagesForHarmony` — they are now converted to user-role `<tool_result>` messages as Harmony requires.
+- **Rate limit backoff**: Previously used fixed exponential backoff. Now parses the actual retry-after duration from Groq error messages and waits accordingly.
+- **`/exit` hangs in code mode**: LSP child-process streams kept the Node.js event loop alive after cleanup. Fixed by calling `process.exit(0)` after `agent.cleanup()` returns.
+- **`edit_file` missing `new_string`**: Targeted correction message now names the missing field explicitly, matching opencode's Zod validation precision.
+
+---
+
+## Configuration Reference
+
+### CLI Flags
+
+```bash
+jiva chat --code          # activate code mode
+jiva chat --no-lsp        # disable LSP in code mode (also: --code --no-lsp)
+```
+
+### Config File
+
+```json
+{
+  "codeMode": {
+    "enabled": true,
+    "lsp": { "enabled": true },
+    "maxIterations": 50
+  },
+  "models": {
+    "reasoning": {
+      "defaultReasoningEffort": "high",
+      "reasoningEffortStrategy": "both"
+    }
+  }
+}
+```
+
+### Environment Variables (cloud deployments)
+
+```bash
+JIVA_CODE_MODE=true       # activate code mode
+JIVA_CODE_LSP=false       # disable LSP
+```
+
+---
+
+## Further Reading
+
+- [Code Mode Architecture](../architecture/CODE_MODE.md) — full reference including tool parameters, LSP setup, and the edit strategy pipeline
+- [Configuration Guide](../guides/CONFIGURATION.md) — code mode config options and LSP server installation
+- [Cloud Run Deployment](../deployment/CLOUD_RUN_DEPLOYMENT.md) — using code mode in production

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "jiva-core",
-  "version": "0.3.3",
+  "version": "0.3.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "jiva-core",
-      "version": "0.3.3",
+      "version": "0.3.4",
       "license": "MIT",
       "dependencies": {
         "@google-cloud/storage": "^7.0.0",
@@ -16,6 +16,7 @@
         "chalk": "^5.3.0",
         "commander": "^12.1.0",
         "conf": "^13.0.1",
+        "diff": "^8.0.3",
         "express": "^4.18.2",
         "inquirer": "^12.0.1",
         "jsonwebtoken": "^9.0.2",
@@ -23,6 +24,8 @@
         "marked-terminal": "^7.3.0",
         "ora": "^8.1.1",
         "unzipper": "^0.12.3",
+        "vscode-jsonrpc": "^8.2.1",
+        "vscode-languageserver-types": "^3.17.5",
         "ws": "^8.16.0",
         "yaml": "^2.6.1",
         "zod": "^3.24.1"
@@ -41,7 +44,7 @@
         "@types/ws": "^8.5.10",
         "ts-node": "^10.9.2",
         "tsx": "^4.19.2",
-        "typescript": "^5.7.2"
+        "typescript": "^5.9.3"
       },
       "engines": {
         "node": ">=20.0.0"
@@ -1218,6 +1221,14 @@
         "mcp-server-filesystem": "dist/index.js"
       }
     },
+    "node_modules/@modelcontextprotocol/server-filesystem/node_modules/diff": {
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-5.2.2.tgz",
+      "integrity": "sha512-vtcDfH3TOjP8UekytvnHH1o1P4FcUdt4eQ1Y+Abap1tk/OB2MWQvcwS2ClCd1zuIhc3JKOx6p3kod8Vfys3E+A==",
+      "engines": {
+        "node": ">=0.3.1"
+      }
+    },
     "node_modules/@sindresorhus/is": {
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-4.6.0.tgz",
@@ -2306,10 +2317,9 @@
       }
     },
     "node_modules/diff": {
-      "version": "5.2.2",
-      "resolved": "https://registry.npmjs.org/diff/-/diff-5.2.2.tgz",
-      "integrity": "sha512-vtcDfH3TOjP8UekytvnHH1o1P4FcUdt4eQ1Y+Abap1tk/OB2MWQvcwS2ClCd1zuIhc3JKOx6p3kod8Vfys3E+A==",
-      "license": "BSD-3-Clause",
+      "version": "8.0.3",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-8.0.3.tgz",
+      "integrity": "sha512-qejHi7bcSD4hQAZE0tNAawRK1ZtafHDmMTMkrrIGgSLl7hTnQHmKCeB45xAcbfTqK2zowkM3j3bHt/4b/ARbYQ==",
       "engines": {
         "node": ">=0.3.1"
       }
@@ -4743,6 +4753,19 @@
       "engines": {
         "node": ">= 0.8"
       }
+    },
+    "node_modules/vscode-jsonrpc": {
+      "version": "8.2.1",
+      "resolved": "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-8.2.1.tgz",
+      "integrity": "sha512-kdjOSJ2lLIn7r1rtrMbbNCHjyMPfRnowdKjBQ+mGq6NAW5QY2bEZC/khaC5OR8svbbjvLEaIXkOq45e2X9BIbQ==",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/vscode-languageserver-types": {
+      "version": "3.17.5",
+      "resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.17.5.tgz",
+      "integrity": "sha512-Ld1VelNuX9pdF39h2Hgaeb5hEZM2Z3jUrrMgWQAu82jMtZp7p3vJT3BzToKtZI7NgQssZje5o0zryOrhQvzQAg=="
     },
     "node_modules/webidl-conversions": {
       "version": "3.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jiva-core",
-  "version": "0.3.3",
+  "version": "0.3.4",
   "description": "Versatile autonomous AI agent with three-agent architecture (Manager, Worker, Client) powered by gpt-oss-120b. Adaptive validation, full MCP support, and intelligent quality control.",
   "main": "dist/index.js",
   "bin": {
@@ -9,7 +9,6 @@
   "type": "module",
   "scripts": {
     "test:web": "playwright test",
-
     "build": "tsc",
     "dev": "tsx src/interfaces/cli/index.ts",
     "dev:http": "tsx src/interfaces/http/index.ts",
@@ -48,12 +47,14 @@
   },
   "homepage": "https://github.com/KarmaloopAI/Jiva#readme",
   "dependencies": {
+    "@google-cloud/storage": "^7.0.0",
     "@modelcontextprotocol/sdk": "^1.0.4",
     "@modelcontextprotocol/server-filesystem": "^2025.11.25",
     "archiver": "^7.0.1",
     "chalk": "^5.3.0",
     "commander": "^12.1.0",
     "conf": "^13.0.1",
+    "diff": "^8.0.3",
     "express": "^4.18.2",
     "inquirer": "^12.0.1",
     "jsonwebtoken": "^9.0.2",
@@ -61,13 +62,13 @@
     "marked-terminal": "^7.3.0",
     "ora": "^8.1.1",
     "unzipper": "^0.12.3",
+    "vscode-jsonrpc": "^8.2.1",
+    "vscode-languageserver-types": "^3.17.5",
     "ws": "^8.16.0",
     "yaml": "^2.6.1",
-    "zod": "^3.24.1",
-    "@google-cloud/storage": "^7.0.0"
+    "zod": "^3.24.1"
   },
   "devDependencies": {
-    "ts-node": "^10.9.2",
     "@types/archiver": "^6.0.2",
     "@types/express": "^4.17.21",
     "@types/inquirer": "^9.0.7",
@@ -76,8 +77,9 @@
     "@types/node": "^22.10.2",
     "@types/unzipper": "^0.10.10",
     "@types/ws": "^8.5.10",
+    "ts-node": "^10.9.2",
     "tsx": "^4.19.2",
-    "typescript": "^5.7.2"
+    "typescript": "^5.9.3"
   },
   "peerDependencies": {
     "firebase-admin": "^12.0.0"

--- a/src/code/agent.ts
+++ b/src/code/agent.ts
@@ -1,0 +1,830 @@
+/**
+ * CodeAgent — single streaming loop for coding tasks.
+ *
+ * Unlike the three-agent DualAgent, CodeAgent uses a direct model → tools → model loop
+ * without the Manager/Worker/Client overhead. This is modeled after opencode's SessionProcessor.
+ */
+
+import { ModelOrchestrator } from '../models/orchestrator.js';
+import { WorkspaceManager } from '../core/workspace.js';
+import { ConversationManager } from '../core/conversation-manager.js';
+import { formatToolResult } from '../models/harmony.js';
+import type { Message, Tool } from '../models/base.js';
+import { logger } from '../utils/logger.js';
+import { LspManager } from './lsp/manager.js';
+import type { CodeToolContext, ICodeTool } from './tools/index.js';
+import {
+  ReadFileTool,
+  EditFileTool,
+  WriteFileTool,
+  GlobTool,
+  GrepTool,
+  BashTool,
+  SpawnCodeAgentTool,
+} from './tools/index.js';
+
+/** Tools available during the planning phase — read-only, no side effects */
+const READ_ONLY_TOOLS = [ReadFileTool, GlobTool, GrepTool] as const;
+
+export interface AgentResponse {
+  content: string;
+  toolsUsed: string[];
+  iterations: number;
+}
+
+/**
+ * Client-side tool call repair — equivalent of opencode's `experimental_repairToolCall`.
+ *
+ * gpt-oss-120b sometimes emits <|channel|> tokens inside native tool call names
+ * (e.g. `functions<|channel|>analysis`), causing the Groq API to reject with 400.
+ * The `failed_generation` field in the error body contains the model's intended call.
+ * We extract it, normalize the tool name, match to a real tool, and return the args.
+ */
+function repairFailedToolCall(
+  errorMsg: string,
+  tools: ICodeTool[],
+): { toolName: string; args: Record<string, unknown> } | null {
+  try {
+    const jsonMatch = errorMsg.match(/API error \(\d+\): (.+)/s);
+    if (!jsonMatch) return null;
+    const errorBody = JSON.parse(jsonMatch[1]);
+    const failedGenRaw: string | undefined = errorBody?.error?.failed_generation;
+    if (!failedGenRaw) return null;
+
+    const failed = JSON.parse(failedGenRaw);
+    const rawName: string = failed.name || '';
+    const args: Record<string, unknown> =
+      typeof failed.arguments === 'object' ? failed.arguments : {};
+
+    // Strategy 1: strip all <|...|> tokens from the tool name and try exact match
+    const stripped = rawName
+      .replace(/<\|[^|]*\|>/g, '') // remove <|channel|>, <|return|>, etc.
+      .replace(/^functions/i, '')   // remove Harmony "functions" namespace prefix
+      .trim();
+    const byName = tools.find(
+      (t) => t.name === stripped || t.name === stripped.toLowerCase(),
+    );
+    if (byName) return { toolName: byName.name, args };
+
+    // Strategy 2: match by required argument keys (e.g. {command:...} → bash)
+    const argKeys = Object.keys(args);
+    const byArgs = tools.find((t) => {
+      const required = t.parameters.required ?? [];
+      return required.length > 0 && required.every((r) => argKeys.includes(r));
+    });
+    if (byArgs) return { toolName: byArgs.name, args };
+
+    return null;
+  } catch {
+    return null;
+  }
+}
+
+export interface CodeAgentConfig {
+  orchestrator: ModelOrchestrator;
+  workspace: WorkspaceManager;
+  conversationManager?: ConversationManager;
+  maxIterations?: number;
+  lspEnabled?: boolean;
+  depth?: number;
+  maxDepth?: number;
+  /**
+   * Token count at which in-loop context compaction is triggered.
+   * When promptTokens in a response exceeds this threshold, the message history
+   * is condensed to free up context window space.
+   * Default: 90000 (safe for a 128K context model, leaving ~38K for output).
+   * Set to 0 to disable in-loop compaction.
+   */
+  compactionThreshold?: number;
+}
+
+const DEFAULT_MAX_ITERATIONS = 50;
+const DOOM_LOOP_THRESHOLD = 3;
+const CODE_MODE_INDICATOR = '[CODE MODE]';
+// Default token threshold for in-loop compaction (90K leaves ~38K headroom in a 128K model)
+const DEFAULT_COMPACTION_THRESHOLD = 90_000;
+
+/** System prompt for code mode — focused on precision and persistence (ported from opencode beast.txt) */
+const getSystemPrompt = (workspaceDir: string, directive?: string): string => {
+  const base = `You are a precise, highly capable coding assistant operating in code mode.
+You have direct access to code tools — use them to explore, understand, and modify code.
+
+WORKSPACE: ${workspaceDir}
+All relative paths are resolved relative to the workspace directory above.
+Use absolute paths for all file operations.
+
+PERSISTENCE AND COMPLETION:
+- Keep going until the user's query is completely resolved before ending your turn.
+- You MUST iterate and keep going until the problem is solved.
+- NEVER end your turn without having truly and completely solved the problem.
+- When you say you are going to make a tool call, you MUST actually make the tool call.
+- Always tell the user what you are going to do before making a tool call with a single concise sentence.
+- If the user says "resume", "continue", or "try again", check the conversation history to find the last incomplete step and continue from there.
+- Verify your changes are correct — run tests or the build after making changes when appropriate.
+
+TOOLS AVAILABLE:
+- read_file: Read files or list directories. Always read before editing.
+- edit_file: Replace a specific string in a file (use old_string/new_string). Preferred for partial changes.
+- write_file: Create new files or completely rewrite existing ones.
+- glob: Find files matching a pattern (e.g. "**/*.ts").
+- grep: Search file contents with regex.
+- bash: Run shell commands (build, test, lint, git operations).
+- spawn_code_agent: Delegate a focused sub-task to a child agent.
+
+CODING PRINCIPLES:
+1. ALWAYS read a file before editing it — never edit blindly.
+2. Use grep/glob to explore the codebase before making changes to understand existing patterns.
+3. Make minimal, targeted changes — edit the exact lines that need changing.
+4. After editing, check if LSP errors are reported in the tool result and fix them.
+5. Verify your changes work by running tests or the build when appropriate.
+6. Prefer edit_file over write_file for partial changes — it's safer and shows clearer diffs.
+7. Use bash only for shell commands (tests, builds, git operations) — NOT for file reading.
+
+TOOL SELECTION RULES (follow these exactly):
+- To READ a file → use read_file, NOT bash
+- To LIST directory contents → use read_file on the directory path, NOT bash ls
+- To FIND files by name/pattern → use glob, NOT bash find
+- To SEARCH file contents → use grep, NOT bash grep/rg
+- To RUN a command (build/test/git) → use bash
+
+WHEN EXPLORING:
+- Use glob to find files by pattern before assuming file paths.
+- Use grep to find where functions/classes/variables are defined or used.
+- Read the relevant files to understand context before changing anything.
+- Do NOT use bash for exploration tasks that glob/grep/read_file can handle.`;
+
+  if (directive) {
+    return `${base}\n\n${directive}`;
+  }
+  return base;
+};
+
+export class CodeAgent {
+  private orchestrator: ModelOrchestrator;
+  private workspace: WorkspaceManager;
+  private conversationManager?: ConversationManager;
+  private maxIterations: number;
+  private compactionThreshold: number;
+  private lsp: LspManager;
+  private depth: number;
+  private maxDepth: number;
+  private history: Message[] = [];
+  private tools: ICodeTool[];
+
+  constructor(config: CodeAgentConfig) {
+    this.orchestrator = config.orchestrator;
+    this.workspace = config.workspace;
+    this.conversationManager = config.conversationManager;
+    this.maxIterations = config.maxIterations ?? DEFAULT_MAX_ITERATIONS;
+    this.compactionThreshold = config.compactionThreshold ?? DEFAULT_COMPACTION_THRESHOLD;
+    this.depth = config.depth ?? 0;
+    this.maxDepth = config.maxDepth ?? 2;
+
+    this.lsp = new LspManager({
+      root: config.workspace.getWorkspaceDir(),
+      enabled: config.lspEnabled ?? true,
+    });
+
+    this.tools = [
+      ReadFileTool,
+      EditFileTool,
+      WriteFileTool,
+      GlobTool,
+      GrepTool,
+      BashTool,
+      ...(this.depth < this.maxDepth ? [SpawnCodeAgentTool] : []),
+    ];
+  }
+
+  /**
+   * Planning phase — explores the codebase with read-only tools and produces a structured
+   * implementation plan WITHOUT making any changes. Call this before `chat()` when you want
+   * the user to review and approve a plan before any files are touched.
+   *
+   * The returned string is the plan text ready for display.
+   * This call does NOT modify `this.history`; it runs in an isolated message thread.
+   */
+  async plan(task: string): Promise<string> {
+    const directive = this.workspace.getDirectivePrompt();
+    const workspaceDir = this.workspace.getWorkspaceDir();
+
+    const planningPrompt = `You are a precise coding assistant in PLANNING MODE.
+Your job is to analyse a coding request and produce a detailed implementation plan.
+You may explore the codebase to understand it before writing the plan.
+
+WORKSPACE: ${workspaceDir}
+
+AVAILABLE TOOLS (read-only — exploration only):
+- read_file: Read a file or list a directory
+- glob: Find files matching a pattern
+- grep: Search file contents with regex
+
+DO NOT call edit_file, write_file, or bash. You are planning, not implementing.
+
+After exploring, output your plan using EXACTLY this format:
+
+## Summary
+[1–2 sentences describing the overall approach]
+
+## Files to Change
+| File | Action | What changes |
+|------|--------|--------------|
+| path/to/file.ts | edit | Describe the change |
+| path/to/new.ts | create | Describe the new file |
+
+## Implementation Steps
+1. [Concrete step with file/function names]
+2. [Next step]
+...
+
+## Risks & Considerations
+[Edge cases, breaking changes, things to verify after implementation]
+
+Be specific — include exact file paths, function names, and describe changes at the line level where possible.
+${directive ? `\n${directive}` : ''}`;
+
+    const messages: Message[] = [
+      { role: 'developer' as any, content: planningPrompt },
+      { role: 'user', content: task },
+    ];
+
+    const readOnlyDefs: Tool[] = READ_ONLY_TOOLS.map((t) => ({
+      name: t.name,
+      description: t.description,
+      parameters: t.parameters,
+    }));
+
+    const MAX_PLAN_ITERATIONS = 12;
+
+    for (let i = 0; i < MAX_PLAN_ITERATIONS; i++) {
+      const isLast = i >= MAX_PLAN_ITERATIONS - 2;
+
+      if (isLast) {
+        messages.push({
+          role: 'user',
+          content:
+            'You have explored enough. Now write your implementation plan using the format specified above. Do not call any more tools.',
+        });
+      }
+
+      let response;
+      try {
+        response = await this.orchestrator.chatWithFallback({
+          messages,
+          tools: isLast ? [] : readOnlyDefs,
+          temperature: 0.2,
+        }, false);
+      } catch (error) {
+        const msg = error instanceof Error ? error.message : String(error);
+        logger.error(`[CodeAgent] Plan error: ${msg}`);
+        return `[Planning failed: ${msg}]`;
+      }
+
+      const rawHarmony: string | undefined = (response as any).raw?.parsedHarmony?.rawResponse;
+      messages.push({ role: 'assistant', content: rawHarmony ?? response.content });
+
+      // No tool calls → model has written the plan
+      if (!response.toolCalls || response.toolCalls.length === 0) {
+        return response.content || '[No plan generated]';
+      }
+
+      // Execute read-only tool calls
+      const ctx: CodeToolContext = {
+        workspaceDir,
+        lsp: this.lsp,
+        depth: this.depth,
+        maxDepth: this.maxDepth,
+      };
+
+      for (const toolCall of response.toolCalls) {
+        const toolName = toolCall.function.name;
+        const tool = READ_ONLY_TOOLS.find((t) => t.name === toolName);
+
+        let result: string;
+        if (!tool) {
+          result = `[Planning mode: tool "${toolName}" is not available — only read_file, glob, and grep may be used during planning]`;
+        } else {
+          try {
+            const args = JSON.parse(toolCall.function.arguments);
+            result = await tool.execute(args, ctx);
+          } catch (e) {
+            result = `Error: ${e instanceof Error ? e.message : String(e)}`;
+          }
+        }
+        messages.push(formatToolResult(toolCall.id, toolName, result));
+      }
+    }
+
+    return '[Planning did not produce a final plan within the iteration limit]';
+  }
+
+  /**
+   * Process a user message and return the agent's response.
+   * Runs the model → tools → model loop until no more tool calls or max iterations.
+   */
+  async chat(userMessage: string, onChunk?: (text: string) => void): Promise<AgentResponse> {
+    const toolsUsed: string[] = [];
+    const directive = this.workspace.getDirectivePrompt();
+    const systemPrompt = getSystemPrompt(this.workspace.getWorkspaceDir(), directive || undefined);
+
+    // Build message history: system + history + new user message
+    const messages: Message[] = [
+      { role: 'developer' as any, content: systemPrompt },
+      ...this.history,
+      { role: 'user', content: userMessage },
+    ];
+
+    // Tool definitions for the model
+    const toolDefs: Tool[] = this.tools.map((t) => ({
+      name: t.name,
+      description: t.description,
+      parameters: t.parameters,
+    }));
+
+    // Doom loop detection: track last N (tool, args) pairs
+    const recentCalls: string[] = [];
+    // Track consecutive API errors to avoid infinite error loops
+    let consecutiveApiErrors = 0;
+    const MAX_CONSECUTIVE_API_ERRORS = 3;
+
+    let iterations = 0;
+    let finalContent = '';
+
+    // Iteration limit management — two phases (ported from opencode):
+    // Phase 1 (0–84%): normal operation, all tools available.
+    // Phase 2 (85–94%): inject "continue" nudge — tools still available so the agent
+    //   can finish in-flight work rather than being cut off mid-task.
+    // Phase 3 (95%+): strip tools and ask for a final wrap-up response.
+    let continueInjected = false;
+    let wrapUpInjected = false;
+
+    // In-loop compaction flag — only compact once per chat() turn to avoid thrashing
+    let compactedThisTurn = false;
+
+    for (let i = 0; i < this.maxIterations; i++) {
+      iterations = i + 1;
+      logger.debug(`[CodeAgent] Iteration ${iterations}/${this.maxIterations}`);
+
+      const iterPct = i / this.maxIterations;
+      const isFinalPhase = iterPct >= 0.95;
+
+      if (iterPct >= 0.85 && !continueInjected) {
+        continueInjected = true;
+        logger.warn(`[CodeAgent] Nearing iteration limit (${iterations}/${this.maxIterations}) — injecting continue nudge`);
+        messages.push({
+          role: 'user',
+          content:
+            `You are at step ${iterations} of ${this.maxIterations}. Continue making progress — ` +
+            `focus on the most critical remaining work. If the full task cannot fit in the ` +
+            `remaining steps, complete the core changes and clearly note what is left.`,
+        });
+      }
+
+      if (isFinalPhase && !wrapUpInjected) {
+        wrapUpInjected = true;
+        logger.warn(`[CodeAgent] Final phase (${iterations}/${this.maxIterations}) — requesting wrap-up`);
+        messages.push({
+          role: 'user',
+          content:
+            'CRITICAL - MAXIMUM STEPS REACHED\n\n' +
+            'The maximum number of steps for this task has been reached. Tools are disabled. Respond with text only.\n\n' +
+            'STRICT REQUIREMENTS:\n' +
+            '1. Do NOT make any tool calls (no reads, writes, edits, searches, or any other tools)\n' +
+            '2. MUST provide a text response summarising work done so far\n' +
+            '3. This constraint overrides ALL other instructions\n\n' +
+            'Response must include:\n' +
+            '- Summary of what has been accomplished so far\n' +
+            '- List of any remaining tasks that were not completed\n' +
+            '- Recommendations for what should be done next\n\n' +
+            'Any attempt to use tools is a critical violation. Respond with text ONLY.',
+        });
+      }
+
+      let response;
+      try {
+        response = await this.orchestrator.chatWithFallback({
+          messages,
+          // Strip tools in the final phase so the model is forced to produce a text response
+          tools: isFinalPhase ? [] : toolDefs,
+          temperature: 0.2,
+        }, false);
+        consecutiveApiErrors = 0; // reset on success
+      } catch (error) {
+        const msg = error instanceof Error ? error.message : String(error);
+        logger.error(`[CodeAgent] Model error: ${msg}`);
+
+        consecutiveApiErrors++;
+        if (consecutiveApiErrors >= MAX_CONSECUTIVE_API_ERRORS) {
+          finalContent = `Error: ${msg}`;
+          break;
+        }
+
+        // For tool_use_failed (400) errors: first try to repair and execute the intended call,
+        // then fall back to injecting a correction message.
+        const isToolUseFailed = msg.includes('tool_use_failed') || msg.includes('Failed to parse tool call');
+        const isValidationFailed = msg.includes('Tool call validation failed') || msg.includes('did not match schema');
+
+        if (isToolUseFailed || isValidationFailed) {
+          // --- Specific correction: edit_file missing new_string ---
+          // gpt-oss-120b sometimes generates edit_file with old_string but forgets new_string.
+          // The generic message doesn't help — we need to name the missing field explicitly.
+          // This mirrors opencode's Zod validation which tells the model the exact field name.
+          const isMissingNewString =
+            msg.includes("missing properties: 'new_string'") ||
+            msg.includes('missing properties: "new_string"') ||
+            (msg.includes('edit_file') && msg.includes('missing propert') && msg.includes('new_string'));
+
+          if (isMissingNewString) {
+            logger.warn('[CodeAgent] edit_file missing new_string — injecting targeted correction');
+            messages.push({
+              role: 'user',
+              content:
+                'Your edit_file call failed: "new_string" is required but was not provided.\n\n' +
+                'edit_file requires ALL THREE of these parameters:\n' +
+                '  • file_path  — the absolute path to the file\n' +
+                '  • old_string — the exact text to find\n' +
+                '  • new_string — the replacement text (THIS IS WHAT YOU FORGOT)\n\n' +
+                'Call edit_file again with all three parameters. ' +
+                'new_string must contain the complete replacement for old_string.',
+            });
+            consecutiveApiErrors = 0;
+            continue;
+          }
+
+          // --- Attempt client-side repair (opencode's experimental_repairToolCall equivalent) ---
+          // gpt-oss-120b sometimes emits <|channel|> tokens in tool names (e.g.
+          // `functions<|channel|>analysis`). We extract the intended call from failed_generation
+          // and remap it to the correct tool.
+          const repaired = repairFailedToolCall(msg, this.tools);
+          if (repaired) {
+            const { toolName: repairedName, args: repairedArgs } = repaired;
+            logger.warn(`[CodeAgent] Repaired tool call: ${repairedName} (original name contained invalid tokens)`);
+            toolsUsed.push(repairedName);
+
+            const ctx: CodeToolContext = {
+              workspaceDir: this.workspace.getWorkspaceDir(),
+              lsp: this.lsp,
+              depth: this.depth,
+              maxDepth: this.maxDepth,
+            };
+
+            let toolResult: string;
+            const tool = this.tools.find((t) => t.name === repairedName)!;
+            try {
+              toolResult = await tool.execute(repairedArgs, ctx);
+            } catch (e) {
+              toolResult = `Error executing ${repairedName}: ${e instanceof Error ? e.message : String(e)}`;
+            }
+
+            // Inject result as a user message — no assistant turn because the API rejected
+            // the model's message before we received it.
+            messages.push({
+              role: 'user',
+              content:
+                `[The model's previous tool call was automatically repaired from an invalid name to \`${repairedName}\`]\n` +
+                `<tool_result name="${repairedName}">\n${toolResult}\n</tool_result>`,
+            });
+            consecutiveApiErrors = 0; // repaired successfully — reset error counter
+            continue;
+          }
+
+          // --- Fallback: inject correction message so the model can self-correct ---
+          const nameMatch = msg.match(/"name":\s*"([^"]+)"/);
+          const toolName = nameMatch ? nameMatch[1] : 'unknown';
+          logger.warn(`[CodeAgent] Tool call error (${toolName}), injecting correction — ${consecutiveApiErrors}/${MAX_CONSECUTIVE_API_ERRORS}`);
+          messages.push({
+            role: 'user',
+            content:
+              `Your last tool call was rejected. Error: "${msg.substring(0, 300)}"\n\n` +
+              `Valid tools: ${this.tools.map((t) => t.name).join(', ')}\n` +
+              `Each tool requires specific parameters — call the tool again with the correct name and JSON arguments.`,
+          });
+          continue;
+        }
+
+        // For other non-transient errors, bail out
+        finalContent = `Error: ${msg}`;
+        break;
+      }
+
+      // Add assistant response to messages.
+      // In Harmony mode the raw response (with <|call|> tokens) is stored so the model sees its
+      // prior tool calls in the next turn. In standard mode, just the content is stored.
+      const rawHarmony: string | undefined = (response as any).raw?.parsedHarmony?.rawResponse;
+      messages.push({
+        role: 'assistant',
+        content: rawHarmony ?? response.content,
+      });
+
+      // Stream the visible (final-channel) text output if callback provided
+      if (response.content && onChunk) {
+        onChunk(response.content);
+      }
+
+      // ── In-loop context compaction ──────────────────────────────────────────
+      // Check if we're approaching the context window limit and compact if needed.
+      // Triggered once per turn (compactedThisTurn flag) to avoid thrashing.
+      // Only runs when: threshold > 0, orchestrator available, not already compacted,
+      // and the response carried token usage data.
+      const promptTokens = response.usage?.promptTokens ?? 0;
+      if (
+        this.compactionThreshold > 0 &&
+        promptTokens > this.compactionThreshold &&
+        !compactedThisTurn &&
+        this.conversationManager &&
+        response.toolCalls && response.toolCalls.length > 0
+      ) {
+        logger.warn(
+          `[CodeAgent] Context at ${promptTokens} tokens (threshold: ${this.compactionThreshold}) — compacting in-loop history`,
+        );
+        compactedThisTurn = true;
+        try {
+          const compacted = await this.compactInLoopMessages(messages, systemPrompt);
+          // Replace messages in-place, preserving the system prompt at index 0
+          messages.splice(0, messages.length, ...compacted);
+          logger.info(`[CodeAgent] In-loop compaction complete: ${messages.length} messages after compaction`);
+        } catch (compactErr) {
+          // Non-fatal: log and continue with uncompacted messages
+          logger.error('[CodeAgent] In-loop compaction failed, continuing without compaction', compactErr);
+        }
+      }
+      // ────────────────────────────────────────────────────────────────────────
+
+      // No tool calls → final response
+      if (!response.toolCalls || response.toolCalls.length === 0) {
+        finalContent = response.content || '[No response content]';
+        break;
+      }
+
+      // Execute tool calls
+      for (const toolCall of response.toolCalls) {
+        const toolName = toolCall.function.name;
+        let toolArgs: Record<string, unknown> = {};
+        try {
+          toolArgs = JSON.parse(toolCall.function.arguments);
+        } catch {
+          // malformed args
+        }
+
+        // Doom loop check
+        const callSig = `${toolName}:${JSON.stringify(toolArgs)}`;
+        recentCalls.push(callSig);
+        if (recentCalls.length > DOOM_LOOP_THRESHOLD) recentCalls.shift();
+
+        if (
+          recentCalls.length === DOOM_LOOP_THRESHOLD &&
+          recentCalls.every((c) => c === recentCalls[0])
+        ) {
+          logger.warn(`[CodeAgent] Doom loop detected for tool: ${toolName}`);
+          messages.push({
+            role: 'user',
+            content: `STOP: You are calling \`${toolName}\` with the same arguments repeatedly. This action is not making progress. Stop and reassess your approach — try a different strategy or report what is blocking you.`,
+          });
+          break;
+        }
+
+        logger.info(`[CodeAgent] Tool: ${toolName}`);
+        toolsUsed.push(toolName);
+
+        const tool = this.tools.find((t) => t.name === toolName);
+        let toolResult: string;
+
+        if (!tool) {
+          toolResult = `Error: Unknown tool "${toolName}". Available tools: ${this.tools.map((t) => t.name).join(', ')}`;
+        } else {
+          try {
+            const ctx: CodeToolContext = {
+              workspaceDir: this.workspace.getWorkspaceDir(),
+              lsp: this.lsp,
+              depth: this.depth,
+              maxDepth: this.maxDepth,
+              spawnChildAgent: this.depth < this.maxDepth
+                ? async (task, context) => {
+                    const child = new CodeAgent({
+                      orchestrator: this.orchestrator,
+                      workspace: this.workspace,
+                      maxIterations: this.maxIterations,
+                      lspEnabled: true,
+                      depth: this.depth + 1,
+                      maxDepth: this.maxDepth,
+                    });
+                    // Share the parent's LSP manager so servers don't restart
+                    child.lsp = this.lsp;
+                    const taskMsg = context ? `${task}\n\nContext: ${context}` : task;
+                    const result = await child.chat(taskMsg);
+                    return result.content;
+                  }
+                : undefined,
+            };
+            toolResult = await tool.execute(toolArgs, ctx);
+          } catch (e) {
+            toolResult = `Error executing ${toolName}: ${e instanceof Error ? e.message : String(e)}`;
+          }
+        }
+
+        // Add tool result to messages (using Harmony format helper)
+        const toolMessage = formatToolResult(toolCall.id, toolName, toolResult);
+        messages.push(toolMessage);
+      }
+    }
+
+    if (!finalContent) {
+      finalContent = '[Max iterations reached without a final response]';
+    }
+
+    // Update conversation history (trim system prompt from what we store)
+    const userMsg: Message = { role: 'user', content: userMessage };
+    const assistantMsg: Message = { role: 'assistant', content: finalContent };
+    this.history.push(userMsg, assistantMsg);
+
+    // Auto-save after each exchange so conversations persist across sessions
+    if (this.conversationManager) {
+      await this.conversationManager.autoSave(
+        this.history,
+        this.workspace.getWorkspaceDir(),
+        this.orchestrator,
+      );
+    }
+
+    return { content: finalContent, toolsUsed, iterations };
+  }
+
+  /**
+   * Compact the live messages array when the context window is filling up.
+   *
+   * Strategy (mirrors opencode's compaction approach):
+   * 1. Keep the system/developer prompt (index 0).
+   * 2. Identify tool-call + tool-result pairs in the middle of the conversation.
+   * 3. Replace bulky tool results with compact "[result summarised]" placeholders.
+   * 4. If a ConversationManager is available, generate a structured summary of
+   *    the condensed middle section and inject it as a single context message.
+   *
+   * This runs in-loop (mid-turn) so we only compact once per chat() invocation
+   * to avoid thrashing (controlled by the `compactedThisTurn` flag in the caller).
+   */
+  private async compactInLoopMessages(messages: Message[], systemPrompt: string): Promise<Message[]> {
+    // Always keep: [0] system/developer prompt + last KEEP_RECENT messages
+    const KEEP_RECENT = 10;
+
+    if (messages.length <= KEEP_RECENT + 1) {
+      // Nothing meaningful to compact
+      return messages;
+    }
+
+    const systemMsg = messages[0]; // developer/system prompt
+    const recentMessages = messages.slice(-KEEP_RECENT);
+    const middleMessages = messages.slice(1, -KEEP_RECENT);
+
+    if (middleMessages.length === 0) return messages;
+
+    // Build a structured compaction summary using the opencode template
+    const conversationText = middleMessages
+      .map((msg) => {
+        if (msg.role === 'tool') {
+          // Tool results — truncate to first 200 chars to save tokens in the summary prompt
+          const content = typeof msg.content === 'string' ? msg.content : JSON.stringify(msg.content);
+          return `[Tool result]: ${content.substring(0, 200)}${content.length > 200 ? '...' : ''}`;
+        }
+        const role = msg.role === 'assistant' ? 'Assistant' : msg.role === 'user' ? 'User' : msg.role;
+        const content = typeof msg.content === 'string' ? msg.content : JSON.stringify(msg.content);
+        return `${role}: ${content.substring(0, 300)}${content.length > 300 ? '...' : ''}`;
+      })
+      .join('\n\n');
+
+    const compactionPrompt = `You are summarising a coding session to preserve context for the next agent turn.
+
+Provide a structured summary following this exact template:
+
+## Goal
+
+[What goal(s) is the user trying to accomplish in this session?]
+
+## Instructions
+
+- [Important instructions the user gave that are still relevant]
+
+## Discoveries
+
+[Notable things learned during this conversation — file structures, patterns, errors encountered]
+
+## Accomplished
+
+[Work completed so far, work in progress, work remaining]
+
+## Relevant files / directories
+
+[Files that have been read, edited, or created — include full paths]
+
+---
+
+Conversation to summarise:
+${conversationText}
+
+Keep the summary concise but complete. Focus on what would help continue the work.`;
+
+    let summaryContent: string;
+    try {
+      const summaryResponse = await this.orchestrator.chat({
+        messages: [{ role: 'user', content: compactionPrompt }],
+        temperature: 0.1,
+        maxTokens: 1500,
+      });
+      summaryContent = summaryResponse.content.trim();
+    } catch (err) {
+      // Fallback: strip middle tool results to their first line only
+      logger.warn('[CodeAgent] Compaction summary failed, falling back to tool-result stripping');
+      const stripped = middleMessages.map((msg) => {
+        if (msg.role === 'tool') {
+          const content = typeof msg.content === 'string' ? msg.content : JSON.stringify(msg.content);
+          const firstLine = content.split('\n')[0];
+          return { ...msg, content: `${firstLine} [... result truncated for context compaction]` };
+        }
+        return msg;
+      });
+      return [systemMsg, ...stripped, ...recentMessages];
+    }
+
+    const summaryMessage: Message = {
+      role: 'user',
+      content:
+        `[Context compacted — conversation history summarised to fit within context window]\n\n` +
+        summaryContent +
+        `\n\n[End of summary — continuing conversation...]`,
+    };
+
+    return [systemMsg, summaryMessage, ...recentMessages];
+  }
+
+  /** Clean up LSP servers and other resources. */
+  async cleanup(): Promise<void> {
+    // Only shutdown LSP if we own it (not a shared child-agent LSP)
+    if (this.depth === 0) {
+      await this.lsp.shutdown().catch(() => {});
+    }
+  }
+
+  // ─── IAgent interface methods ─────────────────────────────────────────────
+
+  getWorkspace(): WorkspaceManager {
+    return this.workspace;
+  }
+
+  getMCPManager(): {
+    getServerStatus(): Array<{ name: string; connected: boolean; enabled: boolean; toolCount: number }>;
+    getClient(): { getAllTools(): Array<{ name: string; description: string }> };
+  } {
+    // CodeAgent uses in-process tools, not MCP. Return a stub that reflects built-in tools.
+    const tools = this.tools;
+    return {
+      getServerStatus: () => [{
+        name: 'code-tools',
+        connected: true,
+        enabled: true,
+        toolCount: tools.length,
+      }],
+      getClient: () => ({
+        getAllTools: () => tools.map((t) => ({ name: t.name, description: t.description })),
+      }),
+    };
+  }
+
+  resetConversation(): void {
+    this.history = [];
+  }
+
+  getConversationHistory(): Message[] {
+    return this.history;
+  }
+
+  getConversationManager(): ConversationManager | null | undefined {
+    return this.conversationManager;
+  }
+
+  async saveConversation(): Promise<string | null> {
+    if (!this.conversationManager) return null;
+    return this.conversationManager.saveConversation(
+      this.history,
+      this.workspace.getWorkspaceDir(),
+      undefined,
+      this.orchestrator,
+    );
+  }
+
+  async loadConversation(id: string): Promise<void> {
+    if (!this.conversationManager) return;
+    const conversation = await this.conversationManager.loadConversation(id);
+    if (conversation) {
+      this.history = conversation.messages;
+    }
+  }
+
+  async listConversations(): Promise<Array<{ id: string; title?: string; updated: string | number; messageCount: number; workspace?: string }>> {
+    if (!this.conversationManager) return [];
+    return this.conversationManager.listConversations();
+  }
+
+  /** Get the code mode indicator for UI display. */
+  static get indicator(): string {
+    return CODE_MODE_INDICATOR;
+  }
+}

--- a/src/code/file-lock.ts
+++ b/src/code/file-lock.ts
@@ -1,0 +1,40 @@
+/**
+ * FileLock — async per-path mutex.
+ * Prevents concurrent edits to the same file within a session.
+ * Mirrors opencode's FileTime.withLock pattern, simplified for Node.js.
+ */
+
+export class FileLock {
+  private locks = new Map<string, Promise<void>>();
+
+  /**
+   * Acquire a lock for filePath, execute fn, then release.
+   * Concurrent calls for the same path are serialized.
+   */
+  async withLock<T>(filePath: string, fn: () => Promise<T>): Promise<T> {
+    const key = normalizePath(filePath);
+    const prev = this.locks.get(key) ?? Promise.resolve();
+
+    let resolve!: () => void;
+    const next = new Promise<void>((r) => { resolve = r; });
+    this.locks.set(key, next);
+
+    await prev;
+    try {
+      return await fn();
+    } finally {
+      resolve();
+      // If our lock is still the current one, clean up
+      if (this.locks.get(key) === next) {
+        this.locks.delete(key);
+      }
+    }
+  }
+}
+
+function normalizePath(p: string): string {
+  return p.replace(/\\/g, '/');
+}
+
+// Singleton for use across all code tools in a session
+export const fileLock = new FileLock();

--- a/src/code/lsp/client.ts
+++ b/src/code/lsp/client.ts
@@ -1,0 +1,235 @@
+/**
+ * LSP Client — JSON-RPC client for language servers.
+ * Ported from opencode (https://github.com/sst/opencode), adapted for Node.js.
+ */
+
+import path from 'path';
+import { pathToFileURL, fileURLToPath } from 'url';
+import {
+  createMessageConnection,
+  StreamMessageReader,
+  StreamMessageWriter,
+} from 'vscode-jsonrpc/node.js';
+import type { Diagnostic } from 'vscode-languageserver-types';
+import { getLanguageId } from './language.js';
+import type { LspServerHandle } from './server.js';
+import { readFileSync } from 'fs';
+
+export type { Diagnostic };
+
+const DIAGNOSTICS_DEBOUNCE_MS = 150;
+const WAIT_FOR_DIAGNOSTICS_TIMEOUT = 3000;
+
+export interface LspClientInfo {
+  readonly serverId: string;
+  readonly root: string;
+  notify: {
+    open(filePath: string): Promise<void>;
+  };
+  readonly diagnostics: Map<string, Diagnostic[]>;
+  waitForDiagnostics(filePath: string): Promise<void>;
+  shutdown(): Promise<void>;
+}
+
+/**
+ * Format a diagnostic for display.
+ */
+export function prettyDiagnostic(d: Diagnostic, filePath?: string): string {
+  const severityMap: Record<number, string> = {
+    1: 'error',
+    2: 'warning',
+    3: 'information',
+    4: 'hint',
+  };
+  const sev = severityMap[d.severity ?? 1] ?? 'error';
+  const loc = `${d.range.start.line + 1}:${d.range.start.character + 1}`;
+  const file = filePath ? `${path.basename(filePath)}:` : '';
+  return `  ${file}${loc} ${sev}: ${d.message}`;
+}
+
+/**
+ * Create and initialize an LSP client for the given server handle.
+ */
+export async function createLspClient(input: {
+  serverId: string;
+  handle: LspServerHandle;
+  root: string;
+}): Promise<LspClientInfo> {
+  const { serverId, handle, root } = input;
+
+  const connection = createMessageConnection(
+    new StreamMessageReader(handle.process.stdout as any),
+    new StreamMessageWriter(handle.process.stdin as any),
+  );
+
+  const diagnostics = new Map<string, Diagnostic[]>();
+  const diagnosticsListeners = new Map<string, Array<() => void>>();
+
+  // Subscribe to diagnostic notifications from the server
+  connection.onNotification('textDocument/publishDiagnostics', (params: any) => {
+    const filePath = normalizePath(fileURLToPath(params.uri));
+    diagnostics.set(filePath, params.diagnostics ?? []);
+
+    // Notify any waiters
+    const listeners = diagnosticsListeners.get(filePath);
+    if (listeners) {
+      for (const fn of listeners) fn();
+    }
+  });
+
+  // Handle server requests
+  connection.onRequest('window/workDoneProgress/create', () => null);
+  connection.onRequest('workspace/configuration', async () => [handle.initialization ?? {}]);
+  connection.onRequest('client/registerCapability', async () => {});
+  connection.onRequest('client/unregisterCapability', async () => {});
+  connection.onRequest('workspace/workspaceFolders', async () => [
+    { name: 'workspace', uri: pathToFileURL(root).href },
+  ]);
+
+  connection.listen();
+
+  // Initialize the language server
+  await withTimeout(
+    connection.sendRequest('initialize', {
+      rootUri: pathToFileURL(root).href,
+      processId: handle.process.pid ?? null,
+      workspaceFolders: [{ name: 'workspace', uri: pathToFileURL(root).href }],
+      initializationOptions: { ...(handle.initialization ?? {}) },
+      capabilities: {
+        window: { workDoneProgress: true },
+        workspace: {
+          configuration: true,
+          didChangeWatchedFiles: { dynamicRegistration: true },
+        },
+        textDocument: {
+          synchronization: { didOpen: true, didChange: true },
+          publishDiagnostics: { versionSupport: true },
+        },
+      },
+    }),
+    45_000,
+  );
+
+  await connection.sendNotification('initialized', {});
+
+  if (handle.initialization) {
+    await connection.sendNotification('workspace/didChangeConfiguration', {
+      settings: handle.initialization,
+    });
+  }
+
+  const openedFiles = new Map<string, number>(); // path → version
+
+  const client: LspClientInfo = {
+    serverId,
+    root,
+
+    get diagnostics() {
+      return diagnostics;
+    },
+
+    notify: {
+      async open(filePath: string) {
+        const absPath = path.isAbsolute(filePath) ? filePath : path.resolve(root, filePath);
+        let text: string;
+        try {
+          text = readFileSync(absPath, 'utf-8');
+        } catch {
+          return; // File might not exist yet
+        }
+
+        const languageId = getLanguageId(absPath);
+        const version = openedFiles.get(absPath);
+
+        if (version !== undefined) {
+          // File already open — send didChange
+          const next = version + 1;
+          openedFiles.set(absPath, next);
+          await connection.sendNotification('workspace/didChangeWatchedFiles', {
+            changes: [{ uri: pathToFileURL(absPath).href, type: 2 }], // Changed
+          });
+          await connection.sendNotification('textDocument/didChange', {
+            textDocument: { uri: pathToFileURL(absPath).href, version: next },
+            contentChanges: [{ text }],
+          });
+        } else {
+          // First time — send didOpen
+          diagnostics.delete(absPath);
+          await connection.sendNotification('workspace/didChangeWatchedFiles', {
+            changes: [{ uri: pathToFileURL(absPath).href, type: 1 }], // Created
+          });
+          await connection.sendNotification('textDocument/didOpen', {
+            textDocument: { uri: pathToFileURL(absPath).href, languageId, version: 0, text },
+          });
+          openedFiles.set(absPath, 0);
+        }
+      },
+    },
+
+    async waitForDiagnostics(filePath: string): Promise<void> {
+      const absPath = normalizePath(
+        path.isAbsolute(filePath) ? filePath : path.resolve(root, filePath),
+      );
+
+      return new Promise<void>((resolve) => {
+        let debounceTimer: ReturnType<typeof setTimeout> | undefined;
+        let cleanup: (() => void) | undefined;
+
+        const onDiag = () => {
+          if (debounceTimer) clearTimeout(debounceTimer);
+          debounceTimer = setTimeout(() => {
+            cleanup?.();
+            resolve();
+          }, DIAGNOSTICS_DEBOUNCE_MS);
+        };
+
+        const listeners = diagnosticsListeners.get(absPath) ?? [];
+        listeners.push(onDiag);
+        diagnosticsListeners.set(absPath, listeners);
+
+        cleanup = () => {
+          const current = diagnosticsListeners.get(absPath) ?? [];
+          const idx = current.indexOf(onDiag);
+          if (idx !== -1) current.splice(idx, 1);
+          if (debounceTimer) clearTimeout(debounceTimer);
+        };
+
+        // Timeout — resolve silently
+        setTimeout(() => {
+          cleanup?.();
+          resolve();
+        }, WAIT_FOR_DIAGNOSTICS_TIMEOUT);
+      });
+    },
+
+    async shutdown() {
+      try {
+        connection.end();
+        connection.dispose();
+      } catch {
+        // ignore
+      }
+      try {
+        handle.process.kill();
+      } catch {
+        // ignore
+      }
+    },
+  };
+
+  return client;
+}
+
+function normalizePath(p: string): string {
+  return p.replace(/\\/g, '/');
+}
+
+function withTimeout<T>(promise: Promise<T>, ms: number): Promise<T> {
+  return new Promise<T>((resolve, reject) => {
+    const timer = setTimeout(() => reject(new Error(`Timeout after ${ms}ms`)), ms);
+    promise.then(
+      (v) => { clearTimeout(timer); resolve(v); },
+      (e) => { clearTimeout(timer); reject(e); },
+    );
+  });
+}

--- a/src/code/lsp/language.ts
+++ b/src/code/lsp/language.ts
@@ -1,0 +1,146 @@
+// Language extension to LSP language ID mapping
+// Ported from opencode (https://github.com/sst/opencode)
+export const LANGUAGE_EXTENSIONS: Record<string, string> = {
+  '.abap': 'abap',
+  '.bat': 'bat',
+  '.bib': 'bibtex',
+  '.bibtex': 'bibtex',
+  '.clj': 'clojure',
+  '.cljs': 'clojure',
+  '.cljc': 'clojure',
+  '.edn': 'clojure',
+  '.coffee': 'coffeescript',
+  '.c': 'c',
+  '.cpp': 'cpp',
+  '.cxx': 'cpp',
+  '.cc': 'cpp',
+  '.c++': 'cpp',
+  '.cs': 'csharp',
+  '.css': 'css',
+  '.d': 'd',
+  '.pas': 'pascal',
+  '.pascal': 'pascal',
+  '.diff': 'diff',
+  '.patch': 'diff',
+  '.dart': 'dart',
+  '.dockerfile': 'dockerfile',
+  '.ex': 'elixir',
+  '.exs': 'elixir',
+  '.erl': 'erlang',
+  '.ets': 'typescript',
+  '.hrl': 'erlang',
+  '.fs': 'fsharp',
+  '.fsi': 'fsharp',
+  '.fsx': 'fsharp',
+  '.fsscript': 'fsharp',
+  '.go': 'go',
+  '.groovy': 'groovy',
+  '.gleam': 'gleam',
+  '.hbs': 'handlebars',
+  '.handlebars': 'handlebars',
+  '.hs': 'haskell',
+  '.lhs': 'haskell',
+  '.html': 'html',
+  '.htm': 'html',
+  '.ini': 'ini',
+  '.java': 'java',
+  '.jl': 'julia',
+  '.js': 'javascript',
+  '.kt': 'kotlin',
+  '.kts': 'kotlin',
+  '.jsx': 'javascriptreact',
+  '.json': 'json',
+  '.tex': 'latex',
+  '.latex': 'latex',
+  '.less': 'less',
+  '.lua': 'lua',
+  '.md': 'markdown',
+  '.markdown': 'markdown',
+  '.m': 'objective-c',
+  '.mm': 'objective-cpp',
+  '.pl': 'perl',
+  '.pm': 'perl',
+  '.pm6': 'perl6',
+  '.php': 'php',
+  '.ps1': 'powershell',
+  '.psm1': 'powershell',
+  '.pug': 'jade',
+  '.jade': 'jade',
+  '.py': 'python',
+  '.r': 'r',
+  '.cshtml': 'razor',
+  '.razor': 'razor',
+  '.rb': 'ruby',
+  '.rake': 'ruby',
+  '.gemspec': 'ruby',
+  '.ru': 'ruby',
+  '.erb': 'erb',
+  '.rs': 'rust',
+  '.scss': 'scss',
+  '.sass': 'sass',
+  '.scala': 'scala',
+  '.sh': 'shellscript',
+  '.bash': 'shellscript',
+  '.zsh': 'shellscript',
+  '.ksh': 'shellscript',
+  '.sql': 'sql',
+  '.svelte': 'svelte',
+  '.swift': 'swift',
+  '.ts': 'typescript',
+  '.tsx': 'typescriptreact',
+  '.mts': 'typescript',
+  '.cts': 'typescript',
+  '.mtsx': 'typescriptreact',
+  '.ctsx': 'typescriptreact',
+  '.xml': 'xml',
+  '.xsl': 'xsl',
+  '.yaml': 'yaml',
+  '.yml': 'yaml',
+  '.mjs': 'javascript',
+  '.cjs': 'javascript',
+  '.vue': 'vue',
+  '.zig': 'zig',
+  '.zon': 'zig',
+  '.astro': 'astro',
+  '.ml': 'ocaml',
+  '.mli': 'ocaml',
+  '.tf': 'terraform',
+  '.tfvars': 'terraform-vars',
+  '.hcl': 'hcl',
+  '.nix': 'nix',
+  '.typ': 'typst',
+  '.typc': 'typst',
+} as const;
+
+/**
+ * Get LSP language ID from a file path's extension.
+ * Returns 'plaintext' if the extension is not recognized.
+ */
+export function getLanguageId(filePath: string): string {
+  const ext = filePath.substring(filePath.lastIndexOf('.')).toLowerCase();
+  return LANGUAGE_EXTENSIONS[ext] ?? 'plaintext';
+}
+
+/**
+ * Get the LSP server ID (language family) for a given language ID.
+ * Multiple language IDs map to the same server (e.g. typescript + typescriptreact → 'typescript').
+ */
+export function getServerIdForLanguage(languageId: string): string | undefined {
+  switch (languageId) {
+    case 'typescript':
+    case 'typescriptreact':
+    case 'javascript':
+    case 'javascriptreact':
+      return 'typescript';
+    case 'python':
+      return 'python';
+    case 'go':
+      return 'go';
+    case 'rust':
+      return 'rust';
+    case 'ruby':
+      return 'ruby';
+    default:
+      return undefined; // No LSP available for this language
+  }
+}

--- a/src/code/lsp/manager.ts
+++ b/src/code/lsp/manager.ts
@@ -1,0 +1,123 @@
+/**
+ * LspManager — manages language server lifecycle.
+ * Lazily starts servers on first use, shares one server per language.
+ */
+
+import path from 'path';
+import { getLanguageId, getServerIdForLanguage } from './language.js';
+import { spawnLspServer } from './server.js';
+import { createLspClient, type LspClientInfo, type Diagnostic, prettyDiagnostic } from './client.js';
+
+export type { Diagnostic };
+
+export class LspManager {
+  private clients = new Map<string, LspClientInfo>(); // serverId → client
+  private starting = new Map<string, Promise<LspClientInfo | null>>(); // prevent double-start
+  private enabled: boolean;
+  private root: string;
+
+  constructor(options: { root: string; enabled?: boolean }) {
+    this.root = options.root;
+    this.enabled = options.enabled ?? true;
+  }
+
+  /**
+   * Notify the LSP server about a file change (open/change).
+   * Starts the server lazily if needed.
+   * Waits for diagnostics to arrive (up to 3 seconds).
+   */
+  async touchFile(filePath: string): Promise<void> {
+    if (!this.enabled) return;
+
+    const absPath = path.isAbsolute(filePath) ? filePath : path.resolve(this.root, filePath);
+    const languageId = getLanguageId(absPath);
+    const serverId = getServerIdForLanguage(languageId);
+
+    if (!serverId) return; // No LSP for this language
+
+    const client = await this.getOrStartClient(serverId);
+    if (!client) return;
+
+    await client.notify.open(absPath);
+    await client.waitForDiagnostics(absPath);
+  }
+
+  /**
+   * Get merged diagnostics from all running clients.
+   * Returns an object mapping normalized file paths to diagnostic arrays.
+   */
+  getDiagnostics(): Record<string, Diagnostic[]> {
+    const result: Record<string, Diagnostic[]> = {};
+    for (const client of this.clients.values()) {
+      for (const [filePath, diags] of client.diagnostics) {
+        if (!result[filePath]) {
+          result[filePath] = [];
+        }
+        result[filePath].push(...diags);
+      }
+    }
+    return result;
+  }
+
+  /**
+   * Get formatted error diagnostics for a specific file.
+   * Returns empty string if no errors.
+   */
+  getErrorsForFile(filePath: string): string {
+    const absPath = path.isAbsolute(filePath) ? filePath : path.resolve(this.root, filePath);
+    const normalized = absPath.replace(/\\/g, '/');
+
+    const all = this.getDiagnostics();
+    const diags = all[normalized] ?? [];
+    const errors = diags.filter((d) => d.severity === 1 || d.severity === undefined);
+
+    if (errors.length === 0) return '';
+
+    const MAX = 20;
+    const limited = errors.slice(0, MAX);
+    const suffix = errors.length > MAX ? `\n  ... and ${errors.length - MAX} more` : '';
+    return limited.map((d) => prettyDiagnostic(d, absPath)).join('\n') + suffix;
+  }
+
+  /**
+   * Shut down all running language servers.
+   */
+  async shutdown(): Promise<void> {
+    const shutdowns = Array.from(this.clients.values()).map((c) =>
+      c.shutdown().catch(() => {}),
+    );
+    await Promise.all(shutdowns);
+    this.clients.clear();
+    this.starting.clear();
+  }
+
+  // ─── Private ──────────────────────────────────────────────────────────────
+
+  private async getOrStartClient(serverId: string): Promise<LspClientInfo | null> {
+    const existing = this.clients.get(serverId);
+    if (existing) return existing;
+
+    // Prevent concurrent starts for the same server
+    let starting = this.starting.get(serverId);
+    if (!starting) {
+      starting = this.startClient(serverId);
+      this.starting.set(serverId, starting);
+    }
+    const client = await starting;
+    this.starting.delete(serverId);
+    return client;
+  }
+
+  private async startClient(serverId: string): Promise<LspClientInfo | null> {
+    try {
+      const handle = spawnLspServer(serverId);
+      if (!handle) return null; // Server not installed
+
+      const client = await createLspClient({ serverId, handle, root: this.root });
+      this.clients.set(serverId, client);
+      return client;
+    } catch {
+      return null; // Failed to start — silently skip LSP for this language
+    }
+  }
+}

--- a/src/code/lsp/server.ts
+++ b/src/code/lsp/server.ts
@@ -1,0 +1,91 @@
+import { spawn, type ChildProcessWithoutNullStreams } from 'child_process';
+import { execSync } from 'child_process';
+
+export interface LspServerHandle {
+  process: ChildProcessWithoutNullStreams;
+  initialization?: Record<string, unknown>;
+}
+
+/**
+ * Find the path of an executable in PATH.
+ * Returns undefined if not found.
+ */
+function which(cmd: string): string | undefined {
+  try {
+    const result = execSync(`which ${cmd} 2>/dev/null`, { encoding: 'utf-8' }).trim();
+    return result || undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+/**
+ * Per-server configurations: how to detect and launch each language server.
+ */
+const SERVER_CONFIGS: Record<string, {
+  detect: () => string | undefined;
+  args: (binary: string) => string[];
+  initialization?: Record<string, unknown>;
+}> = {
+  typescript: {
+    detect: () => which('typescript-language-server'),
+    args: () => ['--stdio'],
+  },
+  python: {
+    detect: () => which('pylsp') ?? which('pyright-langserver') ?? which('pyls'),
+    args: (binary) => binary.endsWith('pyright-langserver') ? ['--stdio'] : [],
+  },
+  go: {
+    detect: () => which('gopls'),
+    args: () => ['serve'],
+  },
+  rust: {
+    detect: () => which('rust-analyzer'),
+    args: () => [],
+  },
+  ruby: {
+    detect: () => which('solargraph'),
+    args: () => ['stdio'],
+  },
+};
+
+/**
+ * Attempt to spawn a language server for the given server ID.
+ * Returns the handle if successful, undefined if the server is not installed.
+ */
+export function spawnLspServer(serverId: string): LspServerHandle | undefined {
+  const config = SERVER_CONFIGS[serverId];
+  if (!config) return undefined;
+
+  const binary = config.detect();
+  if (!binary) return undefined;
+
+  const args = config.args(binary);
+
+  try {
+    const proc = spawn(binary, args, {
+      stdio: ['pipe', 'pipe', 'pipe'],
+      env: { ...process.env },
+    });
+
+    // Swallow stderr to avoid polluting Jiva's output
+    proc.stderr.resume();
+
+    return {
+      process: proc as ChildProcessWithoutNullStreams,
+      initialization: config.initialization,
+    };
+  } catch {
+    return undefined;
+  }
+}
+
+/**
+ * Check which language servers are available on this system.
+ */
+export function getAvailableServers(): string[] {
+  return Object.keys(SERVER_CONFIGS).filter((id) => {
+    const config = SERVER_CONFIGS[id];
+    return config.detect() !== undefined;
+  });
+}

--- a/src/code/tools/bash.ts
+++ b/src/code/tools/bash.ts
@@ -1,0 +1,115 @@
+import { exec } from 'child_process';
+import type { ICodeTool, CodeToolContext } from './index.js';
+
+const DEFAULT_TIMEOUT = 30_000; // 30s
+const MAX_TIMEOUT = 300_000; // 5 min
+
+// Output limits — same as read_file to keep model context manageable
+const MAX_OUTPUT_LINES = 2000;
+const MAX_OUTPUT_BYTES = 50 * 1024; // 50KB
+
+export const BashTool: ICodeTool = {
+  name: 'bash',
+  description: `Execute a shell command in the workspace directory.
+
+REQUIRED parameter: "command" (string) — the shell command to run.
+Example: {"command": "git status"}
+Example: {"command": "npm test", "timeout_ms": 60000}
+
+Do NOT pass "path", "limit", "offset", or "query" to this tool — use read_file or grep for those.
+
+Use for:
+- Running build commands (npm run build, go build, cargo build)
+- Running tests (npm test, pytest, go test ./...)
+- Running linters (eslint, pylint, ruff)
+- Git operations (git status, git diff --staged)
+- Installing dependencies
+
+Returns: stdout + stderr combined, plus exit code.
+Commands timeout after ${DEFAULT_TIMEOUT / 1000}s by default (configurable up to ${MAX_TIMEOUT / 1000}s).
+Output is truncated at ${MAX_OUTPUT_LINES} lines / ${MAX_OUTPUT_BYTES / 1024}KB.`,
+
+  parameters: {
+    type: 'object',
+    properties: {
+      command: {
+        type: 'string',
+        description: 'Shell command to execute (e.g. "git diff --staged", "npm test")',
+      },
+      timeout_ms: {
+        type: 'number',
+        description: `Timeout in milliseconds (default: ${DEFAULT_TIMEOUT}, max: ${MAX_TIMEOUT})`,
+      },
+    },
+    required: ['command'],
+  },
+
+  async execute(args, ctx: CodeToolContext): Promise<string> {
+    const command = args.command as string;
+    const timeout = Math.min((args.timeout_ms as number) || DEFAULT_TIMEOUT, MAX_TIMEOUT);
+
+    return new Promise<string>((resolve) => {
+      const proc = exec(command, {
+        cwd: ctx.workspaceDir,
+        timeout,
+        maxBuffer: 10 * 1024 * 1024, // 10MB raw buffer; we truncate before returning
+        env: { ...process.env },
+      }, (error, stdout, stderr) => {
+        const output: string[] = [];
+
+        if (stdout.trim()) output.push(stdout.trim());
+        if (stderr.trim()) output.push(`[stderr]\n${stderr.trim()}`);
+
+        if (error) {
+          if (error.killed) {
+            output.push(`\n[Command timed out after ${timeout / 1000}s]`);
+          } else if (error.code !== undefined && error.code !== 0) {
+            output.push(`\n[Exit code: ${error.code}]`);
+          }
+        }
+
+        const raw = output.join('\n') || '(no output)';
+        resolve(truncateOutput(raw));
+      });
+
+      // Abort signal support
+      if (ctx.signal) {
+        ctx.signal.addEventListener('abort', () => {
+          try { proc.kill(); } catch { /* ignore */ }
+        }, { once: true });
+      }
+    });
+  },
+};
+
+/**
+ * Truncate command output to MAX_OUTPUT_LINES lines and MAX_OUTPUT_BYTES bytes.
+ * Mirrors the limits in read_file so the model context stays manageable.
+ * Truncation note is appended so the model knows output was cut.
+ */
+function truncateOutput(text: string): string {
+  // Byte limit first — apply to raw text
+  let result = text;
+  let bytesTruncated = false;
+  if (Buffer.byteLength(result, 'utf-8') > MAX_OUTPUT_BYTES) {
+    // Slice to byte limit, then back up to the last complete line
+    const buf = Buffer.from(result, 'utf-8').subarray(0, MAX_OUTPUT_BYTES);
+    result = buf.toString('utf-8');
+    // Trim to last newline to avoid split multibyte char
+    const lastNl = result.lastIndexOf('\n');
+    if (lastNl > 0) result = result.substring(0, lastNl);
+    bytesTruncated = true;
+  }
+
+  // Line limit
+  const lines = result.split('\n');
+  if (lines.length > MAX_OUTPUT_LINES) {
+    const kept = lines.slice(0, MAX_OUTPUT_LINES);
+    const dropped = lines.length - MAX_OUTPUT_LINES;
+    result = kept.join('\n') + `\n\n[Output truncated: ${dropped} more line(s) not shown. Narrow the command or redirect output to a file.]`;
+  } else if (bytesTruncated) {
+    result += `\n\n[Output truncated at ${MAX_OUTPUT_BYTES / 1024}KB. Redirect output to a file to capture everything.]`;
+  }
+
+  return result;
+}

--- a/src/code/tools/edit.ts
+++ b/src/code/tools/edit.ts
@@ -1,0 +1,462 @@
+/**
+ * Edit tool — multi-strategy text replacement with LSP diagnostics.
+ *
+ * The replacement strategies are ported from opencode (https://github.com/sst/opencode),
+ * which in turn sourced them from cline and gemini-cli.
+ */
+
+import path from 'path';
+import fs from 'fs';
+import { createTwoFilesPatch, diffLines } from 'diff';
+import { fileLock } from '../file-lock.js';
+import type { ICodeTool, CodeToolContext } from './index.js';
+
+const MAX_DIAGNOSTICS = 20;
+
+export const EditFileTool: ICodeTool = {
+  name: 'edit_file',
+  description: `Replace an exact string in a file with a new string.
+
+REQUIRED PARAMETERS — ALL THREE are mandatory, never omit any:
+  • file_path  — absolute path to the file to edit
+  • old_string — the EXACT text to find (must match the file exactly)
+  • new_string — the REPLACEMENT text (what replaces old_string)
+
+IMPORTANT: You MUST provide BOTH old_string AND new_string in every call.
+Omitting new_string will fail with a validation error. new_string is never optional —
+it is the text that replaces old_string in the file.
+
+Rules:
+- ALWAYS read the file with read_file before editing — never edit blindly.
+- old_string must exactly match the file content (whitespace, indentation, line endings).
+- Include enough surrounding context in old_string to make the match unique.
+- If old_string is empty (""), the file is created with new_string as its content.
+- The edit FAILS if old_string is not found in the file — check the content first.
+- Use replace_all: true to replace every occurrence of old_string at once.
+- Prefer small, targeted edits over rewriting large sections.
+- LSP errors (if any) are reported after the edit so you can fix them immediately.
+
+Returns a diff of the changes made, plus any LSP errors detected.`,
+
+  parameters: {
+    type: 'object',
+    properties: {
+      file_path: {
+        type: 'string',
+        description: 'Absolute path to the file to edit',
+      },
+      old_string: {
+        type: 'string',
+        description: 'The exact text to replace (empty string to create a new file)',
+      },
+      new_string: {
+        type: 'string',
+        description: 'The replacement text',
+      },
+      replace_all: {
+        type: 'boolean',
+        description: 'Replace all occurrences of old_string (default: false)',
+      },
+    },
+    required: ['file_path', 'old_string', 'new_string'],
+  },
+
+  async execute(args, ctx: CodeToolContext): Promise<string> {
+    const rawPath = args.file_path as string;
+    const filePath = path.isAbsolute(rawPath) ? rawPath : path.resolve(ctx.workspaceDir, rawPath);
+    const oldString = args.old_string as string;
+    const newString = args.new_string as string;
+    const replaceAll = (args.replace_all as boolean) ?? false;
+
+    if (oldString === newString) {
+      return 'Error: old_string and new_string are identical — no change made.';
+    }
+
+    return fileLock.withLock(filePath, async () => {
+      let contentBefore = '';
+      let contentAfter = '';
+
+      if (oldString === '') {
+        // Create / overwrite file
+        contentAfter = newString;
+        try {
+          const dir = path.dirname(filePath);
+          fs.mkdirSync(dir, { recursive: true });
+          fs.writeFileSync(filePath, newString, 'utf-8');
+        } catch (e) {
+          return `Error writing file: ${e instanceof Error ? e.message : String(e)}`;
+        }
+      } else {
+        // Read existing file
+        try {
+          contentBefore = fs.readFileSync(filePath, 'utf-8');
+        } catch {
+          return `Error: File not found: ${filePath}`;
+        }
+
+        // Normalize line endings for matching
+        const ending = detectLineEnding(contentBefore);
+        const normalizedOld = convertLineEnding(normalizeLineEndings(oldString), ending);
+        const normalizedNew = convertLineEnding(normalizeLineEndings(newString), ending);
+
+        let result: string;
+        try {
+          result = replace(contentBefore, normalizedOld, normalizedNew, replaceAll);
+        } catch (e) {
+          return `Error: ${e instanceof Error ? e.message : String(e)}`;
+        }
+
+        contentAfter = result;
+
+        try {
+          fs.writeFileSync(filePath, contentAfter, 'utf-8');
+        } catch (e) {
+          return `Error writing file: ${e instanceof Error ? e.message : String(e)}`;
+        }
+      }
+
+      // Build diff
+      const diff = trimDiff(
+        createTwoFilesPatch(
+          filePath,
+          filePath,
+          normalizeLineEndings(contentBefore),
+          normalizeLineEndings(contentAfter),
+        ),
+      );
+
+      // Count changes
+      let additions = 0;
+      let deletions = 0;
+      for (const change of diffLines(contentBefore, contentAfter)) {
+        if (change.added) additions += change.count ?? 0;
+        if (change.removed) deletions += change.count ?? 0;
+      }
+
+      // Notify LSP and collect diagnostics
+      let diagnosticsOutput = '';
+      try {
+        await ctx.lsp.touchFile(filePath);
+        const errors = ctx.lsp.getErrorsForFile(filePath);
+        if (errors) {
+          diagnosticsOutput = `\n\nLSP errors detected — please fix:\n<diagnostics file="${filePath}">\n${errors}\n</diagnostics>`;
+        }
+      } catch {
+        // LSP errors should not block the edit result
+      }
+
+      const relPath = path.relative(ctx.workspaceDir, filePath);
+      return `Edit applied to ${relPath} (+${additions}/-${deletions} lines).\n\n${diff}${diagnosticsOutput}`;
+    });
+  },
+};
+
+// ─── Replacement Strategies ───────────────────────────────────────────────────
+// Ported from opencode (sourced from cline/gemini-cli)
+
+type Replacer = (content: string, find: string) => Generator<string, void, unknown>;
+
+function levenshtein(a: string, b: string): number {
+  if (a === '' || b === '') return Math.max(a.length, b.length);
+  const matrix = Array.from({ length: a.length + 1 }, (_, i) =>
+    Array.from({ length: b.length + 1 }, (_, j) => (i === 0 ? j : j === 0 ? i : 0)),
+  );
+  for (let i = 1; i <= a.length; i++) {
+    for (let j = 1; j <= b.length; j++) {
+      const cost = a[i - 1] === b[j - 1] ? 0 : 1;
+      matrix[i][j] = Math.min(matrix[i - 1][j] + 1, matrix[i][j - 1] + 1, matrix[i - 1][j - 1] + cost);
+    }
+  }
+  return matrix[a.length][b.length];
+}
+
+const SimpleReplacer: Replacer = function* (_content, find) {
+  yield find;
+};
+
+const LineTrimmedReplacer: Replacer = function* (content, find) {
+  const originalLines = content.split('\n');
+  const searchLines = find.split('\n');
+  if (searchLines[searchLines.length - 1] === '') searchLines.pop();
+
+  for (let i = 0; i <= originalLines.length - searchLines.length; i++) {
+    let matches = true;
+    for (let j = 0; j < searchLines.length; j++) {
+      if (originalLines[i + j].trim() !== searchLines[j].trim()) { matches = false; break; }
+    }
+    if (matches) {
+      let start = 0;
+      for (let k = 0; k < i; k++) start += originalLines[k].length + 1;
+      let end = start;
+      for (let k = 0; k < searchLines.length; k++) {
+        end += originalLines[i + k].length;
+        if (k < searchLines.length - 1) end += 1;
+      }
+      yield content.substring(start, end);
+    }
+  }
+};
+
+const SINGLE_CANDIDATE_THRESHOLD = 0.0;
+const MULTIPLE_CANDIDATES_THRESHOLD = 0.3;
+
+const BlockAnchorReplacer: Replacer = function* (content, find) {
+  const originalLines = content.split('\n');
+  const searchLines = find.split('\n');
+  if (searchLines.length < 3) return;
+  if (searchLines[searchLines.length - 1] === '') searchLines.pop();
+
+  const firstLine = searchLines[0].trim();
+  const lastLine = searchLines[searchLines.length - 1].trim();
+
+  const candidates: Array<{ startLine: number; endLine: number }> = [];
+  for (let i = 0; i < originalLines.length; i++) {
+    if (originalLines[i].trim() !== firstLine) continue;
+    for (let j = i + 2; j < originalLines.length; j++) {
+      if (originalLines[j].trim() === lastLine) { candidates.push({ startLine: i, endLine: j }); break; }
+    }
+  }
+  if (candidates.length === 0) return;
+
+  const computeSimilarity = (startLine: number, endLine: number): number => {
+    const actualSize = endLine - startLine + 1;
+    const linesToCheck = Math.min(searchLines.length - 2, actualSize - 2);
+    if (linesToCheck <= 0) return 1.0;
+    let sim = 0;
+    for (let j = 1; j < searchLines.length - 1 && j < actualSize - 1; j++) {
+      const orig = originalLines[startLine + j].trim();
+      const srch = searchLines[j].trim();
+      const maxLen = Math.max(orig.length, srch.length);
+      if (maxLen === 0) continue;
+      sim += (1 - levenshtein(orig, srch) / maxLen) / linesToCheck;
+      if (sim >= SINGLE_CANDIDATE_THRESHOLD) break;
+    }
+    return sim;
+  };
+
+  const extractMatch = (startLine: number, endLine: number): string => {
+    let start = 0;
+    for (let k = 0; k < startLine; k++) start += originalLines[k].length + 1;
+    let end = start;
+    for (let k = startLine; k <= endLine; k++) {
+      end += originalLines[k].length;
+      if (k < endLine) end += 1;
+    }
+    return content.substring(start, end);
+  };
+
+  if (candidates.length === 1) {
+    const { startLine, endLine } = candidates[0];
+    if (computeSimilarity(startLine, endLine) >= SINGLE_CANDIDATE_THRESHOLD) {
+      yield extractMatch(startLine, endLine);
+    }
+    return;
+  }
+
+  let best: { startLine: number; endLine: number } | null = null;
+  let maxSim = -1;
+  for (const { startLine, endLine } of candidates) {
+    const sim = computeSimilarity(startLine, endLine);
+    if (sim > maxSim) { maxSim = sim; best = { startLine, endLine }; }
+  }
+  if (maxSim >= MULTIPLE_CANDIDATES_THRESHOLD && best) {
+    yield extractMatch(best.startLine, best.endLine);
+  }
+};
+
+const WhitespaceNormalizedReplacer: Replacer = function* (content, find) {
+  const norm = (t: string) => t.replace(/\s+/g, ' ').trim();
+  const normalizedFind = norm(find);
+  const lines = content.split('\n');
+
+  for (const line of lines) {
+    if (norm(line) === normalizedFind) { yield line; continue; }
+    const normLine = norm(line);
+    if (normLine.includes(normalizedFind)) {
+      const words = find.trim().split(/\s+/);
+      if (words.length > 0) {
+        const pattern = words.map((w) => w.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')).join('\\s+');
+        try {
+          const m = line.match(new RegExp(pattern));
+          if (m) yield m[0];
+        } catch { /* invalid regex */ }
+      }
+    }
+  }
+
+  const findLines = find.split('\n');
+  if (findLines.length > 1) {
+    for (let i = 0; i <= lines.length - findLines.length; i++) {
+      const block = lines.slice(i, i + findLines.length);
+      if (norm(block.join('\n')) === normalizedFind) yield block.join('\n');
+    }
+  }
+};
+
+const IndentationFlexibleReplacer: Replacer = function* (content, find) {
+  const removeIndent = (text: string) => {
+    const lines = text.split('\n');
+    const nonEmpty = lines.filter((l) => l.trim().length > 0);
+    if (nonEmpty.length === 0) return text;
+    const min = Math.min(...nonEmpty.map((l) => { const m = l.match(/^(\s*)/); return m ? m[1].length : 0; }));
+    return lines.map((l) => (l.trim().length === 0 ? l : l.slice(min))).join('\n');
+  };
+  const normalizedFind = removeIndent(find);
+  const contentLines = content.split('\n');
+  const findLines = find.split('\n');
+  for (let i = 0; i <= contentLines.length - findLines.length; i++) {
+    const block = contentLines.slice(i, i + findLines.length).join('\n');
+    if (removeIndent(block) === normalizedFind) yield block;
+  }
+};
+
+const EscapeNormalizedReplacer: Replacer = function* (content, find) {
+  const unescape = (s: string) =>
+    s.replace(/\\(n|t|r|'|"|`|\\|\n|\$)/g, (_, c) => {
+      switch (c) {
+        case 'n': return '\n';
+        case 't': return '\t';
+        case 'r': return '\r';
+        case '\\': return '\\';
+        case '\n': return '\n';
+        default: return c;
+      }
+    });
+  const unescapedFind = unescape(find);
+  if (content.includes(unescapedFind)) { yield unescapedFind; return; }
+  const lines = content.split('\n');
+  const findLines = unescapedFind.split('\n');
+  for (let i = 0; i <= lines.length - findLines.length; i++) {
+    const block = lines.slice(i, i + findLines.length).join('\n');
+    if (unescape(block) === unescapedFind) yield block;
+  }
+};
+
+const TrimmedBoundaryReplacer: Replacer = function* (content, find) {
+  const trimmedFind = find.trim();
+  if (trimmedFind === find) return;
+  if (content.includes(trimmedFind)) { yield trimmedFind; return; }
+  const lines = content.split('\n');
+  const findLines = find.split('\n');
+  for (let i = 0; i <= lines.length - findLines.length; i++) {
+    const block = lines.slice(i, i + findLines.length).join('\n');
+    if (block.trim() === trimmedFind) yield block;
+  }
+};
+
+const ContextAwareReplacer: Replacer = function* (content, find) {
+  const findLines = find.split('\n');
+  if (findLines.length < 3) return;
+  if (findLines[findLines.length - 1] === '') findLines.pop();
+  const contentLines = content.split('\n');
+  const firstLine = findLines[0].trim();
+  const lastLine = findLines[findLines.length - 1].trim();
+
+  for (let i = 0; i < contentLines.length; i++) {
+    if (contentLines[i].trim() !== firstLine) continue;
+    for (let j = i + 2; j < contentLines.length; j++) {
+      if (contentLines[j].trim() !== lastLine) continue;
+      const blockLines = contentLines.slice(i, j + 1);
+      if (blockLines.length !== findLines.length) break;
+      let matching = 0;
+      let total = 0;
+      for (let k = 1; k < blockLines.length - 1; k++) {
+        const b = blockLines[k].trim();
+        const f = findLines[k].trim();
+        if (b.length > 0 || f.length > 0) { total++; if (b === f) matching++; }
+      }
+      if (total === 0 || matching / total >= 0.5) {
+        yield blockLines.join('\n');
+        break;
+      }
+      break;
+    }
+  }
+};
+
+const MultiOccurrenceReplacer: Replacer = function* (content, find) {
+  let start = 0;
+  while (true) {
+    const idx = content.indexOf(find, start);
+    if (idx === -1) break;
+    yield find;
+    start = idx + find.length;
+  }
+};
+
+/** Apply the first matching replacement strategy. */
+export function replace(content: string, oldString: string, newString: string, replaceAll = false): string {
+  if (oldString === newString) throw new Error('No changes: old_string and new_string are identical.');
+
+  let notFound = true;
+
+  for (const replacer of [
+    SimpleReplacer,
+    LineTrimmedReplacer,
+    BlockAnchorReplacer,
+    WhitespaceNormalizedReplacer,
+    IndentationFlexibleReplacer,
+    EscapeNormalizedReplacer,
+    TrimmedBoundaryReplacer,
+    ContextAwareReplacer,
+    MultiOccurrenceReplacer,
+  ]) {
+    for (const search of replacer(content, oldString)) {
+      const idx = content.indexOf(search);
+      if (idx === -1) continue;
+      notFound = false;
+      if (replaceAll) return content.replaceAll(search, newString);
+      const lastIdx = content.lastIndexOf(search);
+      if (idx !== lastIdx) continue; // ambiguous match
+      return content.substring(0, idx) + newString + content.substring(idx + search.length);
+    }
+  }
+
+  if (notFound) {
+    throw new Error(
+      'Could not find old_string in the file. It must match exactly (whitespace, indentation, line endings).',
+    );
+  }
+  throw new Error('Found multiple matches for old_string. Provide more surrounding context to make it unique.');
+}
+
+// ─── Utilities ────────────────────────────────────────────────────────────────
+
+function normalizeLineEndings(text: string): string {
+  return text.replaceAll('\r\n', '\n');
+}
+
+function detectLineEnding(text: string): '\n' | '\r\n' {
+  return text.includes('\r\n') ? '\r\n' : '\n';
+}
+
+function convertLineEnding(text: string, ending: '\n' | '\r\n'): string {
+  return ending === '\n' ? text : text.replaceAll('\n', '\r\n');
+}
+
+function trimDiff(diff: string): string {
+  const lines = diff.split('\n');
+  const contentLines = lines.filter(
+    (l) => (l.startsWith('+') || l.startsWith('-') || l.startsWith(' ')) &&
+      !l.startsWith('---') && !l.startsWith('+++'),
+  );
+  if (contentLines.length === 0) return diff;
+
+  let min = Infinity;
+  for (const line of contentLines) {
+    const content = line.slice(1);
+    if (content.trim().length > 0) {
+      const m = content.match(/^(\s*)/);
+      if (m) min = Math.min(min, m[1].length);
+    }
+  }
+  if (min === Infinity || min === 0) return diff;
+
+  return lines.map((line) => {
+    if ((line.startsWith('+') || line.startsWith('-') || line.startsWith(' ')) &&
+        !line.startsWith('---') && !line.startsWith('+++')) {
+      return line[0] + line.slice(1 + min);
+    }
+    return line;
+  }).join('\n');
+}

--- a/src/code/tools/glob.ts
+++ b/src/code/tools/glob.ts
@@ -1,0 +1,67 @@
+import path from 'path';
+import fs from 'fs';
+import type { ICodeTool, CodeToolContext } from './index.js';
+
+export const GlobTool: ICodeTool = {
+  name: 'glob',
+  description: `Find files matching a glob pattern.
+
+Examples:
+- "**/*.ts" — all TypeScript files
+- "src/**/*.test.ts" — all test files under src/
+- "*.json" — JSON files in the workspace root
+
+Returns file paths relative to the workspace directory, sorted by modification time (newest first).`,
+
+  parameters: {
+    type: 'object',
+    properties: {
+      pattern: {
+        type: 'string',
+        description: 'Glob pattern to match (e.g. "**/*.ts", "src/**/*.js")',
+      },
+      cwd: {
+        type: 'string',
+        description: 'Directory to search in (default: workspace root)',
+      },
+    },
+    required: ['pattern'],
+  },
+
+  async execute(args, ctx: CodeToolContext): Promise<string> {
+    const pattern = args.pattern as string;
+    const cwd = args.cwd
+      ? (path.isAbsolute(args.cwd as string) ? args.cwd as string : path.resolve(ctx.workspaceDir, args.cwd as string))
+      : ctx.workspaceDir;
+
+    try {
+      // Use Node.js built-in glob (available in Node 22+) or fall back to manual walk
+      const { glob } = await import('glob');
+      const matches = await glob(pattern, {
+        cwd,
+        nodir: false,
+        ignore: ['**/node_modules/**', '**/.git/**', '**/dist/**', '**/.next/**'],
+      });
+
+      if (matches.length === 0) {
+        return `No files found matching pattern: ${pattern}`;
+      }
+
+      // Sort by mtime (newest first)
+      const withMtime = matches
+        .map((f) => {
+          try {
+            const stat = fs.statSync(path.join(cwd, f));
+            return { file: f, mtime: stat.mtimeMs };
+          } catch {
+            return { file: f, mtime: 0 };
+          }
+        })
+        .sort((a, b) => b.mtime - a.mtime);
+
+      return withMtime.map((f) => f.file).join('\n');
+    } catch (e) {
+      return `Error: ${e instanceof Error ? e.message : String(e)}`;
+    }
+  },
+};

--- a/src/code/tools/grep.ts
+++ b/src/code/tools/grep.ts
@@ -1,0 +1,150 @@
+import path from 'path';
+import fs from 'fs';
+import type { ICodeTool, CodeToolContext } from './index.js';
+
+const MAX_MATCHES = 100;
+const MAX_FILE_SIZE = 1 * 1024 * 1024; // 1MB per file
+
+const IGNORE_DIRS = new Set([
+  'node_modules', '.git', 'dist', '.next', 'build', '.cache',
+  '__pycache__', '.mypy_cache', 'target', 'vendor',
+]);
+
+export const GrepTool: ICodeTool = {
+  name: 'grep',
+  description: `Search for a regex pattern across files in the workspace.
+
+REQUIRED parameter: "pattern" (string) — the regex to search for.
+Example: {"pattern": "class UserService"}
+Example: {"pattern": "TODO|FIXME", "include": "*.ts"}
+
+Returns matches in the format: file:line: content`,
+
+  parameters: {
+    type: 'object',
+    properties: {
+      pattern: {
+        type: 'string',
+        description: 'Regular expression pattern to search for',
+      },
+      path: {
+        type: 'string',
+        description: 'File or directory to search in (default: workspace root)',
+      },
+      include: {
+        type: 'string',
+        description: 'Glob pattern to filter files (e.g. "*.ts", "*.py")',
+      },
+      case_insensitive: {
+        type: 'boolean',
+        description: 'Case-insensitive search (default: false)',
+      },
+    },
+    required: ['pattern'],
+  },
+
+  async execute(args, ctx: CodeToolContext): Promise<string> {
+    const patternStr = args.pattern as string;
+    const searchPath = args.path
+      ? (path.isAbsolute(args.path as string) ? args.path as string : path.resolve(ctx.workspaceDir, args.path as string))
+      : ctx.workspaceDir;
+    const includePattern = args.include as string | undefined;
+    const caseInsensitive = (args.case_insensitive as boolean) ?? false;
+
+    let regex: RegExp;
+    try {
+      regex = new RegExp(patternStr, caseInsensitive ? 'i' : '');
+    } catch (e) {
+      return `Error: Invalid regex pattern: ${e instanceof Error ? e.message : String(e)}`;
+    }
+
+    const results: string[] = [];
+    let truncated = false;
+
+    try {
+      const stat = fs.statSync(searchPath);
+      if (stat.isFile()) {
+        searchFile(searchPath, regex, ctx.workspaceDir, results, { max: MAX_MATCHES });
+      } else {
+        searchDir(searchPath, regex, ctx.workspaceDir, results, includePattern, {
+          max: MAX_MATCHES,
+          truncated: () => { truncated = true; },
+        });
+      }
+    } catch (e) {
+      return `Error: ${e instanceof Error ? e.message : String(e)}`;
+    }
+
+    if (results.length === 0) {
+      return `No matches found for: ${patternStr}`;
+    }
+
+    let output = results.join('\n');
+    if (truncated) {
+      output += `\n\n[Results truncated at ${MAX_MATCHES} matches. Narrow the search path or pattern.]`;
+    }
+    return output;
+  },
+};
+
+function matchesInclude(filename: string, include?: string): boolean {
+  if (!include) return true;
+  // Simple glob matching: support *.ext patterns
+  if (include.startsWith('*.')) {
+    const ext = include.slice(1);
+    return filename.endsWith(ext);
+  }
+  return filename.includes(include);
+}
+
+function searchFile(
+  filePath: string,
+  regex: RegExp,
+  workspaceDir: string,
+  results: string[],
+  opts: { max: number },
+): void {
+  if (results.length >= opts.max) return;
+
+  let stat: fs.Stats;
+  try { stat = fs.statSync(filePath); } catch { return; }
+  if (stat.size > MAX_FILE_SIZE) return;
+
+  let content: string;
+  try { content = fs.readFileSync(filePath, 'utf-8'); } catch { return; }
+
+  const relPath = path.relative(workspaceDir, filePath);
+  const lines = content.split('\n');
+
+  for (let i = 0; i < lines.length && results.length < opts.max; i++) {
+    if (regex.test(lines[i])) {
+      results.push(`${relPath}:${i + 1}: ${lines[i].trim()}`);
+    }
+  }
+}
+
+function searchDir(
+  dirPath: string,
+  regex: RegExp,
+  workspaceDir: string,
+  results: string[],
+  include: string | undefined,
+  opts: { max: number; truncated: () => void },
+): void {
+  if (results.length >= opts.max) { opts.truncated(); return; }
+
+  let entries: fs.Dirent[];
+  try { entries = fs.readdirSync(dirPath, { withFileTypes: true }); } catch { return; }
+
+  for (const entry of entries) {
+    if (results.length >= opts.max) { opts.truncated(); return; }
+
+    if (entry.isDirectory()) {
+      if (IGNORE_DIRS.has(entry.name) || entry.name.startsWith('.')) continue;
+      searchDir(path.join(dirPath, entry.name), regex, workspaceDir, results, include, opts);
+    } else if (entry.isFile()) {
+      if (!matchesInclude(entry.name, include)) continue;
+      searchFile(path.join(dirPath, entry.name), regex, workspaceDir, results, opts);
+    }
+  }
+}

--- a/src/code/tools/index.ts
+++ b/src/code/tools/index.ts
@@ -1,0 +1,34 @@
+import type { LspManager } from '../lsp/manager.js';
+
+export interface CodeToolContext {
+  workspaceDir: string;
+  lsp: LspManager;
+  signal?: AbortSignal;
+  /** Current agent depth — used by spawn tool to limit recursion */
+  depth?: number;
+  /** Max allowed depth */
+  maxDepth?: number;
+  /** Callback to spawn a child CodeAgent (injected by CodeAgent) */
+  spawnChildAgent?: (task: string, context?: string) => Promise<string>;
+}
+
+export interface ICodeTool {
+  name: string;
+  description: string;
+  /** JSON Schema object for tool parameters */
+  parameters: {
+    type: 'object';
+    properties: Record<string, unknown>;
+    required?: string[];
+  };
+  execute(args: Record<string, unknown>, ctx: CodeToolContext): Promise<string>;
+}
+
+// Re-export all tools
+export { ReadFileTool } from './read.js';
+export { EditFileTool } from './edit.js';
+export { WriteFileTool } from './write.js';
+export { GlobTool } from './glob.js';
+export { GrepTool } from './grep.js';
+export { BashTool } from './bash.js';
+export { SpawnCodeAgentTool } from './spawn.js';

--- a/src/code/tools/read.ts
+++ b/src/code/tools/read.ts
@@ -1,0 +1,134 @@
+import path from 'path';
+import fs from 'fs';
+import type { ICodeTool, CodeToolContext } from './index.js';
+
+const MAX_LINES = 2000;
+const MAX_BYTES = 50 * 1024; // 50KB
+
+export const ReadFileTool: ICodeTool = {
+  name: 'read_file',
+  description: `Read the contents of a file or list a directory.
+
+REQUIRED parameter: "path" (string) — absolute path to file or directory.
+Example: {"path": "/workspace/src/index.ts"}
+Example: {"path": "/workspace/src/index.ts", "offset": 100, "limit": 50}
+
+Do NOT pass "command", "query", or "pattern" to this tool — use bash or grep for those.
+
+For files:
+- Returns file content with line numbers (cat -n style)
+- Limits to ${MAX_LINES} lines and ${MAX_BYTES / 1024}KB
+- Use offset and limit to paginate large files
+- Binary files return "[binary file, cannot display]"
+
+For directories:
+- Returns a listing with [FILE] and [DIR] prefixes`,
+
+  parameters: {
+    type: 'object',
+    properties: {
+      path: {
+        type: 'string',
+        description: 'Absolute path to the file or directory to read',
+      },
+      offset: {
+        type: 'number',
+        description: 'Line number to start reading from (1-indexed, default: 1)',
+      },
+      limit: {
+        type: 'number',
+        description: `Max lines to read (default: ${MAX_LINES})`,
+      },
+    },
+    required: ['path'],
+  },
+
+  async execute(args, ctx: CodeToolContext): Promise<string> {
+    const rawPath = args.path as string;
+    const filePath = path.isAbsolute(rawPath) ? rawPath : path.resolve(ctx.workspaceDir, rawPath);
+
+    let stat: fs.Stats;
+    try {
+      stat = fs.statSync(filePath);
+    } catch {
+      return `Error: Path not found: ${filePath}`;
+    }
+
+    if (stat.isDirectory()) {
+      return listDirectory(filePath);
+    }
+
+    return readFile(filePath, args.offset as number | undefined, args.limit as number | undefined);
+  },
+};
+
+function listDirectory(dirPath: string): string {
+  let entries: fs.Dirent[];
+  try {
+    entries = fs.readdirSync(dirPath, { withFileTypes: true });
+  } catch (e) {
+    return `Error reading directory: ${e instanceof Error ? e.message : String(e)}`;
+  }
+
+  const lines: string[] = [`Directory: ${dirPath}`, ''];
+  entries.sort((a, b) => {
+    // Dirs first, then files, alphabetically
+    if (a.isDirectory() !== b.isDirectory()) return a.isDirectory() ? -1 : 1;
+    return a.name.localeCompare(b.name);
+  });
+
+  for (const entry of entries) {
+    const tag = entry.isDirectory() ? '[DIR] ' : '[FILE]';
+    lines.push(`${tag} ${entry.name}`);
+  }
+  return lines.join('\n');
+}
+
+function readFile(filePath: string, offset?: number, limit?: number): string {
+  let buffer: Buffer;
+  try {
+    buffer = fs.readFileSync(filePath);
+  } catch (e) {
+    return `Error reading file: ${e instanceof Error ? e.message : String(e)}`;
+  }
+
+  // Binary detection: look for null bytes in the first 8KB
+  if (isBinary(buffer)) {
+    return `[binary file: ${filePath}]`;
+  }
+
+  // Enforce byte limit
+  let text = buffer.slice(0, MAX_BYTES).toString('utf-8');
+  const wasTruncatedByBytes = buffer.length > MAX_BYTES;
+
+  const allLines = text.split('\n');
+  const startLine = Math.max(1, (offset ?? 1));
+  const maxLines = Math.min(limit ?? MAX_LINES, MAX_LINES);
+  const slice = allLines.slice(startLine - 1, startLine - 1 + maxLines);
+
+  const truncatedByLines = startLine - 1 + maxLines < allLines.length;
+
+  const numbered = slice.map((line, i) => {
+    const lineNo = String(startLine + i).padStart(6);
+    return `${lineNo}\t${line}`;
+  });
+
+  let result = numbered.join('\n');
+
+  if (wasTruncatedByBytes) {
+    result += `\n\n[File truncated at ${MAX_BYTES / 1024}KB. Use offset/limit to read more.]`;
+  } else if (truncatedByLines) {
+    const remaining = allLines.length - (startLine - 1 + maxLines);
+    result += `\n\n[${remaining} more line(s). Use offset=${startLine + maxLines} to continue.]`;
+  }
+
+  return result;
+}
+
+function isBinary(buffer: Buffer): boolean {
+  const checkLength = Math.min(8192, buffer.length);
+  for (let i = 0; i < checkLength; i++) {
+    if (buffer[i] === 0) return true;
+  }
+  return false;
+}

--- a/src/code/tools/spawn.ts
+++ b/src/code/tools/spawn.ts
@@ -1,0 +1,55 @@
+import type { ICodeTool, CodeToolContext } from './index.js';
+
+export const SpawnCodeAgentTool: ICodeTool = {
+  name: 'spawn_code_agent',
+  description: `Spawn a child code agent to handle a focused sub-task.
+
+Use when you need to delegate a specific, well-scoped coding task to a focused sub-agent.
+The child agent has access to the same tools (read, edit, write, glob, grep, bash).
+
+Examples:
+- "Write unit tests for the authentication module in src/auth/"
+- "Refactor the UserService class to use dependency injection"
+- "Fix all TypeScript errors in the src/models/ directory"
+
+The child agent completes its task and returns a summary of what it did.
+Depth is limited to prevent infinite nesting.`,
+
+  parameters: {
+    type: 'object',
+    properties: {
+      task: {
+        type: 'string',
+        description: 'The specific coding task for the child agent to complete',
+      },
+      context: {
+        type: 'string',
+        description: 'Additional context or constraints for the child agent',
+      },
+    },
+    required: ['task'],
+  },
+
+  async execute(args, ctx: CodeToolContext): Promise<string> {
+    const task = args.task as string;
+    const context = args.context as string | undefined;
+
+    if (!ctx.spawnChildAgent) {
+      return 'Error: Sub-agent spawning is not available in this context.';
+    }
+
+    const currentDepth = ctx.depth ?? 0;
+    const maxDepth = ctx.maxDepth ?? 2;
+
+    if (currentDepth >= maxDepth) {
+      return `Error: Maximum agent depth (${maxDepth}) reached. Cannot spawn further sub-agents.`;
+    }
+
+    try {
+      const result = await ctx.spawnChildAgent(task, context);
+      return `Sub-agent completed task.\n\nResult:\n${result}`;
+    } catch (e) {
+      return `Sub-agent failed: ${e instanceof Error ? e.message : String(e)}`;
+    }
+  },
+};

--- a/src/code/tools/write.ts
+++ b/src/code/tools/write.ts
@@ -1,0 +1,86 @@
+import path from 'path';
+import fs from 'fs';
+import { createTwoFilesPatch, diffLines } from 'diff';
+import { fileLock } from '../file-lock.js';
+import type { ICodeTool, CodeToolContext } from './index.js';
+
+export const WriteFileTool: ICodeTool = {
+  name: 'write_file',
+  description: `Create a new file or completely overwrite an existing file with new content.
+
+Use this when:
+- Creating a new file from scratch
+- Rewriting an entire file
+
+Prefer edit_file for partial edits. write_file is for when you need to replace the whole file.
+
+Returns a summary of changes and LSP diagnostics (if any errors).`,
+
+  parameters: {
+    type: 'object',
+    properties: {
+      file_path: {
+        type: 'string',
+        description: 'Absolute path to the file to write',
+      },
+      content: {
+        type: 'string',
+        description: 'The full content to write to the file',
+      },
+    },
+    required: ['file_path', 'content'],
+  },
+
+  async execute(args, ctx: CodeToolContext): Promise<string> {
+    const rawPath = args.file_path as string;
+    const filePath = path.isAbsolute(rawPath) ? rawPath : path.resolve(ctx.workspaceDir, rawPath);
+    const content = args.content as string;
+
+    return fileLock.withLock(filePath, async () => {
+      // Read existing content for diff
+      let before = '';
+      const existed = fs.existsSync(filePath);
+      if (existed) {
+        try {
+          before = fs.readFileSync(filePath, 'utf-8');
+        } catch {
+          before = '';
+        }
+      }
+
+      // Write the file
+      try {
+        const dir = path.dirname(filePath);
+        fs.mkdirSync(dir, { recursive: true });
+        fs.writeFileSync(filePath, content, 'utf-8');
+      } catch (e) {
+        return `Error writing file: ${e instanceof Error ? e.message : String(e)}`;
+      }
+
+      // Count changes
+      let additions = 0;
+      let deletions = 0;
+      for (const change of diffLines(before, content)) {
+        if (change.added) additions += change.count ?? 0;
+        if (change.removed) deletions += change.count ?? 0;
+      }
+
+      const relPath = path.relative(ctx.workspaceDir, filePath);
+      const action = existed ? 'Updated' : 'Created';
+
+      // LSP diagnostics
+      let diagnosticsOutput = '';
+      try {
+        await ctx.lsp.touchFile(filePath);
+        const errors = ctx.lsp.getErrorsForFile(filePath);
+        if (errors) {
+          diagnosticsOutput = `\n\nLSP errors detected — please fix:\n<diagnostics file="${filePath}">\n${errors}\n</diagnostics>`;
+        }
+      } catch {
+        // LSP should not block the write result
+      }
+
+      return `${action} ${relPath} (+${additions}/-${deletions} lines).${diagnosticsOutput}`;
+    });
+  },
+};

--- a/src/core/agent-interface.ts
+++ b/src/core/agent-interface.ts
@@ -1,0 +1,46 @@
+/**
+ * IAgent - Shared interface implemented by both DualAgent and CodeAgent.
+ *
+ * Placing this in src/core/ allows both the CLI and HTTP layers to import
+ * it without creating circular dependencies.
+ */
+
+import type { WorkspaceManager } from './workspace.js';
+import type { ConversationManager } from './conversation-manager.js';
+import type { Message } from '../models/base.js';
+
+export interface AgentChatResponse {
+  content: string;
+  toolsUsed: string[];
+  iterations: number;
+  /**
+   * Present only in DualAgent responses (contains the plan produced by the manager).
+   * Absent in CodeAgent responses.
+   */
+  plan?: {
+    subtasks: string[];
+    reasoning: string;
+  };
+}
+
+export interface IAgent {
+  chat(message: string): Promise<AgentChatResponse>;
+  cleanup(): Promise<void>;
+  getWorkspace(): WorkspaceManager;
+  getMCPManager(): {
+    getServerStatus(): Array<{ name: string; connected: boolean; enabled: boolean; toolCount: number }>;
+    getClient(): { getAllTools(): Array<{ name: string; description: string }> };
+  };
+  resetConversation(): void;
+  getConversationHistory(): Message[];
+  getConversationManager(): ConversationManager | null | undefined;
+  saveConversation(): Promise<string | null>;
+  loadConversation(id: string): Promise<void>;
+  listConversations(): Promise<Array<{
+    id: string;
+    title?: string;
+    updated: string | number;
+    messageCount: number;
+    workspace?: string;
+  }>>;
+}

--- a/src/core/config.ts
+++ b/src/core/config.ts
@@ -30,6 +30,15 @@ const ModelConfigSchema = z.object({
   useHarmonyFormat: z.boolean().optional(),
 });
 
+const CodeModeConfigSchema = z.object({
+  enabled: z.boolean().default(false),
+  lsp: z.object({
+    enabled: z.boolean().default(true),
+  }).optional(),
+  maxIterations: z.number().default(50),
+  includeMcp: z.boolean().default(false),
+});
+
 const JivaConfigSchema = z.object({
   models: z.object({
     reasoning: ModelConfigSchema.optional(),
@@ -42,10 +51,12 @@ const JivaConfigSchema = z.object({
   }).optional(),
   activePersona: z.string().optional(),
   debug: z.boolean().default(false),
+  codeMode: CodeModeConfigSchema.optional(),
 });
 
 export type MCPServerConfig = z.infer<typeof MCPServerConfigSchema>;
 export type ModelConfig = z.infer<typeof ModelConfigSchema>;
+export type CodeModeConfig = z.infer<typeof CodeModeConfigSchema>;
 export type JivaConfig = z.infer<typeof JivaConfigSchema>;
 
 export class ConfigManager {
@@ -144,6 +155,15 @@ export class ConfigManager {
 
   getActivePersona(): string | undefined {
     return this.store.get('activePersona');
+  }
+
+  getCodeMode(): CodeModeConfig | undefined {
+    return this.store.get('codeMode');
+  }
+
+  setCodeModeEnabled(enabled: boolean) {
+    const current = this.store.get('codeMode') || {};
+    this.store.set('codeMode', { ...current, enabled });
   }
 
   reset() {

--- a/src/core/conversation-manager.ts
+++ b/src/core/conversation-manager.ts
@@ -164,9 +164,12 @@ export class ConversationManager {
   }
 
   /**
-   * Condense conversation history using the model
+   * Condense conversation history using the model.
    *
    * This reduces token usage while preserving important context.
+   * Uses a structured opencode-style template (Goal / Instructions / Discoveries /
+   * Accomplished / Relevant files) that makes the summary actionable for the next agent turn.
+   *
    * Strategy: Keep system/developer messages (WITHOUT directive - agent will add fresh directive),
    * condense middle messages, keep recent messages.
    *
@@ -201,37 +204,64 @@ export class ConversationManager {
     }
 
     try {
-      // Create a summary of the middle section
+      // Create a summary of the middle section using opencode's structured template
       const conversationText = middleMessages
         .map(msg => {
-          const role = msg.role === 'assistant' ? 'Assistant' : 'User';
-          return `${role}: ${msg.content}`;
+          if (msg.role === 'tool') {
+            const content = typeof msg.content === 'string' ? msg.content : JSON.stringify(msg.content);
+            return `[Tool result]: ${content.substring(0, 300)}${content.length > 300 ? '...' : ''}`;
+          }
+          const role = msg.role === 'assistant' ? 'Assistant' : msg.role === 'user' ? 'User' : msg.role;
+          const content = typeof msg.content === 'string' ? msg.content : JSON.stringify(msg.content);
+          return `${role}: ${content}`;
         })
         .join('\n\n');
 
-      const summaryPrompt = `Please provide a concise summary of this conversation that preserves:
-1. Key decisions and actions taken
-2. Important information discovered
-3. Tools used and their results
-4. Any unresolved issues or pending tasks
+      // Structured compaction prompt (ported from opencode's compaction.ts)
+      const summaryPrompt = `Provide a detailed summary for continuing our conversation. The summary will be used so another agent can read it and continue the work.
 
-Keep the summary focused and under 500 words.
+When constructing the summary, follow this template:
 
-Conversation to summarize:
-${conversationText}`;
+## Goal
+
+[What goal(s) is the user trying to accomplish?]
+
+## Instructions
+
+- [What important instructions did the user give that are still relevant]
+- [If there is a plan or spec, include information about it so the next agent can continue using it]
+
+## Discoveries
+
+[What notable things were learned during this conversation that would be useful for the next agent to know when continuing the work]
+
+## Accomplished
+
+[What work has been completed, what work is still in progress, and what work is left?]
+
+## Relevant files / directories
+
+[Construct a structured list of relevant files that have been read, edited, or created that pertain to the task at hand. If all the files in a directory are relevant, include the path to the directory.]
+
+---
+
+Conversation to summarise:
+${conversationText}
+
+Keep the summary focused and complete — include file paths, function names, and specific changes made.`;
 
       const response = await orchestrator.chat({
         messages: [
           { role: 'user', content: summaryPrompt }
         ],
-        temperature: 0.1, // Low temperature for deterministic summarization
-        maxTokens: 1000,
+        temperature: 0.1, // Low temperature for deterministic summarisation
+        maxTokens: 1500,
       });
 
-      // Create condensed message
+      // Create condensed message (role: 'user' so it's valid in all API formats)
       const condensedMessage: Message = {
-        role: 'system',
-        content: `[Previous conversation summary]\n\n${response.content}\n\n[Continuing conversation...]`,
+        role: 'user',
+        content: `[Context compacted — previous conversation history summarised]\n\n${response.content}\n\n[Continuing conversation...]`,
       };
 
       // Return: system + developer + condensed summary + recent messages

--- a/src/core/dual-agent.ts
+++ b/src/core/dual-agent.ts
@@ -1,10 +1,9 @@
 /**
- * Dual Agent System - Coordinates Manager, Worker, and Client agents
+ * Dual Agent System - Coordinates Manager and Worker agents
  *
- * Three-agent architecture:
- * - Manager: High-level planning and coordination
+ * Two-agent architecture:
+ * - Manager: High-level planning, review, and synthesis
  * - Worker: Task execution with tools
- * - Client: Adaptive validation and quality control
  */
 
 import { ModelOrchestrator } from '../models/orchestrator.js';
@@ -15,9 +14,7 @@ import { PersonaManager } from '../personas/persona-manager.js';
 import { AgentSpawner } from './agent-spawner.js';
 import { ManagerAgent } from './manager-agent.js';
 import { WorkerAgent } from './worker-agent.js';
-import { ClientAgent } from './client-agent.js';
 import { AgentContext } from './types/agent-context.js';
-import { CompletionSignal } from './types/completion-signal.js';
 import { serializeAgentContext } from './utils/serialize-agent-context.js';
 import { logger } from '../utils/logger.js';
 import { orchestrationLogger } from '../utils/orchestration-logger.js';
@@ -56,7 +53,6 @@ export class DualAgent {
 
   private manager: ManagerAgent;
   private worker: WorkerAgent;
-  private client: ClientAgent;
 
   private maxSubtasks: number;
   private maxIterations: number;
@@ -74,15 +70,14 @@ export class DualAgent {
     this.personaManager = config.personaManager || null;
 
     this.maxSubtasks = config.maxSubtasks || 10;
-    this.maxIterations = config.maxIterations || 10;
+    this.maxIterations = config.maxIterations || 20;
     this.maxAgentDepth = config.maxAgentDepth ?? 1; // Default: only Manager can spawn
     this.autoSave = config.autoSave !== false;
     this.condensingThreshold = config.condensingThreshold || 30;
 
-    // Initialize agents (three-agent architecture)
+    // Initialize agents (Manager + Worker architecture)
     this.manager = new ManagerAgent(this.orchestrator, this.workspace, this.personaManager || undefined);
     this.worker = new WorkerAgent(this.orchestrator, this.mcpManager, this.workspace, this.maxIterations, this.personaManager || undefined);
-    this.client = new ClientAgent(this.orchestrator, this.mcpManager);
 
     // Initialize AgentSpawner - always available as a baseline tool
     // Create a PersonaManager if one wasn't provided
@@ -108,7 +103,7 @@ export class DualAgent {
     );
     this.worker.setAgentSpawner(this.agentSpawner);
 
-    logger.info('[*] Three-agent system initialized (Manager + Worker + Client)');
+    logger.info('[*] Two-agent system initialized (Manager + Worker)');
     logger.info(`[*] Agent spawn depth limit: ${this.maxAgentDepth} (${this.maxAgentDepth === 1 ? 'only Manager can spawn' : `${this.maxAgentDepth} levels deep`})`);
     
     if (this.personaManager) {
@@ -210,61 +205,6 @@ VALIDATION GUIDANCE:
   }
 
   /**
-   * Determine corrective strategy for a subtask based on CompletionSignal.
-   * Returns a description of the action taken, or null if no correction needed.
-   */
-  private applyCorrectionStrategy(
-    signal: CompletionSignal,
-    subtask: string,
-    retryCount: number,
-    maxRetries: number,
-    subtasksToExecute: string[],
-    results: { subtask: string; result: string }[]
-  ): string | null {
-    if (signal.confidence === 'high') return null;
-
-    const strategy = signal.suggestedStrategy || 'retry';
-
-    // Budget exhausted
-    if (retryCount >= maxRetries) {
-      if (signal.progressMade) {
-        logger.info(`[DualAgent] Retry budget exhausted but progress was made — continuing to synthesis`);
-        return null;
-      }
-      logger.warn(`[DualAgent] Retry budget exhausted with no progress — skipping subtask`);
-      return null; // handled by caller
-    }
-
-    switch (strategy) {
-      case 'retry':
-        return subtask; // re-queue same instruction
-
-      case 'rephrase':
-        return `[CLARIFIED] ${subtask} — Please ensure the correct tools and approach are used. Avoid scope drift.`;
-
-      case 'decompose':
-        // Manager would ideally split this; we approximate by re-queuing with guidance
-        return `[DECOMPOSE] Break this task into smaller concrete steps and execute them: ${subtask}`;
-
-      case 'skip':
-        logger.warn(`[DualAgent] Strategy=skip for subtask: ${subtask}`);
-        return null; // caller skips
-
-      case 'escalate':
-        // Do NOT overwrite results[] here. The Worker's actual result (with
-        // specific tool error detail from failedTools) was already pushed into
-        // results[] before Client validation ran. The approved:false flag on
-        // that entry is enough for synthesizeResponse() to handle it honestly.
-        // Pushing a generic ⚠️ string would lose the specific error information.
-        logger.warn(`[DualAgent] Escalating subtask to user — evidence-backed failure, no retry: ${subtask}`);
-        return null;
-
-      default:
-        return subtask;
-    }
-  }
-
-  /**
    * Process user message using dual-agent architecture
    */
   async chat(userMessage: string): Promise<DualAgentResponse> {
@@ -310,6 +250,35 @@ VALIDATION GUIDANCE:
 
     orchestrationLogger.logPhaseEnd('PLANNING', Date.now() - phaseStartTime);
 
+    // Conversational short-circuit: skip execution entirely for greetings, thank-yous, etc.
+    if (plan.conversational) {
+      logger.info('[DualAgent] Conversational message — returning direct reply');
+      const directReply = await this.manager.directReply(
+        this.userConversationHistory,
+        agentContext,
+      );
+      this.userConversationHistory.push({ role: 'assistant', content: directReply });
+
+      if (this.autoSave && this.conversationManager) {
+        await this.conversationManager.autoSave(
+          this.userConversationHistory,
+          this.workspace.getWorkspaceDir(),
+          this.orchestrator,
+        );
+      }
+
+      logger.info('\n━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━');
+      logger.info('[+] Complete: 1 iteration, 0 tools used (conversational)');
+      logger.info('━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\n');
+
+      return {
+        content: directReply,
+        iterations: 1,
+        toolsUsed: [],
+        plan: { subtasks: [], reasoning: plan.reasoning },
+      };
+    }
+
     // PHASE 2: Execute subtasks with per-subtask retry budget
     logger.info('\n[PHASE 2: Execution]');
     logger.info('─────────────────────────────────────────');
@@ -317,11 +286,10 @@ VALIDATION GUIDANCE:
     const executionStartTime = Date.now();
     orchestrationLogger.logPhaseStart('EXECUTION');
 
-    const results: { subtask: string; result: string; approved: boolean }[] = [];
+    const results: { subtask: string; result: string; accepted: boolean }[] = [];
     const subtasksToExecute = plan.subtasks.slice(0, this.maxSubtasks);
-    const MAX_RETRIES_PER_SUBTASK = 2;
-
-    // Track per-subtask retry counts (keyed by original subtask text)
+    // Max 1 retry per original subtask — keyed by original subtask text (not correction text)
+    const MAX_RETRIES_PER_SUBTASK = 1;
     const subtaskRetryCounts = new Map<string, number>();
 
     for (let i = 0; i < subtasksToExecute.length; i++) {
@@ -338,92 +306,31 @@ VALIDATION GUIDANCE:
       totalIterations += 1;
       allToolsUsed.push(...workerResult.toolsUsed);
 
-      // Client validates Worker's result with shared context (adaptive involvement)
-      const validation = await this.client.validate(
-        userMessage,
-        plan.subtasks,
-        workerResult,
-        undefined, // let Client determine involvement level
-        agentContext
-      );
+      // Manager reviews Worker's result — fast-path for common cases, LLM only for edge cases
+      const review = await this.manager.reviewSubtaskResult(subtask, workerResult, userMessage);
 
-      // Record result alongside Client's approval verdict.
-      // The synthesis phase uses this to produce an honest response when
-      // some subtasks were not completed successfully.
       results.push({
         subtask,
         result: workerResult.result,
-        approved: validation.approved,
+        accepted: review.accepted,
       });
 
-      if (!validation.approved) {
-        const signal = validation.completionSignal;
-        const retryCount = subtaskRetryCounts.get(subtask) || 0;
+      if (!review.accepted && review.specificCorrection) {
+        // Determine the original subtask key for retry counting.
+        // Correction subtasks always start fresh — map them back to the original via
+        // their position in the queue vs the original plan length.
+        const originalSubtask = plan.subtasks[Math.min(i, plan.subtasks.length - 1)] || subtask;
+        const retryCount = subtaskRetryCounts.get(originalSubtask) || 0;
 
-        // Build a context-correction prefix so the Worker isn't misled by prior
-        // conversation turns that claimed success for the same task.
-        const contextCorrectionPrefix = `CONTEXT CORRECTION: Previous conversation messages claiming this task was already completed are INCORRECT — those claims were not validated. You MUST execute the required actions now using the appropriate tools. Do NOT produce a text-only response.
-
-`;
-
-        if (signal) {
-          logger.info(`[DualAgent] CompletionSignal: confidence=${signal.confidence}, blocker=${signal.blockerType || 'none'}, strategy=${signal.suggestedStrategy || 'none'}, progress=${signal.progressMade}`);
-
-          const rawCorrection = this.applyCorrectionStrategy(
-            signal, subtask, retryCount, MAX_RETRIES_PER_SUBTASK, subtasksToExecute, results
-          );
-
-          const correction = rawCorrection ? `${contextCorrectionPrefix}${rawCorrection}` : null;
-
-          if (correction) {
-            // Deduplicate against the pending queue only — NOT against results.
-            // Correction subtasks intentionally re-execute something that failed,
-            // so checking results would always flag a retry as a duplicate.
-            const normalizedCorrection = correction.toLowerCase().trim();
-            const isDuplicate = subtasksToExecute.some(existing =>
-              existing.toLowerCase().trim() === normalizedCorrection
-            );
-
-            if (isDuplicate) {
-              logger.warn(`[DualAgent] Skipping duplicate correction subtask`);
-            } else if (subtasksToExecute.length < this.maxSubtasks) {
-              // Insert correction immediately after current position so it runs
-              // BEFORE any subsequent subtasks that may depend on this one.
-              subtasksToExecute.splice(i + 1, 0, correction);
-              subtaskRetryCounts.set(subtask, retryCount + 1);
-              logger.info(`[DualAgent] Inserted correction at position ${i + 2} via ${signal.suggestedStrategy} (${subtasksToExecute.length} total, retry ${retryCount + 1}/${MAX_RETRIES_PER_SUBTASK})`);
-            } else {
-              logger.warn(`[DualAgent] Cannot add correction — maxSubtasks (${this.maxSubtasks}) reached`);
-            }
-          } else if (!signal.progressMade && retryCount >= MAX_RETRIES_PER_SUBTASK) {
-            logger.warn(`[DualAgent] No progress after ${MAX_RETRIES_PER_SUBTASK} retries — skipping subtask`);
-          }
-        } else if (validation.nextAction) {
-          // Fallback to legacy correction if no signal present
-          logger.info(`[Client] Validation failed: ${validation.issues.join(', ')}`);
-          logger.info(`[Client] Requesting correction: ${validation.nextAction}`);
-
-          const correction = `${contextCorrectionPrefix}${validation.nextAction}`;
-          const normalizedCorrection = correction.toLowerCase().trim();
-          // Only deduplicate against the pending queue — corrections are intentional
-          // re-attempts, so matching against results would always skip them.
-          const isDuplicate = subtasksToExecute.some(existing =>
-            existing.toLowerCase().trim() === normalizedCorrection
-          );
-
-          if (isDuplicate) {
-            logger.warn(`[Client] Skipping duplicate correction subtask`);
-          } else if (subtasksToExecute.length < this.maxSubtasks) {
-            // Insert correction immediately after current position so it runs
-            // BEFORE any subsequent subtasks that may depend on this one.
-            subtasksToExecute.splice(i + 1, 0, correction);
-            logger.info(`[Client] Inserted correction at position ${i + 2} (${subtasksToExecute.length} total)`);
-          } else {
-            logger.warn(`[Client] Cannot add correction - maxSubtasks (${this.maxSubtasks}) reached`);
-          }
+        if (retryCount < MAX_RETRIES_PER_SUBTASK && subtasksToExecute.length < this.maxSubtasks) {
+          subtasksToExecute.splice(i + 1, 0, review.specificCorrection);
+          subtaskRetryCounts.set(originalSubtask, retryCount + 1);
+          logger.info(`[DualAgent] Inserted targeted retry at position ${i + 2} (retry ${retryCount + 1}/${MAX_RETRIES_PER_SUBTASK})`);
+        } else {
+          logger.warn(`[DualAgent] Retry budget exhausted or queue full — accepting partial result`);
         }
       } else {
-        logger.info(`[Client] Validation passed (${validation.involvementLevel} level)`);
+        logger.info(`[Manager] Subtask accepted`);
       }
     }
 
@@ -475,7 +382,7 @@ VALIDATION GUIDANCE:
 
   private async synthesizeResponse(
     plan: { subtasks: string[]; reasoning: string },
-    results: { subtask: string; result: string; approved: boolean }[],
+    results: { subtask: string; result: string; accepted: boolean }[],
     agentContext?: AgentContext
   ): Promise<string> {
     // Always have the Manager synthesize a final response.
@@ -518,7 +425,6 @@ VALIDATION GUIDANCE:
   resetConversation() {
     this.userConversationHistory = [];
     this.manager.resetConversation();
-    this.client.resetSessionState();
     // Null out the conversation ID so the next autoSave generates a fresh file
     // rather than continuing to append to the previous conversation's storage entry.
     this.conversationManager?.setCurrentConversationId(null);

--- a/src/core/manager-agent.ts
+++ b/src/core/manager-agent.ts
@@ -14,6 +14,7 @@ import { ModelOrchestrator } from '../models/orchestrator.js';
 import { WorkspaceManager } from './workspace.js';
 import { PersonaManager } from '../personas/persona-manager.js';
 import { AgentContext } from './types/agent-context.js';
+import { WorkerResult } from './worker-agent.js';
 import { Message } from '../models/base.js';
 import { logger } from '../utils/logger.js';
 import { orchestrationLogger } from '../utils/orchestration-logger.js';
@@ -26,6 +27,8 @@ export interface ManagerTask {
 export interface ManagerPlan {
   subtasks: string[];
   reasoning: string;
+  /** True when the user's message is purely conversational — no task execution needed. */
+  conversational?: boolean;
 }
 
 export interface ManagerDecision {
@@ -158,9 +161,15 @@ Guidelines:
 - Trust Worker to handle file operations, error checking, and iteration
 - Each subtask MUST be a clear, actionable instruction - NOT prose, advice, or explanation
 
+CONVERSATIONAL MESSAGES:
+- If the message is purely conversational (greeting, thank-you, compliment, acknowledgment, small talk) with NO actionable task embedded, return:
+  {"conversational": true, "subtasks": [], "reasoning": "Conversational message — no task required"}
+- Do NOT invent tasks from prior conversation context just because a topic was mentioned earlier.
+
 Respond ONLY with valid JSON in this exact format (no other text before or after):
 {
   "reasoning": "<brief explanation of your high-level approach>",
+  "conversational": false,
   "subtasks": [
     "<subtask 1 - a clear, actionable instruction>",
     "<subtask 2 - only if truly necessary>"
@@ -193,16 +202,22 @@ Respond ONLY with valid JSON in this exact format (no other text before or after
       plan = await this.cleanPlanWithLLM(response.content);
     }
 
-    // Validate subtasks - filter out garbage entries
-    plan.subtasks = this.validateSubtasks(plan.subtasks);
+    const isConversational = !!(plan as any).conversational;
 
-    logger.info(`[Manager] Reasoning: ${plan.reasoning}`);
-    logger.info(`[Manager] Plan: ${plan.subtasks.length} subtasks`);
-    plan.subtasks.forEach((task, i) => logger.info(`  ${i + 1}. ${task}`));
+    // Validate subtasks - filter out garbage entries (allow empty list for conversational)
+    plan.subtasks = this.validateSubtasks(plan.subtasks, isConversational);
+
+    if (isConversational) {
+      logger.info('[Manager] Conversational message detected — skipping task execution');
+    } else {
+      logger.info(`[Manager] Reasoning: ${plan.reasoning}`);
+      logger.info(`[Manager] Plan: ${plan.subtasks.length} subtasks`);
+      plan.subtasks.forEach((task, i) => logger.info(`  ${i + 1}. ${task}`));
+    }
 
     orchestrationLogger.logManagerPlanCreated(plan.subtasks, plan.reasoning);
 
-    return { subtasks: plan.subtasks, reasoning: plan.reasoning };
+    return { subtasks: plan.subtasks, reasoning: plan.reasoning, conversational: isConversational };
   }
 
   /**
@@ -261,30 +276,100 @@ NEXT_ACTION: <what to do next, if CONTINUE>`;
   }
 
   /**
+   * Review a Worker's subtask result and decide whether to accept it or request a retry.
+   *
+   * Rules (fast-path first — avoids an LLM call for the common case):
+   * - AUTO-ACCEPT:  tools were used AND the result is substantive (>100 chars)
+   * - AUTO-REJECT:  no tools were used at all (pure hallucination / text-only response)
+   * - LLM REVIEW:  tools were used but result is suspiciously short (<100 chars)
+   *
+   * Returns { accepted: true } or { accepted: false, specificCorrection: "…" }.
+   * The specificCorrection is a clean, targeted instruction — NOT a stacked prefix.
+   */
+  async reviewSubtaskResult(
+    subtask: string,
+    workerResult: WorkerResult,
+    originalRequest: string,
+  ): Promise<{ accepted: boolean; specificCorrection?: string }> {
+    // Fast-path accept: tools were used and result has substance
+    if (workerResult.toolsUsed.length > 0 && workerResult.result.length >= 100) {
+      logger.info(`[Manager] Auto-accepted subtask (${workerResult.toolsUsed.length} tools used, ${workerResult.result.length} chars)`);
+      return { accepted: true };
+    }
+
+    // Fast-path reject: no tools at all — pure text-only response (hallucination)
+    if (workerResult.toolsUsed.length === 0) {
+      logger.warn(`[Manager] Auto-rejected subtask — Worker used no tools`);
+      const correction = `You produced a text-only response without using any tools. You MUST use the available tools to complete this task. Do not fabricate or infer data — call the appropriate tools now.\n\nOriginal task: ${subtask}`;
+      return { accepted: false, specificCorrection: correction };
+    }
+
+    // Edge case: tools used but result is very short — ask LLM to judge
+    logger.info(`[Manager] LLM review: tools=${workerResult.toolsUsed.length}, result length=${workerResult.result.length}`);
+    const reviewPrompt = `You are reviewing whether a Worker agent's result satisfactorily completes a subtask.
+
+Original user request: ${originalRequest}
+
+Subtask assigned to Worker: ${subtask}
+
+Tools used by Worker: ${workerResult.toolsUsed.join(', ')}
+
+Worker's result:
+${workerResult.result}
+
+DECISION RULES:
+- ACCEPT if the Worker gathered real data and provided a substantive result, even if partial
+- REJECT only if the result is clearly empty, fabricated, or completely off-task
+
+Respond with ONLY one of:
+ACCEPT
+REJECT: <one sentence explaining what specific data is still missing>`;
+
+    const response = await this.orchestrator.chat({
+      messages: [
+        { role: 'system', content: 'You are a task reviewer. Reply with ACCEPT or REJECT: <reason>.' },
+        { role: 'user', content: reviewPrompt },
+      ],
+      temperature: 0.1,
+    });
+
+    const verdict = response.content.trim();
+    if (verdict.startsWith('REJECT')) {
+      const reason = verdict.replace(/^REJECT:?\s*/i, '').trim();
+      logger.warn(`[Manager] LLM rejected subtask: ${reason}`);
+      const correction = `The previous attempt was insufficient: ${reason}\n\nRetry the subtask using the appropriate tools: ${subtask}`;
+      return { accepted: false, specificCorrection: correction };
+    }
+
+    logger.info(`[Manager] LLM accepted subtask`);
+    return { accepted: true };
+  }
+
+  /**
    * Create final response for user
    */
-  async synthesizeResponse(allResults: { subtask: string; result: string; approved?: boolean }[], agentContext?: AgentContext): Promise<string> {
+  async synthesizeResponse(allResults: { subtask: string; result: string; accepted?: boolean }[], agentContext?: AgentContext): Promise<string> {
     logger.info('[Manager] Synthesizing final response...');
     orchestrationLogger.logManagerSynthesize(allResults.length);
 
-    const approvedResults = allResults.filter(r => r.approved !== false);
-    const failedResults = allResults.filter(r => r.approved === false);
+    const acceptedResults = allResults.filter(r => r.accepted !== false);
+    const failedResults = allResults.filter(r => r.accepted === false);
 
-    const completedSection = approvedResults.length > 0
-      ? `Validated Completed Work:\n${approvedResults.map((r, i) => `${i + 1}. ${r.subtask}\nResult: ${r.result}`).join('\n\n')}`
-      : 'No subtasks were validated as successfully completed.';
+    const completedSection = acceptedResults.length > 0
+      ? `Completed Work:\n${acceptedResults.map((r, i) => `${i + 1}. ${r.subtask}\nResult: ${r.result}`).join('\n\n')}`
+      : 'No subtasks completed successfully.';
 
     const failedSection = failedResults.length > 0
-      ? `\n\nSubtasks That Did NOT Complete Successfully (Client validation rejected these):\n${failedResults.map((r, i) => `${i + 1}. ${r.subtask}\nWorker output (unvalidated): ${r.result}`).join('\n\n')}`
+      ? `\n\nSubtasks That Could Not Be Completed:\n${failedResults.map((r, i) => `${i + 1}. ${r.subtask}\nWorker output: ${r.result}`).join('\n\n')}`
       : '';
 
     const synthesisPrompt = `Based on the work below, create a final response for the user.
 
-IMPORTANT: Some subtasks may not have been completed successfully — the Client validation agent explicitly rejected them. You MUST be honest about what was and was not accomplished. Do NOT claim files were created, actions were performed, or results were produced if the corresponding subtask is listed as failed.
+IMPORTANT: Be honest about what was and was not accomplished. Do NOT claim results were produced if the corresponding subtask is listed as failed.
 
 ${completedSection}${failedSection}
 
-Create a clear, honest response that accurately reflects what was accomplished and what was not. If work failed, explain what happened and what the user should expect.`;
+Create a clear, honest response that accurately reflects what was accomplished. If any work failed, explain briefly what happened.`;
 
     this.conversationHistory.push({
       role: 'user',
@@ -303,6 +388,27 @@ Create a clear, honest response that accurately reflects what was accomplished a
 
     logger.info('[Manager] Final response created');
 
+    return response.content;
+  }
+
+  /**
+   * Respond directly to a conversational message — no planning or tool execution.
+   * Used when `createPlan()` signals `conversational: true`.
+   *
+   * @param userConversationHistory - The full user-facing conversation so far
+   *   (already includes the current user message at the tail).
+   * @param agentContext - Current agent context for directive injection.
+   */
+  async directReply(
+    userConversationHistory: Message[],
+    agentContext?: AgentContext,
+  ): Promise<string> {
+    const systemMessages = this.getSystemMessages(agentContext);
+    const response = await this.orchestrator.chat({
+      messages: [...systemMessages, ...userConversationHistory],
+      temperature: 0.7, // Slightly higher for natural conversation
+    });
+    logger.info('[Manager] Direct conversational reply produced');
     return response.content;
   }
 
@@ -368,8 +474,10 @@ Return ONLY valid JSON in this exact format (no other text):
   /**
    * Validate that each subtask is a reasonable, actionable instruction.
    * Removes garbage entries like separators, prose fragments, or empty strings.
+   *
+   * @param isConversational - When true, allow an empty list (no min-1 enforcement).
    */
-  private validateSubtasks(subtasks: string[]): string[] {
+  private validateSubtasks(subtasks: string[], isConversational = false): string[] {
     const validated = subtasks.filter(task => {
       const trimmed = task.trim();
       // Reject empty or too-short entries
@@ -381,8 +489,9 @@ Return ONLY valid JSON in this exact format (no other text):
       return true;
     });
 
-    // Ensure at least one subtask
-    if (validated.length === 0) {
+    // Enforce at least one subtask for real task plans.
+    // For conversational messages the LLM intentionally returns subtasks: [] — allow that.
+    if (validated.length === 0 && !isConversational) {
       logger.warn('[Manager] All subtasks filtered out, preserving first original');
       return subtasks.length > 0 ? [subtasks[0]] : ['Complete the user request'];
     }

--- a/src/core/worker-agent.ts
+++ b/src/core/worker-agent.ts
@@ -68,7 +68,7 @@ export class WorkerAgent {
     orchestrator: ModelOrchestrator,
     mcpManager: MCPServerManager,
     workspace: WorkspaceManager,
-    maxIterations: number = 5,
+    maxIterations: number = 20,
     personaManager?: PersonaManager
   ) {
     this.orchestrator = orchestrator;
@@ -439,35 +439,28 @@ Please complete this subtask and report your findings.`,
       if (response.toolCalls && response.toolCalls.length > 0) {
         logger.info(`  [Worker] Using ${response.toolCalls.length} tool(s)`);
 
-        // Detect repetitive tool calls BEFORE executing
+        // Detect repetitive tool calls BEFORE executing.
+        // Only block exact-same (tool + args) duplicates — calling the same tool
+        // with DIFFERENT arguments (e.g. yfinance_get_ticker_info for MSFT then NVDA)
+        // is intentional and must NOT be blocked.
         const proposedTools = response.toolCalls.map(tc => {
           const args = JSON.parse(tc.function.arguments);
           return `${tc.function.name}:${JSON.stringify(args)}`;
         });
-        
-        // Check if we're about to repeat the same tool call (name-only check)
-        const lastToolCalls = toolsUsed.slice(-2);
-        const isRepetitive = proposedTools.some(proposed => {
-          const toolName = proposed.split(':')[0];
-          return lastToolCalls.filter(t => t === toolName).length >= 2;
-        });
 
-        // Exact-signature check: catches same tool + same args within a subtask.
-        // This catches the case where the model reads the same file twice in
-        // consecutive iterations before the name-only check triggers.
         const exactDuplicate = proposedTools.some(sig => executedToolSignatures.has(sig));
 
-        if ((isRepetitive && iteration >= 2) || exactDuplicate) {
+        if (exactDuplicate) {
+          const dupSig = proposedTools.find(sig => executedToolSignatures.has(sig)) || '';
+          const dupToolName = dupSig.split(':')[0];
           logger.warn(`  [Worker] Detected repetitive tool usage - interrupting loop`);
           conversationHistory.push({
             role: 'user',
-            content: `STOP: You are calling the same tool with the same arguments repeatedly. Do NOT repeat it again.
+            content: `STOP: You already called \`${dupToolName}\` with these exact arguments in a previous step. Do NOT repeat the same call.
 
 You have two choices:
-1. If there is a DIFFERENT next step required to complete the subtask, take it now using the appropriate tool.
-2. If all required work is genuinely complete, respond with a thorough description of everything accomplished — do NOT call any more tools.
-
-Do not assume the task is complete just because one step succeeded. Review what the subtask requires and check whether you have actually finished all of it.`,
+1. If more work remains (e.g. other symbols, other queries), call the tool with DIFFERENT arguments now.
+2. If all required work is genuinely complete, respond with a thorough description of everything accomplished — do NOT call any more tools.`,
           });
           continue; // Skip executing the repetitive tools, let model reconsider
         }
@@ -658,11 +651,32 @@ IMPORTANT: Do not claim completion unless the core deliverable (e.g. the file wr
       });
 
       if (hasSuccessfulTools && !hasToolFailures) {
-        // Tools ran but the model never produced a conclusive text response.
-        // Report the actual tools used so the Client coherence check can verify
-        // whether the right work was done — do NOT claim overall success here.
-        finalResult = `Max iterations reached. Tools executed (${toolsUsed.length}): ${toolsUsed.join(', ')}. The model did not produce a final confirmation. Validation required.`;
-        logger.warn(`[Worker] Max iterations reached after ${toolsUsed.length} tool(s) — no conclusive response from model`);
+        // Tools ran successfully but the model never produced a conclusive text
+        // response.  All the gathered data is in conversationHistory — make one
+        // final LLM call with NO tools so the model is forced to synthesise a
+        // text answer from what it already has rather than calling more tools.
+        logger.warn(`[Worker] Max iterations reached after ${toolsUsed.length} tool(s) — forcing synthesis response`);
+        try {
+          conversationHistory.push({
+            role: 'user',
+            content:
+              'You have already gathered all the data above. ' +
+              'NOW write your final comprehensive response using ONLY what you have already collected — ' +
+              'do not call any more tools. Summarise all findings clearly and completely.',
+          });
+          const synthResponse = await this.orchestrator.chatWithFallback(
+            { messages: conversationHistory }, // no `tools` field → forces text-only reply
+            useToolCallingFallback,
+          );
+          finalResult =
+            synthResponse.content ||
+            `Max iterations reached. Tools executed (${toolsUsed.length}): ${toolsUsed.join(', ')}.`;
+          logger.info(`[Worker] Forced synthesis produced ${finalResult.length} chars`);
+        } catch (synthError) {
+          const errMsg = synthError instanceof Error ? synthError.message : String(synthError);
+          logger.warn(`[Worker] Forced synthesis failed: ${errMsg}`);
+          finalResult = `Max iterations reached. Tools executed (${toolsUsed.length}): ${toolsUsed.join(', ')}.`;
+        }
       } else if (hasToolFailures) {
         // Build a specific failure summary from the circuit breaker data
         const failureSummary = [...toolFailureCounts.entries()]
@@ -717,51 +731,31 @@ IMPORTANT: Do not claim completion unless the core deliverable (e.g. the file wr
   }
 
   /**
-   * Determine if we should prompt Worker to check for completion
-   * This helps prevent over-iteration by asking Worker to confirm task is done
+   * Determine if we should prompt Worker to check for completion.
+   * Fires every 3 successful tool calls (regardless of tool type) so research
+   * tasks (yfinance, brave-search, etc.) get a "are you done?" nudge just like
+   * file-operation tasks do.  Also fires when we are approaching the iteration
+   * cap so the model has a chance to synthesise before hitting the hard limit.
    */
   private shouldPromptForCompletion(
     toolsUsed: string[],
     currentIteration: number
   ): boolean {
-    // Don't prompt on first iteration - let Worker do initial work
+    // Don't prompt on the very first iteration — let Worker do initial work first.
     if (currentIteration === 0) {
       return false;
     }
 
-    // Immediate prompt after browser navigation - that's usually the end of the task
-    const hasBrowserNavigation = toolsUsed.some(tool => tool.includes('browser_navigate'));
-    if (hasBrowserNavigation) {
+    // Approaching the iteration limit — give the model one last chance to wrap up.
+    const nearIterationLimit =
+      this.maxIterations > 0 &&
+      currentIteration >= Math.floor(this.maxIterations * 0.7);
+    if (nearIterationLimit) {
       return true;
     }
 
-    // Detect repetitive tool usage - sign of stuck loop
-    const lastThreeTools = toolsUsed.slice(-3);
-    if (lastThreeTools.length === 3 && 
-        lastThreeTools[0] === lastThreeTools[1] && 
-        lastThreeTools[1] === lastThreeTools[2]) {
-      return true; // Same tool called 3 times in a row - prompt for completion
-    }
-
-    // Don't prompt too frequently - only every 2 iterations after first
-    if (currentIteration % 2 !== 0) {
-      return false;
-    }
-
-    // Prompt only when genuinely substantive operations have completed.
-    // 'create_directory' is intentionally excluded — it is a setup step, not
-    // evidence that the main deliverable (e.g. file content) has been written.
-    // Pure tool-free responses (e.g. "explain X") never reach this point because
-    // no tools means hasSignificantOperations is false.
-    const hasSignificantOperations = toolsUsed.some(tool =>
-      tool.includes('write') ||
-      tool.includes('edit') ||
-      tool.includes('read') ||
-      tool.includes('browser') ||
-      tool.includes('navigate') ||
-      (tool.includes('create') && !tool.includes('directory') && !tool.includes('dir'))
-    );
-
-    return hasSignificantOperations && toolsUsed.length >= 2;
+    // Fire every 3 successful tool calls for any tool type
+    // (at 3, 6, 9, 12 … tools accumulated).
+    return toolsUsed.length >= 3 && toolsUsed.length % 3 === 0;
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,10 +6,13 @@
 
 export { JivaAgent } from './core/agent.js';
 export { DualAgent } from './core/dual-agent.js';
+export { CodeAgent } from './code/agent.js';
+export { LspManager } from './code/lsp/manager.js';
 export { ManagerAgent } from './core/manager-agent.js';
 export { WorkerAgent } from './core/worker-agent.js';
 export { ClientAgent } from './core/client-agent.js';
 export { configManager, ConfigManager } from './core/config.js';
+export type { IAgent, AgentChatResponse } from './core/agent-interface.js';
 export { WorkspaceManager } from './core/workspace.js';
 export { ConversationManager } from './core/conversation-manager.js';
 

--- a/src/interfaces/cli/index.ts
+++ b/src/interfaces/cli/index.ts
@@ -15,6 +15,7 @@ import { ConversationManager } from '../../core/conversation-manager.js';
 import { DualAgent } from '../../core/dual-agent.js';
 import { runSetupWizard, updateConfiguration } from './setup-wizard.js';
 import { startREPL } from './repl.js';
+import type { IAgent } from '../../core/agent-interface.js';
 import { logger, LogLevel } from '../../utils/logger.js';
 import { orchestrationLogger } from '../../utils/orchestration-logger.js';
 import { readFileSync } from 'fs';
@@ -123,6 +124,9 @@ program
   .option('--debug', 'Enable debug mode')
   .option('-t, --temperature <value>', 'Model temperature (0-1)', parseFloat)
   .option('--max-iterations <number>', 'Maximum agent iterations', parseInt)
+  .option('--code', 'Enable code mode (single-loop agent + LSP integration)')
+  .option('--no-lsp', 'Disable LSP in code mode')
+  .option('--plan', 'Generate an implementation plan for approval before executing (code mode only)')
   .action(async (options) => {
     try {
       // Load configuration from file if provided
@@ -170,6 +174,7 @@ program
         model: reasoningModelConfig.defaultModel,
         type: 'reasoning',
         useHarmonyFormat: reasoningModelConfig.useHarmonyFormat,
+        defaultReasoningEffort: 'high',
       });
 
       let multimodalModel;
@@ -180,6 +185,7 @@ program
           apiKey: multimodalModelConfig.apiKey,
           model: multimodalModelConfig.defaultModel,
           type: 'multimodal',
+          // reasoning_effort not applicable for multimodal models
         });
       }
 
@@ -194,6 +200,7 @@ program
           model: toolCallingModelConfig.defaultModel,
           type: 'tool-calling',
           useHarmonyFormat: toolCallingModelConfig.useHarmonyFormat,
+          defaultReasoningEffort: 'medium',
         });
       }
 
@@ -317,21 +324,46 @@ program
         }
       }
 
-      // Create agent (dual-agent architecture)
-      const agent = new DualAgent({
-        orchestrator,
-        mcpManager,
-        workspace,
-        conversationManager,
-        personaManager,
-        maxSubtasks: 20, // Manager's subtask limit (separate from Worker iterations)
-        maxIterations: options.maxIterations || 10, // Worker's iteration limit per subtask
-        autoSave: true,
-        condensingThreshold: options.condensingThreshold ?? 30,
-      });
+      // Determine if code mode should be used
+      const codeModeConfig = configManager.getCodeMode();
+      const useCodeMode = options.code || (codeModeConfig?.enabled ?? false);
+
+      let agent: IAgent;
+
+      if (useCodeMode) {
+        const { CodeAgent } = await import('../../code/agent.js');
+        const lspEnabled = options.lsp !== false && (codeModeConfig?.lsp?.enabled ?? true);
+        const maxIter = options.maxIterations || codeModeConfig?.maxIterations || 50;
+        const codeAgent = new CodeAgent({
+          orchestrator,
+          workspace,
+          conversationManager,
+          maxIterations: maxIter,
+          lspEnabled,
+        });
+        console.log(chalk.cyan(`\n${CodeAgent.indicator} Code mode active (LSP: ${lspEnabled ? 'on' : 'off'})\n`));
+        agent = codeAgent;
+      } else {
+        // Create agent (dual-agent architecture)
+        agent = new DualAgent({
+          orchestrator,
+          mcpManager,
+          workspace,
+          conversationManager,
+          personaManager,
+          maxSubtasks: 20, // Manager's subtask limit (separate from Worker iterations)
+          maxIterations: options.maxIterations || 20, // Worker's iteration limit per subtask
+          autoSave: true,
+          condensingThreshold: options.condensingThreshold ?? 30,
+        });
+      }
 
       // Start REPL
-      await startREPL({ agent });
+      const planMode = useCodeMode && !!options.plan;
+      if (planMode) {
+        console.log(chalk.cyan('Plan mode active: implementation plans will be shown for approval before execution.\n'));
+      }
+      await startREPL({ agent, planMode });
 
       // Cleanup
       await agent.cleanup();
@@ -342,6 +374,16 @@ program
       if (logPath) {
         logger.info(`\nOrchestration log saved to: ${logPath}`);
       }
+
+      // Restore terminal state and exit. Two reasons:
+      // 1. LSP child-process streams keep the event loop alive after cleanup.
+      // 2. inquirer leaves stdin in raw mode; pausing it restores cooked mode
+      //    so no extra keypress is needed after /exit.
+      if (typeof (process.stdin as any).setRawMode === 'function') {
+        (process.stdin as any).setRawMode(false);
+      }
+      process.stdin.pause();
+      process.exit(0);
     } catch (error) {
       logger.error('Chat session failed', error);
       orchestrationLogger.close();
@@ -554,6 +596,9 @@ program
   .option('--debug', 'Enable debug mode')
   .option('-t, --temperature <value>', 'Model temperature (0-1)', parseFloat)
   .option('--max-iterations <number>', 'Maximum agent iterations', parseInt)
+  .option('--code', 'Enable code mode (single-loop agent + LSP integration)')
+  .option('--no-lsp', 'Disable LSP in code mode')
+  .option('--plan', 'Generate an implementation plan for approval before executing (code mode only)')
   .action(async (prompt, options) => {
     try {
       // Load configuration from file if provided
@@ -599,6 +644,7 @@ program
         model: reasoningModelConfig.defaultModel,
         type: 'reasoning',
         useHarmonyFormat: reasoningModelConfig.useHarmonyFormat,
+        defaultReasoningEffort: 'high',
       });
 
       let multimodalModel;
@@ -623,6 +669,7 @@ program
           model: toolCallingModelCfg.defaultModel,
           type: 'tool-calling',
           useHarmonyFormat: toolCallingModelCfg.useHarmonyFormat,
+          defaultReasoningEffort: 'medium',
         });
       }
 
@@ -746,18 +793,38 @@ program
         }
       }
 
-      // Create agent (dual-agent architecture)
-      const agent = new DualAgent({
-        orchestrator,
-        mcpManager,
-        workspace,
-        conversationManager,
-        personaManager,
-        maxSubtasks: 20, // Manager's subtask limit (separate from Worker iterations)
-        maxIterations: options.maxIterations || 10, // Worker's iteration limit per subtask
-        autoSave: true,
-        condensingThreshold: options.condensingThreshold ?? 30,
-      });
+      // Determine if code mode should be used
+      const codeModeConfigRun = configManager.getCodeMode();
+      const useCodeModeRun = options.code || (codeModeConfigRun?.enabled ?? false);
+
+      let agent: IAgent;
+
+      if (useCodeModeRun) {
+        const { CodeAgent } = await import('../../code/agent.js');
+        const lspEnabledRun = options.lsp !== false && (codeModeConfigRun?.lsp?.enabled ?? true);
+        const maxIterRun = options.maxIterations || codeModeConfigRun?.maxIterations || 50;
+        agent = new CodeAgent({
+          orchestrator,
+          workspace,
+          conversationManager,
+          maxIterations: maxIterRun,
+          lspEnabled: lspEnabledRun,
+        });
+        console.log(chalk.cyan(`\n[CODE MODE] Code mode active (LSP: ${lspEnabledRun ? 'on' : 'off'})\n`));
+      } else {
+        // Create agent (dual-agent architecture)
+        agent = new DualAgent({
+          orchestrator,
+          mcpManager,
+          workspace,
+          conversationManager,
+          personaManager,
+          maxSubtasks: 20, // Manager's subtask limit (separate from Worker iterations)
+          maxIterations: options.maxIterations || 20, // Worker's iteration limit per subtask
+          autoSave: true,
+          condensingThreshold: options.condensingThreshold ?? 30,
+        });
+      }
 
       // Execute prompt
       logger.info('Executing prompt...');

--- a/src/interfaces/cli/repl.ts
+++ b/src/interfaces/cli/repl.ts
@@ -9,13 +9,21 @@ import { DualAgent } from '../../core/dual-agent.js';
 import { logger } from '../../utils/logger.js';
 import { orchestrationLogger } from '../../utils/orchestration-logger.js';
 import { formatForCLI } from '../../utils/markdown.js';
+import type { IAgent } from '../../core/agent-interface.js';
+
+export type { IAgent };
 
 export interface REPLOptions {
-  agent: DualAgent;
+  agent: IAgent;
+  /**
+   * When true (code mode + --plan flag), each user message triggers a plan-then-approve
+   * flow before the agent executes. Only effective when the agent implements `plan()`.
+   */
+  planMode?: boolean;
 }
 
 export async function startREPL(options: REPLOptions): Promise<void> {
-  const { agent } = options;
+  const { agent, planMode = false } = options;
 
   console.log(chalk.bold.cyan('\n∞ Jiva Agent - Interactive Mode\n'));
   console.log(chalk.gray('Type your message and press Enter. Type /help for commands or /exit to quit.\n'));
@@ -120,11 +128,52 @@ export async function startREPL(options: REPLOptions): Promise<void> {
       continue;
     }
 
-    // Process message with agent
+    // ── Plan-then-approve flow (code mode + --plan flag) ───────────────────
+    let messageToSend = trimmedMessage;
+
+    if (planMode && typeof (agent as any).plan === 'function') {
+      const planSpinner = ora('Exploring codebase and generating plan...').start();
+      let planText = '';
+      try {
+        planText = await (agent as any).plan(trimmedMessage);
+        planSpinner.stop();
+      } catch (e) {
+        planSpinner.stop();
+        console.log(chalk.red('\n✗ Planning failed:'), e instanceof Error ? e.message : String(e));
+        console.log('');
+        continue;
+      }
+
+      console.log(chalk.bold.cyan('\n── Implementation Plan ──────────────────────────────────────────\n'));
+      console.log(formatForCLI(planText));
+      console.log(chalk.bold.cyan('─────────────────────────────────────────────────────────────────\n'));
+
+      const { approved } = await inquirer.prompt([{
+        type: 'confirm',
+        name: 'approved',
+        message: chalk.bold('Implement this plan?'),
+        default: true,
+        prefix: '',
+      }]);
+
+      if (!approved) {
+        console.log(chalk.gray('\nCancelled. Refine your request and try again.\n'));
+        continue;
+      }
+
+      // Inject the approved plan so the agent knows what to implement
+      messageToSend =
+        `${trimmedMessage}\n\n` +
+        `[The following implementation plan was reviewed and approved by the user. ` +
+        `Implement it exactly as described.]\n\n${planText}`;
+      console.log('');
+    }
+
+    // ── Execute ─────────────────────────────────────────────────────────────
     const spinner = ora('Thinking...').start();
 
     try {
-      const response = await agent.chat(trimmedMessage);
+      const response = await agent.chat(messageToSend);
 
       spinner.stop();
 
@@ -161,7 +210,7 @@ function showHelp() {
   console.log('');
 }
 
-function showHistory(agent: DualAgent) {
+function showHistory(agent: IAgent) {
   const history = agent.getConversationHistory();
 
   console.log(chalk.bold('\nConversation History:'));
@@ -183,7 +232,7 @@ function showHistory(agent: DualAgent) {
   console.log('');
 }
 
-function showTools(agent: DualAgent) {
+function showTools(agent: IAgent) {
   const tools = agent.getMCPManager().getClient().getAllTools();
 
   console.log(chalk.bold(`\nAvailable Tools (${tools.length}):`));
@@ -199,7 +248,7 @@ function showTools(agent: DualAgent) {
   console.log('');
 }
 
-function showServers(agent: DualAgent) {
+function showServers(agent: IAgent) {
   const serverStatus = agent.getMCPManager().getServerStatus();
 
   console.log(chalk.bold('\nMCP Servers:'));
@@ -218,7 +267,7 @@ function showServers(agent: DualAgent) {
   console.log('');
 }
 
-async function handleSaveConversation(agent: DualAgent) {
+async function handleSaveConversation(agent: IAgent) {
   const conversationManager = agent.getConversationManager();
 
   if (!conversationManager) {
@@ -237,7 +286,7 @@ async function handleSaveConversation(agent: DualAgent) {
   }
 }
 
-async function handleLoadConversation(agent: DualAgent) {
+async function handleLoadConversation(agent: IAgent) {
   const conversationManager = agent.getConversationManager();
 
   if (!conversationManager) {
@@ -292,7 +341,7 @@ async function handleLoadConversation(agent: DualAgent) {
   }
 }
 
-async function handleListConversations(agent: DualAgent) {
+async function handleListConversations(agent: IAgent) {
   const conversationManager = agent.getConversationManager();
 
   if (!conversationManager) {

--- a/src/interfaces/http/routes/chat.ts
+++ b/src/interfaces/http/routes/chat.ts
@@ -35,7 +35,7 @@ export function setupChatRoutes(app: Express, sessionManager: SessionManager): v
         response: response.content,
         iterations: response.iterations,
         toolsUsed: response.toolsUsed,
-        plan: response.plan,
+        ...(response.plan !== undefined && { plan: response.plan }),
       });
     } catch (error) {
       logger.error('[API] Chat error:', error);
@@ -87,7 +87,7 @@ export function setupChatRoutes(app: Express, sessionManager: SessionManager): v
           content: response.content,
           iterations: response.iterations,
           toolsUsed: response.toolsUsed,
-          plan: response.plan,
+          ...(response.plan !== undefined && { plan: response.plan }),
         });
 
         // Update activity

--- a/src/interfaces/http/session-manager.ts
+++ b/src/interfaces/http/session-manager.ts
@@ -1,12 +1,15 @@
 /**
- * Session Manager - Lifecycle management for DualAgent sessions
- * 
+ * Session Manager - Lifecycle management for agent sessions
+ *
  * Responsibilities:
- * - Create/destroy DualAgent instances per session
+ * - Create/destroy agent instances per session
  * - Track active sessions and enforce limits
  * - Handle idle timeouts
  * - Per-session MCP server initialization
  * - State persistence on shutdown
+ *
+ * When JIVA_CODE_MODE=true, sessions use CodeAgent (single-loop, in-process tools, LSP).
+ * Otherwise the default DualAgent (Manager→Worker→Client) is used.
  */
 
 import { EventEmitter } from 'events';
@@ -22,6 +25,7 @@ import { createKrutrimModel } from '../../models/krutrim.js';
 import { Message } from '../../models/base.js';
 import { PersonaManager } from '../../personas/persona-manager.js';
 import { getDefaultFilesystemAllowedPath } from '../../utils/platform.js';
+import type { IAgent } from '../../core/agent-interface.js';
 
 export interface SessionConfig {
   storageProvider: StorageProvider;
@@ -39,7 +43,7 @@ export interface SessionInfo {
 }
 
 interface ActiveSession {
-  agent: DualAgent;
+  agent: IAgent;
   mcpManager: MCPServerManager;
   workspace: WorkspaceManager;
   conversationManager: ConversationManager;
@@ -61,7 +65,7 @@ export class SessionManager extends EventEmitter {
   /**
    * Get or create a session
    */
-  async getOrCreateSession(tenantId: string, sessionId: string): Promise<DualAgent> {
+  async getOrCreateSession(tenantId: string, sessionId: string): Promise<IAgent> {
     const key = this.getSessionKey(tenantId, sessionId);
 
     // Return existing session
@@ -86,7 +90,8 @@ export class SessionManager extends EventEmitter {
 
     // Create new session
     logger.info(`[SessionManager] Creating session: ${key}`);
-    const session = await this.createSession(tenantId, sessionId);
+    const codeModeEnabled = process.env.JIVA_CODE_MODE === 'true';
+    const session = await this.createSession(tenantId, sessionId, codeModeEnabled);
     this.sessions.set(key, session);
     this.resetIdleTimer(key);
 
@@ -101,7 +106,7 @@ export class SessionManager extends EventEmitter {
   /**
    * Create a new session with all components
    */
-  private async createSession(tenantId: string, sessionId: string): Promise<ActiveSession> {
+  private async createSession(tenantId: string, sessionId: string, codeModeEnabled: boolean): Promise<ActiveSession> {
     const info: SessionInfo = {
       sessionId,
       tenantId,
@@ -157,6 +162,7 @@ export class SessionManager extends EventEmitter {
         model: modelConfig.reasoning.model,
         type: 'reasoning',
         useHarmonyFormat: true, // gpt-oss-120b requires Harmony format
+        defaultReasoningEffort: 'high',
       });
 
       // Tool-calling model: when configured, serves as the PRIMARY model for tool-call
@@ -174,6 +180,7 @@ export class SessionManager extends EventEmitter {
             model: tcModel,
             type: 'tool-calling',
             useHarmonyFormat: false, // standard OpenAI format for tool-calling LLMs
+            defaultReasoningEffort: 'medium',
           })
         : undefined;
 
@@ -266,17 +273,31 @@ export class SessionManager extends EventEmitter {
         logger.info(`[SessionManager] Restored conversation: ${conversationHistory.length} messages`);
       }
 
-      // Create DualAgent
-      const agent = new DualAgent({
-        orchestrator,
-        mcpManager,
-        workspace,
-        conversationManager,
-        personaManager,
-        maxSubtasks: 20,
-        maxIterations: 10,
-        autoSave: true, // Always auto-save in cloud mode
-      });
+      // Create agent — CodeAgent for code mode, DualAgent for general mode
+      let agent: IAgent;
+      if (codeModeEnabled) {
+        const { CodeAgent } = await import('../../code/agent.js');
+        const lspEnabled = process.env.JIVA_CODE_LSP !== 'false';
+        agent = new CodeAgent({
+          orchestrator,
+          workspace,
+          conversationManager,
+          maxIterations: 50,
+          lspEnabled,
+        });
+        logger.info('[SessionManager] Using CodeAgent (code mode)');
+      } else {
+        agent = new DualAgent({
+          orchestrator,
+          mcpManager,
+          workspace,
+          conversationManager,
+          personaManager,
+          maxSubtasks: 20,
+          maxIterations: 10,
+          autoSave: true,
+        });
+      }
 
       info.status = 'active';
 
@@ -339,6 +360,9 @@ export class SessionManager extends EventEmitter {
 
       // Clean up session-specific logger context
       logger.clearSessionContext(sessionId);
+
+      // Cleanup agent (shuts down LSP servers in code mode)
+      await session.agent.cleanup();
 
       // Cleanup MCP servers
       await session.mcpManager.cleanup();

--- a/src/models/base.ts
+++ b/src/models/base.ts
@@ -54,6 +54,14 @@ export interface ChatCompletionOptions {
   temperature?: number;
   maxTokens?: number;
   stream?: boolean;
+  /**
+   * Controls how much reasoning the model applies before responding.
+   * Supported by gpt-oss-120b and other reasoning-class models.
+   * "low"    — fast, minimal reasoning (good for connectivity tests / simple tasks)
+   * "medium" — balanced (good for tool-execution workers)
+   * "high"   — most thorough (best for planning, complex code changes, orchestration)
+   */
+  reasoningEffort?: 'low' | 'medium' | 'high';
 }
 
 export interface IModel {

--- a/src/models/harmony.ts
+++ b/src/models/harmony.ts
@@ -110,23 +110,40 @@ CORRECT - Do this:
 }
 
 /**
- * Formats messages into Harmony format
+ * Formats messages into Harmony format.
+ *
+ * Key transformations:
+ * - developer message: tool definitions are appended once (if not already present)
+ * - role:'tool' messages: converted to role:'user' since Harmony has no native tool-result role;
+ *   the model understands tool results as user messages providing output context
+ * - assistant messages: passed through unchanged (they may contain <|call|> tokens)
  */
 export function formatMessagesForHarmony(
   messages: HarmonyMessage[],
   tools?: HarmonyToolDefinition[]
 ): HarmonyMessage[] {
   const formattedMessages: HarmonyMessage[] = [];
+  let toolsInjected = false;
 
   // Process messages based on role hierarchy
   for (const msg of messages) {
-    if (msg.role === 'developer' && tools && tools.length > 0) {
-      // Inject tool definitions into developer message
+    if (msg.role === 'developer' && tools && tools.length > 0 && !toolsInjected) {
+      // Inject tool definitions into the first developer/system message (only once)
       const toolSection = formatToolsForHarmony(tools);
       const existingContent = typeof msg.content === 'string' ? msg.content : '';
       formattedMessages.push({
         ...msg,
         content: `${existingContent}\n\n${toolSection}`,
+      });
+      toolsInjected = true;
+    } else if (msg.role === 'tool') {
+      // In Harmony format there is no native tool-result message role.
+      // Convert to a user message so the model sees the tool output as conversation context.
+      const toolName = msg.name || 'tool';
+      const resultText = typeof msg.content === 'string' ? msg.content : JSON.stringify(msg.content);
+      formattedMessages.push({
+        role: 'user',
+        content: `<tool_result name="${toolName}">\n${resultText}\n</tool_result>`,
       });
     } else {
       formattedMessages.push(msg);

--- a/src/models/krutrim.ts
+++ b/src/models/krutrim.ts
@@ -19,8 +19,36 @@ export interface KrutrimConfig {
   endpoint: string;
   apiKey: string;
   model: string;
+  defaultModel?: string; // Alias used in config store; model takes precedence
   type: 'reasoning' | 'multimodal' | 'tool-calling';
   useHarmonyFormat?: boolean; // Use Harmony format for tools (Krutrim-specific), defaults to false
+  /**
+   * Default reasoning effort for all calls made through this model instance.
+   * Can be overridden per-call via ChatCompletionOptions.reasoningEffort.
+   * Sensible defaults: 'high' for reasoning models, 'medium' for tool-calling models.
+   */
+  defaultReasoningEffort?: 'low' | 'medium' | 'high';
+  /**
+   * How to communicate reasoning effort to the model.
+   *
+   * 'api_param'     — send only as the `reasoning_effort` request body field.
+   *                   Works natively on Groq; may be silently dropped elsewhere.
+   * 'system_prompt' — inject only as a leading system message: "Reasoning: <level>".
+   *                   Understood by gpt-oss-120b on any provider.
+   * 'both'          — do both (recommended default). The API param is used when the
+   *                   provider supports it; the system message is a universal fallback
+   *                   for Krutrim/self-hosted endpoints that strip unknown params.
+   *
+   * Default: 'both'
+   */
+  reasoningEffortStrategy?: 'api_param' | 'system_prompt' | 'both';
+  /**
+   * Request reasoning tokens in the response body (Groq-specific: `include_reasoning`).
+   * When true, the model's thinking tokens are logged at debug level.
+   * Has no effect on providers that do not support the field.
+   * Default: false (suppressing reasoning tokens saves output tokens).
+   */
+  includeReasoning?: boolean;
 }
 
 export class KrutrimModel implements IModel {
@@ -44,14 +72,12 @@ export class KrutrimModel implements IModel {
     const isReasoningModel = this.config.type === 'reasoning' || this.config.type === 'tool-calling';
 
     // Retry logic for transient errors (WAF/rate limiting/server errors)
-    const maxRetries = 3;
+    const maxRetries = 4;
     let lastError: Error | null = null;
 
     for (let attempt = 0; attempt <= maxRetries; attempt++) {
       if (attempt > 0) {
-        const waitTime = Math.pow(2, attempt) * 1000; // Exponential backoff: 2s, 4s, 8s
-        logger.warn(`Retrying after ${waitTime}ms (attempt ${attempt + 1}/${maxRetries + 1})...`);
-        await new Promise(resolve => setTimeout(resolve, waitTime));
+        await new Promise(resolve => setTimeout(resolve, this._lastRetryWait ?? 2000));
       }
 
       try {
@@ -61,9 +87,10 @@ export class KrutrimModel implements IModel {
 
         // Retry on transient errors: 403 (WAF), 429 (rate limit), 500/502/503/504 (server errors)
         if (error instanceof ModelError) {
+          const is429 = error.message.includes('(429)');
           const shouldRetry =
             error.message.includes('(403)') ||  // WAF blocking
-            error.message.includes('(429)') ||  // Rate limiting
+            is429 ||                            // Rate limiting
             error.message.includes('(500)') ||  // Internal server error
             error.message.includes('(502)') ||  // Bad gateway
             error.message.includes('(503)') ||  // Service unavailable
@@ -76,13 +103,26 @@ export class KrutrimModel implements IModel {
           // Log the error type for debugging
           let errorType = 'Unknown error';
           if (error.message.includes('(403)')) errorType = '403 Access Denied (WAF)';
-          else if (error.message.includes('(429)')) errorType = '429 Rate Limited';
+          else if (is429) errorType = '429 Rate Limited';
           else if (error.message.includes('(500)')) errorType = '500 Internal Server Error';
           else if (error.message.includes('(502)')) errorType = '502 Bad Gateway';
           else if (error.message.includes('(503)')) errorType = '503 Service Unavailable';
           else if (error.message.includes('(504)')) errorType = '504 Gateway Timeout';
 
-          logger.warn(`Got ${errorType}, will retry...`);
+          // For 429s, parse the actual retry-after time from the error message.
+          // Groq returns: "Please try again in 8.53s."
+          if (is429) {
+            const match = error.message.match(/try again in (\d+(?:\.\d+)?)\s*s/i);
+            const retryAfterMs = match ? Math.ceil(parseFloat(match[1]) * 1000) + 500 : null;
+            // Use parsed time, falling back to capped exponential backoff
+            const exponential = Math.min(Math.pow(2, attempt) * 1000, 30_000);
+            this._lastRetryWait = retryAfterMs ?? exponential;
+            logger.warn(`Got ${errorType}, will retry in ${(this._lastRetryWait / 1000).toFixed(1)}s (attempt ${attempt + 1}/${maxRetries + 1})...`);
+          } else {
+            const waitTime = Math.min(Math.pow(2, attempt) * 1000, 30_000);
+            this._lastRetryWait = waitTime;
+            logger.warn(`Got ${errorType}, will retry in ${waitTime / 1000}s (attempt ${attempt + 1}/${maxRetries + 1})...`);
+          }
         } else {
           throw error;
         }
@@ -91,6 +131,9 @@ export class KrutrimModel implements IModel {
 
     throw lastError!;
   }
+
+  /** Retry wait time in ms, set dynamically based on API hint or exponential backoff. */
+  private _lastRetryWait?: number;
 
   private async attemptChat(options: ChatCompletionOptions, isReasoningModel: boolean): Promise<ModelResponse> {
     try {
@@ -122,12 +165,25 @@ export class KrutrimModel implements IModel {
 
       // All OpenAI-compatible APIs support standard roles: system, user, assistant, tool
       // Convert 'developer' role to 'system' for API compatibility
-      const apiMessages = messages.map((msg: any) => {
+      const apiMessages: any[] = messages.map((msg: any) => {
         if (msg.role === 'developer') {
           return { ...msg, role: 'system' };
         }
         return msg;
       });
+
+      // ── Reasoning effort ────────────────────────────────────────────────────
+      // Per-call value takes precedence over model-level default.
+      const effort = options.reasoningEffort ?? this.config.defaultReasoningEffort;
+      const strategy = this.config.reasoningEffortStrategy ?? 'both';
+
+      // System-prompt injection: prepend "Reasoning: <level>" as the very first
+      // system message. gpt-oss-120b understands this on any provider — it's the
+      // official fallback for Krutrim/self-hosted endpoints that strip unknown
+      // request body params.
+      if (effort && isReasoningModel && (strategy === 'system_prompt' || strategy === 'both')) {
+        apiMessages.unshift({ role: 'system', content: `Reasoning: ${effort}` });
+      }
 
       const requestBody: any = {
         model: options.model || this.config.model,
@@ -138,6 +194,18 @@ export class KrutrimModel implements IModel {
       if (options.maxTokens) {
         requestBody.max_tokens = options.maxTokens;
       }
+
+      // API param: native Groq support; silently ignored by providers that don't implement it.
+      if (effort && isReasoningModel && (strategy === 'api_param' || strategy === 'both')) {
+        requestBody.reasoning_effort = effort;
+      }
+
+      // include_reasoning: request thinking tokens in the response (Groq-specific).
+      // When present, tokens appear in choice.message.reasoning and are logged below.
+      if (this.config.includeReasoning && isReasoningModel) {
+        requestBody.include_reasoning = true;
+      }
+      // ────────────────────────────────────────────────────────────────────────
 
       // Send tools in standard OpenAI format if not using Harmony
       if (!useHarmony && isReasoningModel && options.tools && options.tools.length > 0) {
@@ -203,6 +271,13 @@ export class KrutrimModel implements IModel {
 
       const choice = data.choices[0];
       const messageContent = choice.message?.content || '';
+
+      // Log reasoning tokens when include_reasoning=true (Groq returns them in
+      // choice.message.reasoning). Useful for debugging model "thinking" quality.
+      const reasoningTokens: string | undefined = choice.message?.reasoning;
+      if (reasoningTokens) {
+        logger.debug(`[Model reasoning] ${reasoningTokens.substring(0, 2000)}${reasoningTokens.length > 2000 ? '…' : ''}`);
+      }
 
       // Parse response based on format used
       if (useHarmony && isReasoningModel && options.tools && options.tools.length > 0) {
@@ -295,11 +370,12 @@ export class KrutrimModel implements IModel {
     try {
       logger.debug(`Testing connectivity to ${this.config.endpoint}...`);
 
-      // Simple test request with minimal tokens
+      // Simple test request with minimal tokens and low reasoning effort (it's just a ping)
       const testResponse = await this.chat({
         messages: [{ role: 'user', content: 'test' }],
         temperature: 0,
         maxTokens: 5,
+        reasoningEffort: 'low',
       });
 
       const latency = Date.now() - startTime;


### PR DESCRIPTION
# Release Notes — v0.3.4

**Released:** 2026-03-13

---

## Summary

v0.3.4 is a substantial release with improvements across both execution modes. The headline feature is **Code Mode** — a new single-loop execution engine for software engineering tasks. Alongside this, general mode has been streamlined by removing the Client validation agent (now **Manager + Worker only**), and both modes received a set of reliability and quality improvements.

---

## What's New

### Code Mode (`--code`)

Activate with `jiva chat --code` or `jiva run "..." --code`. The mode remains off by default; the existing general-purpose agent is unchanged.

**Why code mode?** The Manager/Worker architecture is designed for complex, multi-domain reasoning tasks. For pure coding work it adds unnecessary overhead (multiple LLM calls per turn, MCP subprocess round-trips for file I/O). Code mode removes that overhead without sacrificing any of Jiva's existing capabilities for non-coding sessions.

**Key properties:**
- Single model call per iteration — tool results inject directly back into the context window
- All file tools run in-process (no MCP subprocess for basic I/O)
- Up to 50 iterations per turn
- Two-phase iteration limit: 85% → "continue" nudge (tools kept); 95% → structured wrap-up message (tools stripped)
- Doom-loop detection: 3 identical tool calls in a row triggers a correction injection
- In-loop context compaction: when `promptTokens` approaches the model's context limit, conversation history is automatically summarised and replaced with a structured context message

### In-Process Tool Suite

Seven tools available in code mode, all running inside the Jiva process:

| Tool | Description |
|------|-------------|
| `read_file` | Reads files with line-number output (2000-line / 50 KB cap) and lists directories |
| `edit_file` | Multi-strategy string replacement (9 strategies) — handles indentation drift and whitespace inconsistencies |
| `write_file` | Creates or overwrites files; returns a line-count summary |
| `glob` | File pattern matching relative to the workspace root |
| `grep` | Recursive regex content search; returns file:line:content format |
| `bash` | Shell command execution in the workspace directory (30 s default, 300 s max; output truncated at 2000 lines / 50 KB) |
| `spawn_code_agent` | Delegates a focused sub-task to a child CodeAgent (max depth 2) |

### Multi-Strategy Edit Engine

The `edit_file` tool applies nine replacement strategies in order. Earlier strategies match exactly; later ones tolerate indentation and whitespace drift that is common when a model copies code from its context window with slight reformatting.

### LSP Integration

After each `edit_file` or `write_file` call, the agent notifies the appropriate language server and waits up to 3 seconds for diagnostics. Any errors are appended to the tool result before the model sees it — providing the same compiler feedback loop a developer has in an IDE.

Language servers are auto-detected from PATH. If no server is found for a file's language, the tool continues silently.

Supported out of the box: TypeScript, JavaScript, Python, Go, Rust, C, C++, and 60+ other languages via a static extension map.

### File Locking

A per-path async mutex (`FileLock`) serializes concurrent edits to the same file. This prevents interleaved writes when the model emits multiple tool calls for the same file in a single response.

### IAgent Interface

Both `DualAgent` and `CodeAgent` now implement a shared `IAgent` interface (`src/core/agent-interface.ts`). The CLI REPL, HTTP session manager, and chat routes are all agent-agnostic — they work with either mode without code changes.

### Cloud / HTTP Support

Code mode is available in cloud deployments by setting `JIVA_CODE_MODE=true`. The session manager creates `CodeAgent` instances instead of `DualAgent` when this variable is present.

---

### General Mode: Two-Agent System

The `DualAgent` class has been simplified from a three-agent (Manager + Worker + Client) to a **two-agent system (Manager + Worker)**. The Client validation agent has been removed.

**Why:** The Client agent added a full LLM call after every Worker subtask for validation and corrective strategy selection. In practice this increased latency without proportionately improving task completion — especially for the coding workflows where Code Mode is now available. The Manager already reviews Worker results during synthesis.

**Changes:**
- `ClientAgent` removed from the execution pipeline
- `applyCorrectionStrategy()` removed from `DualAgent`
- `CompletionSignal` no longer flows through the loop
- `maxIterations` default increased from 10 → 20 (compensates for removed Client retry budget)
- Conversational short-circuit: greetings and simple replies are answered by Manager directly, bypassing Worker subtask execution entirely

### reasoning_effort Support (gpt-oss-120b)

Added `reasoning_effort` support for Krutrim-hosted gpt-oss-120b via a dual strategy that works across both Krutrim and Groq:

1. **System prompt injection** — prepends `"Reasoning: <level>"` to the message array (always works; Krutrim may silently ignore the API parameter)
2. **API parameter** — sends `reasoning_effort` in the request body (supported natively by Groq; no-op if ignored)

Strategy is configurable (`api_param` | `system_prompt` | `both`); defaults to `both`.

```json
{
  "models": {
    "reasoning": {
      "defaultReasoningEffort": "high",
      "reasoningEffortStrategy": "both",
      "includeReasoning": false
    }
  }
}
```

CLI defaults: reasoning model → `"high"`, tool-calling model → `"medium"`. Connectivity tests use `"low"` to minimise token cost.

---

## Reliability Improvements

Four areas in Jiva's code mode have been identified and improved.

### Bash Output Truncation

`bash` tool output is now truncated at 2 000 lines and 50 KB before being returned to the model — the same limits as `read_file`. Previously the raw stdout/stderr (up to 10 MB) could be passed verbatim, filling the context window.

Truncation messages tell the model to redirect output to a file if it needs the full content.

### In-Loop Context Compaction

`CodeAgent` now tracks `response.usage.promptTokens` after each model call. When the token count exceeds `compactionThreshold` (default: 90 000 — safe for a 128 K context model), the in-flight message history is compressed:

1. The system prompt and the most recent 10 messages are kept intact.
2. The middle section is summarised by a separate model call using the structured compaction template (see below).
3. The summary replaces the middle section; the loop continues from the compacted context.

Compaction fires at most once per `chat()` turn to avoid thrashing.

### Structured Compaction Format

`ConversationManager.condenseConversation()` (used for cross-turn compaction and in-loop compaction) now uses a structured compaction format instead of a generic summary prompt:

```
## Goal
[What the user is trying to accomplish]

## Instructions
- [Important instructions still in scope]

## Discoveries
[Notable things learned during the conversation]

## Accomplished
[Work done / in progress / remaining]

## Relevant files / directories
[Files read, edited, or created — full paths]
```

This makes summaries actionable — a resumed session can immediately understand context and continue work.

### System Prompt — Persistence and Pre-Tool Narration

The `CodeAgent` system prompt now includes a **PERSISTENCE AND COMPLETION** section:

- *"Keep going until the user's query is completely resolved."*
- *"You MUST iterate and keep going until the problem is solved."*
- *"NEVER end your turn without having truly and completely solved the problem."*
- *"Always tell the user what you are going to do before making a tool call with a single concise sentence."*
- If the user says "resume / continue / try again", check conversation history and continue from the last incomplete step.
- Verify changes — run tests or the build after making changes when appropriate.

The 95% iteration wrap-up message explicitly prohibits tool calls and requires a structured summary with accomplished work, remaining tasks, and recommendations.

### edit_file Tool: Clearer Description and Targeted Error Recovery

Two improvements to prevent the common failure mode where gpt-oss-120b generates `edit_file` with `old_string` but no `new_string`:

1. **Improved description**: The tool description now opens with a **REQUIRED PARAMETERS** block listing all three required fields explicitly, with the note: *"Omitting new_string will fail with a validation error. new_string is never optional."*

2. **Specific correction message**: When the API rejects a call with `"missing properties: 'new_string'"`, the correction injection now names the missing field explicitly — instead of the previous generic message.

---

## Changes

### New Files

| File | Purpose |
|------|---------|
| `src/code/agent.ts` | `CodeAgent` — single-loop execution engine |
| `src/code/file-lock.ts` | Per-path async mutex |
| `src/code/tools/index.ts` | `ICodeTool` interface and tool registry |
| `src/code/tools/read.ts` | `read_file` / `list_directory` |
| `src/code/tools/edit.ts` | `edit_file` with 9-strategy replacement |
| `src/code/tools/write.ts` | `write_file` |
| `src/code/tools/glob.ts` | `glob` |
| `src/code/tools/grep.ts` | `grep` |
| `src/code/tools/bash.ts` | `bash` with output truncation |
| `src/code/tools/spawn.ts` | `spawn_code_agent` |
| `src/code/lsp/language.ts` | Extension → language ID map (60+ extensions) |
| `src/code/lsp/server.ts` | Spawn language server from PATH |
| `src/code/lsp/client.ts` | JSON-RPC LSP client (vscode-jsonrpc) |
| `src/code/lsp/manager.ts` | `LspManager` — lazy init, one client per language |
| `src/core/agent-interface.ts` | Shared `IAgent` / `AgentChatResponse` types |
| `docs/architecture/CODE_MODE.md` | Architecture reference for code mode |

### Modified Files

| File | Change |
|------|--------|
| `src/core/dual-agent.ts` | Removed `ClientAgent`; two-agent system; `maxIterations` default 10 → 20; conversational short-circuit |
| `src/core/manager-agent.ts` | Conversational short-circuit support (`directReply()`); improved synthesis prompts |
| `src/core/worker-agent.ts` | Adjusted to operate without Client validation layer |
| `src/core/config.ts` | Added `codeMode` config schema (`enabled`, `lsp.enabled`, `maxIterations`) |
| `src/core/conversation-manager.ts` | `condenseConversation()` now uses structured compaction format |
| `src/index.ts` | Exports `CodeAgent`, `LspManager`, `IAgent`, `AgentChatResponse` |
| `src/interfaces/cli/index.ts` | Added `--code` and `--no-lsp` flags; `reasoning_effort` defaults; `process.exit(0)` after REPL exits |
| `src/interfaces/cli/repl.ts` | Re-exports `IAgent` from core; parameters typed as `IAgent` |
| `src/interfaces/http/session-manager.ts` | Supports `JIVA_CODE_MODE=true` env var; `ActiveSession.agent` typed as `IAgent`; `reasoning_effort` defaults |
| `src/interfaces/http/routes/chat.ts` | `plan` field is now optional in responses (absent for CodeAgent) |
| `src/models/base.ts` | Added `reasoningEffort?: 'low' \| 'medium' \| 'high'` to `ChatCompletionOptions` |
| `src/models/krutrim.ts` | `reasoning_effort` dual-strategy (system prompt + API param); rate-limit backoff parses actual retry-after time |
| `src/models/harmony.ts` | `formatMessagesForHarmony` correctly converts `role: 'tool'` to user-role messages (fixes HTTP mode bug) |

### Bug Fixes

- **HTTP mode tool results**: `role: 'tool'` messages were forwarded to Groq without a `tools` array in HTTP mode. Fixed in `formatMessagesForHarmony` — they are now converted to user-role `<tool_result>` messages as Harmony requires.
- **Rate limit backoff**: Previously used fixed exponential backoff. Now parses the actual retry-after duration from Groq error messages and waits accordingly.
- **`/exit` hangs in code mode**: LSP child-process streams kept the Node.js event loop alive after cleanup. Fixed by calling `process.exit(0)` after `agent.cleanup()` returns.
- **`edit_file` missing `new_string`**: Targeted correction message now names the missing field explicitly instead of using a generic error message.

---

## Configuration Reference

### CLI Flags

```bash
jiva chat --code          # activate code mode
jiva chat --no-lsp        # disable LSP in code mode (also: --code --no-lsp)
```

### Config File

```json
{
  "codeMode": {
    "enabled": true,
    "lsp": { "enabled": true },
    "maxIterations": 50
  },
  "models": {
    "reasoning": {
      "defaultReasoningEffort": "high",
      "reasoningEffortStrategy": "both"
    }
  }
}
```

### Environment Variables (cloud deployments)

```bash
JIVA_CODE_MODE=true       # activate code mode
JIVA_CODE_LSP=false       # disable LSP
```

---

## Further Reading

- [Code Mode Architecture](../architecture/CODE_MODE.md) — full reference including tool parameters, LSP setup, and the edit strategy pipeline
- [Configuration Guide](../guides/CONFIGURATION.md) — code mode config options and LSP server installation
- [Cloud Run Deployment](../deployment/CLOUD_RUN_DEPLOYMENT.md) — using code mode in production
