### PR TITLE
v0.3.41

### DIFF
--- a/docs/release_notes/v0.3.41.md
+++ b/docs/release_notes/v0.3.41.md
@@ -1,12 +1,12 @@
-# Release Notes — v0.3.4
+# Release Notes — v0.3.41
 
-**Released:** 2026-03-13
+**Released:** 2026-03-14
 
 ---
 
 ## Summary
 
-v0.3.4 is a substantial release with improvements across both execution modes. The headline feature is **Code Mode** — a new single-loop execution engine for software engineering tasks. Alongside this, general mode has been streamlined by removing the Client validation agent (now **Manager + Worker only**), and both modes received a set of reliability and quality improvements.
+v0.3.41 is a substantial release with improvements across both execution modes. The headline feature is **Code Mode** — a new single-loop execution engine for software engineering tasks. Alongside this, general mode has been streamlined by removing the Client validation agent (now **Manager + Worker only**), and both modes received a set of reliability and quality improvements.
 
 ---
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jiva-core",
-  "version": "0.3.4",
+  "version": "0.3.41",
   "description": "Versatile autonomous AI agent with three-agent architecture (Manager, Worker, Client) powered by gpt-oss-120b. Adaptive validation, full MCP support, and intelligent quality control.",
   "main": "dist/index.js",
   "bin": {

--- a/src/code/agent.ts
+++ b/src/code/agent.ts
@@ -100,6 +100,8 @@ export interface CodeAgentConfig {
 
 const DEFAULT_MAX_ITERATIONS = 50;
 const DOOM_LOOP_THRESHOLD = 3;
+/** Max consecutive read_file calls before injecting an "act, don't just read" nudge. */
+const MAX_CONSECUTIVE_READS = 5;
 const CODE_MODE_INDICATOR = '[CODE MODE]';
 // Default token threshold for in-loop compaction (90K leaves ~38K headroom in a 128K model)
 const DEFAULT_COMPACTION_THRESHOLD = 90_000;
@@ -123,35 +125,41 @@ PERSISTENCE AND COMPLETION:
 - Verify your changes are correct — run tests or the build after making changes when appropriate.
 
 TOOLS AVAILABLE:
-- read_file: Read files or list directories. Always read before editing.
-- edit_file: Replace a specific string in a file (use old_string/new_string). Preferred for partial changes.
-- write_file: Create new files or completely rewrite existing ones.
-- glob: Find files matching a pattern (e.g. "**/*.ts").
-- grep: Search file contents with regex.
+- read_file: Read an existing file or list a directory. Only needed before editing an existing file.
+- edit_file: Replace a specific string in an existing file (old_string → new_string). For partial changes.
+- write_file: Create a new file or fully overwrite an existing one. Use this to create files from scratch.
+- glob: Find files matching a pattern (e.g. "**/*.ts"). Only when you need to locate existing files.
+- grep: Search existing file contents with regex. Only when you need to find something in existing code.
 - bash: Run shell commands (build, test, lint, git operations).
 - spawn_code_agent: Delegate a focused sub-task to a child agent.
 
-CODING PRINCIPLES:
-1. ALWAYS read a file before editing it — never edit blindly.
-2. Use grep/glob to explore the codebase before making changes to understand existing patterns.
-3. Make minimal, targeted changes — edit the exact lines that need changing.
-4. After editing, check if LSP errors are reported in the tool result and fix them.
-5. Verify your changes work by running tests or the build when appropriate.
-6. Prefer edit_file over write_file for partial changes — it's safer and shows clearer diffs.
-7. Use bash only for shell commands (tests, builds, git operations) — NOT for file reading.
+CODING PRINCIPLES — READ CAREFULLY:
+1. CREATING A NEW FILE → use write_file immediately. Do NOT read or explore first.
+2. EDITING AN EXISTING FILE → read it first with read_file, then edit_file for targeted changes.
+3. Only use glob/grep when you genuinely need to locate or understand existing code.
+4. Make minimal, targeted changes — edit the exact lines that need changing.
+5. After editing, check LSP errors in the tool result and fix them.
+6. Verify your changes work by running tests or the build when appropriate.
+7. Use bash only for shell commands (tests, builds, git) — NOT for reading files.
+8. LARGE FILES (100+ lines): write in stages — never try to generate a complete large file in one call.
+   - Stage 1: write_file with the skeleton/structure only (HTML tags, empty <style>, empty <script>)
+   - Stage 2: edit_file to add CSS content into the <style> block
+   - Stage 3: edit_file to add JS content into the <script> block
+   - Each individual call must be short enough to fit in one model response.
 
-TOOL SELECTION RULES (follow these exactly):
-- To READ a file → use read_file, NOT bash
-- To LIST directory contents → use read_file on the directory path, NOT bash ls
-- To FIND files by name/pattern → use glob, NOT bash find
-- To SEARCH file contents → use grep, NOT bash grep/rg
-- To RUN a command (build/test/git) → use bash
+TOOL SELECTION RULES (follow exactly):
+- To CREATE a new file → write_file immediately (no reads needed first)
+- To READ an existing file → read_file (not bash)
+- To LIST directory contents → read_file on the directory path (not bash ls)
+- To FIND files by pattern → glob (not bash find)
+- To SEARCH file contents → grep (not bash grep/rg)
+- To RUN commands (build/test/git) → bash
 
-WHEN EXPLORING:
-- Use glob to find files by pattern before assuming file paths.
-- Use grep to find where functions/classes/variables are defined or used.
-- Read the relevant files to understand context before changing anything.
-- Do NOT use bash for exploration tasks that glob/grep/read_file can handle.`;
+WHEN TO EXPLORE (only when actually needed):
+- You are modifying existing code and need to understand its structure first.
+- You need to find where a function, class, or variable is defined.
+- You are debugging or tracing code through multiple files.
+- Do NOT explore before creating brand-new files — just write them directly.`;
 
   if (directive) {
     return `${base}\n\n${directive}`;
@@ -346,6 +354,13 @@ ${directive ? `\n${directive}` : ''}`;
     // Track consecutive API errors to avoid infinite error loops
     let consecutiveApiErrors = 0;
     const MAX_CONSECUTIVE_API_ERRORS = 3;
+    // Track empty responses (no tool calls, no content) so we can inject a recovery nudge.
+    // Allow up to 4 retries — Krutrim/Groq can return blank responses transiently and the
+    // model usually recovers within 2-3 nudges.
+    let emptyResponseCount = 0;
+    const MAX_EMPTY_RESPONSES = 4;
+    // Track consecutive read_file calls — model can get stuck re-reading without making changes
+    let consecutiveReadCount = 0;
 
     let iterations = 0;
     let finalContent = '';
@@ -425,6 +440,15 @@ ${directive ? `\n${directive}` : ''}`;
         const isValidationFailed = msg.includes('Tool call validation failed') || msg.includes('did not match schema');
 
         if (isToolUseFailed || isValidationFailed) {
+          // Conversation turn guard: for API-rejected calls (e.g. 400 tool_use_failed), the
+          // model's assistant turn was never recorded. Injecting a user correction directly
+          // would create an invalid user→user sequence. Add an empty assistant placeholder
+          // so the structure is user→assistant→user before the correction lands.
+          const lastMsg = messages[messages.length - 1];
+          if (lastMsg && lastMsg.role !== 'assistant') {
+            messages.push({ role: 'assistant', content: '' });
+          }
+
           // --- Specific correction: edit_file missing new_string ---
           // gpt-oss-120b sometimes generates edit_file with old_string but forgets new_string.
           // The generic message doesn't help — we need to name the missing field explicitly.
@@ -448,6 +472,55 @@ ${directive ? `\n${directive}` : ''}`;
                 'new_string must contain the complete replacement for old_string.',
             });
             consecutiveApiErrors = 0;
+            emptyResponseCount = 0; // fresh recovery budget after targeted guidance
+            continue;
+          }
+
+          // --- Specific correction: tool content too large (output token limit hit) ---
+          // When the model generates a very large write_file or edit_file call, the API cuts off
+          // the JSON mid-content because the response exceeds the output token limit. The resulting
+          // JSON is unparseable. Detect by tool name appearing in the failed_generation field.
+          // Note: failed_generation is a JSON-encoded string so quotes are escaped (\"tool_name\").
+          const isContentTooLarge =
+            (msg.includes('write_file') || msg.includes('edit_file')) &&
+            (msg.includes('Failed to parse tool call') || msg.includes('tool_use_failed'));
+
+          if (isContentTooLarge) {
+            // Parse the actual tool name from failed_generation to distinguish write_file vs edit_file
+            let failedToolName = msg.includes('edit_file') && !msg.includes('write_file') ? 'edit_file' : 'write_file';
+            let targetFile = '';
+            try {
+              const jsonMatch = msg.match(/API error \(\d+\): (.+)/s);
+              if (jsonMatch) {
+                const errorBody = JSON.parse(jsonMatch[1]);
+                const failedGen: string | undefined = errorBody?.error?.failed_generation;
+                if (failedGen) {
+                  const parsed = JSON.parse(failedGen);
+                  if (parsed?.name) failedToolName = parsed.name; // authoritative source
+                  const fp = parsed?.arguments?.file_path;
+                  if (fp) targetFile = ` for \`${fp}\``;
+                }
+              }
+            } catch { /* ignore extraction errors */ }
+            const isEditFile = failedToolName === 'edit_file';
+
+            logger.warn(`[CodeAgent] ${isEditFile ? 'edit_file' : 'write_file'}${targetFile} content truncated (exceeded output token limit) — asking model to write in stages`);
+            const correctionContent = isEditFile
+              ? `Your edit_file call${targetFile} failed: new_string was too large and the response was cut off mid-JSON.\n\n` +
+                `MAXIMUM 20 LINES per edit_file call. Write one tiny chunk at a time:\n` +
+                `  - For JavaScript: add just ONE or TWO functions per call\n` +
+                `  - For HTML: add just one row of buttons per call\n\n` +
+                `Call edit_file now with a new_string of at most 20 lines.`
+              : `Your write_file call${targetFile} failed: the file content was too large and was cut off mid-JSON.\n\n` +
+                `Write the file in stages — NEVER put CSS or JavaScript in the initial write_file:\n` +
+                `  Stage 1: write_file — HTML skeleton ONLY (empty <style></style> and empty <script></script>) — MAX 20 lines\n` +
+                `  Stage 2: edit_file — add CSS (max 20 lines at a time)\n` +
+                `  Stage 3: edit_file — add JavaScript ONE function at a time\n\n` +
+                `Start with Stage 1 NOW: write_file with just the bare HTML skeleton (20 lines max).`;
+
+            messages.push({ role: 'user', content: correctionContent });
+            consecutiveApiErrors = 0;
+            emptyResponseCount = 0; // reset so model has fresh recovery budget for staged CSS/JS edits
             continue;
           }
 
@@ -507,14 +580,26 @@ ${directive ? `\n${directive}` : ''}`;
         break;
       }
 
-      // Add assistant response to messages.
-      // In Harmony mode the raw response (with <|call|> tokens) is stored so the model sees its
-      // prior tool calls in the next turn. In standard mode, just the content is stored.
+      // Add assistant response to messages, preserving the full structure needed for the next turn.
+      //
+      // Three cases:
+      //   1. Harmony mode: store rawHarmony string (contains <|call|> tokens the model needs).
+      //   2. Standard tool-calling with tool calls: store content + tool_calls so subsequent
+      //      role:'tool' results can be matched by tool_call_id (required by OpenAI-compatible APIs).
+      //   3. Text-only response: store content as-is.
       const rawHarmony: string | undefined = (response as any).raw?.parsedHarmony?.rawResponse;
-      messages.push({
-        role: 'assistant',
-        content: rawHarmony ?? response.content,
-      });
+      if (rawHarmony) {
+        messages.push({ role: 'assistant', content: rawHarmony });
+      } else if (response.toolCalls && response.toolCalls.length > 0) {
+        // Preserve tool_calls so tool results are properly matched in the next turn
+        messages.push({
+          role: 'assistant',
+          content: response.content || null,
+          tool_calls: response.toolCalls,
+        });
+      } else {
+        messages.push({ role: 'assistant', content: response.content });
+      }
 
       // Stream the visible (final-channel) text output if callback provided
       if (response.content && onChunk) {
@@ -550,8 +635,36 @@ ${directive ? `\n${directive}` : ''}`;
       }
       // ────────────────────────────────────────────────────────────────────────
 
-      // No tool calls → final response
+      // No tool calls → model is done (or gave up)
       if (!response.toolCalls || response.toolCalls.length === 0) {
+        if (!response.content && emptyResponseCount < MAX_EMPTY_RESPONSES) {
+          // Model returned empty content with no tool calls — it got stuck or confused.
+          // Inject an escalating recovery nudge and let it try again.
+          emptyResponseCount++;
+          logger.warn(
+            `[CodeAgent] Empty response with no tool calls (${emptyResponseCount}/${MAX_EMPTY_RESPONSES}) — injecting recovery nudge`,
+          );
+
+          // Escalate urgency with each retry so the model doesn't keep ignoring it
+          let nudgeContent: string;
+          if (emptyResponseCount <= 2) {
+            nudgeContent =
+              'Your last response was empty. Please continue working on the task.\n\n' +
+              '- If you need to CREATE a file → call write_file now.\n' +
+              '- If you need to EDIT a file → call read_file then edit_file.\n' +
+              '- If the task is already complete → provide a brief summary of what was done.';
+          } else {
+            nudgeContent =
+              `IMPORTANT (attempt ${emptyResponseCount}/${MAX_EMPTY_RESPONSES}): Your response is empty again — you have not called any tools.\n\n` +
+              `You MUST call a tool NOW. Do not output plain text without a tool call.\n` +
+              `  • To CREATE a new file → call write_file immediately with the file content.\n` +
+              `  • To EDIT an existing file → call edit_file with old_string and new_string.\n` +
+              `  • To LIST files → call read_file on the directory.\n\n` +
+              `Make a tool call in your very next response. Do not explain — just call the tool.`;
+          }
+          messages.push({ role: 'user', content: nudgeContent });
+          continue;
+        }
         finalContent = response.content || '[No response content]';
         break;
       }
@@ -564,6 +677,13 @@ ${directive ? `\n${directive}` : ''}`;
           toolArgs = JSON.parse(toolCall.function.arguments);
         } catch {
           // malformed args
+        }
+
+        // Consecutive reads tracker — any non-read tool resets the streak
+        if (toolName === 'read_file') {
+          consecutiveReadCount++;
+        } else {
+          consecutiveReadCount = 0;
         }
 
         // Doom loop check
@@ -625,6 +745,32 @@ ${directive ? `\n${directive}` : ''}`;
         // Add tool result to messages (using Harmony format helper)
         const toolMessage = formatToolResult(toolCall.id, toolName, toolResult);
         messages.push(toolMessage);
+
+        // Reset empty response budget after any productive (mutating) tool call.
+        // This gives the model a fresh set of recovery nudges for each new work phase
+        // (e.g., after writing the skeleton, it gets 4 more chances to add CSS/JS).
+        if (toolName === 'write_file' || toolName === 'edit_file' || toolName === 'bash') {
+          emptyResponseCount = 0;
+        }
+
+        // Excessive reads nudge — model is re-reading without making any changes.
+        // Fires after MAX_CONSECUTIVE_READS consecutive read_file calls; resets the count
+        // so the model gets a fresh budget after each nudge (prevents spamming).
+        if (consecutiveReadCount >= MAX_CONSECUTIVE_READS) {
+          logger.warn(`[CodeAgent] ${consecutiveReadCount} consecutive read_file calls without edits — nudging model to act`);
+          consecutiveReadCount = 0;
+          messages.push({
+            role: 'user',
+            content:
+              `You have called read_file ${MAX_CONSECUTIVE_READS}+ times in a row without making any changes.\n\n` +
+              `STOP READING — you have enough context. Make a concrete change NOW:\n` +
+              `  • To ADD or CHANGE content in an existing file → call edit_file with old_string and new_string\n` +
+              `  • To CREATE a new file → call write_file\n` +
+              `  • If the task is fully complete → provide a final summary (no more tool calls needed)\n\n` +
+              `Do NOT call read_file again until you have made at least one edit_file or write_file call.`,
+          });
+          break; // exit inner tool loop — model sees the nudge on the next outer iteration
+        }
       }
     }
 

--- a/src/core/utils/serialize-agent-context.ts
+++ b/src/core/utils/serialize-agent-context.ts
@@ -40,7 +40,9 @@ function serializeMessage(msg: Message): string {
   const role = msg.role.toUpperCase();
   const content = typeof msg.content === 'string'
     ? msg.content
-    : msg.content.map(c => c.text || '[image]').join(' ');
+    : msg.content
+      ? msg.content.map(c => c.text || '[image]').join(' ')
+      : '[tool call]';
   return `[${role}]: ${content}`;
 }
 

--- a/src/models/base.ts
+++ b/src/models/base.ts
@@ -4,9 +4,16 @@
 
 export interface Message {
   role: 'system' | 'developer' | 'user' | 'assistant' | 'tool';
-  content: string | MessageContent[];
+  /** Text content. May be null/empty when the message contains only tool_calls. */
+  content: string | MessageContent[] | null;
   name?: string;
   tool_call_id?: string;
+  /**
+   * Standard OpenAI tool call array. Present on assistant messages in standard
+   * (non-Harmony) tool-calling mode. Must be preserved in the message history so
+   * subsequent role:'tool' results can be matched by tool_call_id.
+   */
+  tool_calls?: ToolCall[];
 }
 
 export interface MessageContent {


### PR DESCRIPTION
# Release Notes — v0.3.41

**Released:** 2026-03-14

---

## Summary

v0.3.41 is a substantial release with improvements across both execution modes. The headline feature is **Code Mode** — a new single-loop execution engine for software engineering tasks. Alongside this, general mode has been streamlined by removing the Client validation agent (now **Manager + Worker only**), and both modes received a set of reliability and quality improvements.

---

## What's New

### Code Mode (`--code`)

Activate with `jiva chat --code` or `jiva run "..." --code`. The mode remains off by default; the existing general-purpose agent is unchanged.

**Why code mode?** The Manager/Worker architecture is designed for complex, multi-domain reasoning tasks. For pure coding work it adds unnecessary overhead (multiple LLM calls per turn, MCP subprocess round-trips for file I/O). Code mode removes that overhead without sacrificing any of Jiva's existing capabilities for non-coding sessions.

**Key properties:**
- Single model call per iteration — tool results inject directly back into the context window
- All file tools run in-process (no MCP subprocess for basic I/O)
- Up to 50 iterations per turn
- Two-phase iteration limit: 85% → "continue" nudge (tools kept); 95% → structured wrap-up message (tools stripped)
- Doom-loop detection: 3 identical tool calls in a row triggers a correction injection
- In-loop context compaction: when `promptTokens` approaches the model's context limit, conversation history is automatically summarised and replaced with a structured context message

### In-Process Tool Suite

Seven tools available in code mode, all running inside the Jiva process:

| Tool | Description |
|------|-------------|
| `read_file` | Reads files with line-number output (2000-line / 50 KB cap) and lists directories |
| `edit_file` | Multi-strategy string replacement (9 strategies) — handles indentation drift and whitespace inconsistencies |
| `write_file` | Creates or overwrites files; returns a line-count summary |
| `glob` | File pattern matching relative to the workspace root |
| `grep` | Recursive regex content search; returns file:line:content format |
| `bash` | Shell command execution in the workspace directory (30 s default, 300 s max; output truncated at 2000 lines / 50 KB) |
| `spawn_code_agent` | Delegates a focused sub-task to a child CodeAgent (max depth 2) |

### Multi-Strategy Edit Engine

The `edit_file` tool applies nine replacement strategies in order. Earlier strategies match exactly; later ones tolerate indentation and whitespace drift that is common when a model copies code from its context window with slight reformatting.

### LSP Integration

After each `edit_file` or `write_file` call, the agent notifies the appropriate language server and waits up to 3 seconds for diagnostics. Any errors are appended to the tool result before the model sees it — providing the same compiler feedback loop a developer has in an IDE.

Language servers are auto-detected from PATH. If no server is found for a file's language, the tool continues silently.

Supported out of the box: TypeScript, JavaScript, Python, Go, Rust, C, C++, and 60+ other languages via a static extension map.

### File Locking

A per-path async mutex (`FileLock`) serializes concurrent edits to the same file. This prevents interleaved writes when the model emits multiple tool calls for the same file in a single response.

### IAgent Interface

Both `DualAgent` and `CodeAgent` now implement a shared `IAgent` interface (`src/core/agent-interface.ts`). The CLI REPL, HTTP session manager, and chat routes are all agent-agnostic — they work with either mode without code changes.

### Cloud / HTTP Support

Code mode is available in cloud deployments by setting `JIVA_CODE_MODE=true`. The session manager creates `CodeAgent` instances instead of `DualAgent` when this variable is present.

---

### General Mode: Two-Agent System

The `DualAgent` class has been simplified from a three-agent (Manager + Worker + Client) to a **two-agent system (Manager + Worker)**. The Client validation agent has been removed.

**Why:** The Client agent added a full LLM call after every Worker subtask for validation and corrective strategy selection. In practice this increased latency without proportionately improving task completion — especially for the coding workflows where Code Mode is now available. The Manager already reviews Worker results during synthesis.

**Changes:**
- `ClientAgent` removed from the execution pipeline
- `applyCorrectionStrategy()` removed from `DualAgent`
- `CompletionSignal` no longer flows through the loop
- `maxIterations` default increased from 10 → 20 (compensates for removed Client retry budget)
- Conversational short-circuit: greetings and simple replies are answered by Manager directly, bypassing Worker subtask execution entirely

### reasoning_effort Support (gpt-oss-120b)

Added `reasoning_effort` support for Krutrim-hosted gpt-oss-120b via a dual strategy that works across both Krutrim and Groq:

1. **System prompt injection** — prepends `"Reasoning: <level>"` to the message array (always works; Krutrim may silently ignore the API parameter)
2. **API parameter** — sends `reasoning_effort` in the request body (supported natively by Groq; no-op if ignored)

Strategy is configurable (`api_param` | `system_prompt` | `both`); defaults to `both`.

```json
{
  "models": {
    "reasoning": {
      "defaultReasoningEffort": "high",
      "reasoningEffortStrategy": "both",
      "includeReasoning": false
    }
  }
}
```

CLI defaults: reasoning model → `"high"`, tool-calling model → `"medium"`. Connectivity tests use `"low"` to minimise token cost.

---

## Reliability Improvements

Four areas in Jiva's code mode have been identified and improved.

### Bash Output Truncation

`bash` tool output is now truncated at 2 000 lines and 50 KB before being returned to the model — the same limits as `read_file`. Previously the raw stdout/stderr (up to 10 MB) could be passed verbatim, filling the context window.

Truncation messages tell the model to redirect output to a file if it needs the full content.

### In-Loop Context Compaction

`CodeAgent` now tracks `response.usage.promptTokens` after each model call. When the token count exceeds `compactionThreshold` (default: 90 000 — safe for a 128 K context model), the in-flight message history is compressed:

1. The system prompt and the most recent 10 messages are kept intact.
2. The middle section is summarised by a separate model call using the structured compaction template (see below).
3. The summary replaces the middle section; the loop continues from the compacted context.

Compaction fires at most once per `chat()` turn to avoid thrashing.

### Structured Compaction Format

`ConversationManager.condenseConversation()` (used for cross-turn compaction and in-loop compaction) now uses a structured compaction format instead of a generic summary prompt:

```
## Goal
[What the user is trying to accomplish]

## Instructions
- [Important instructions still in scope]

## Discoveries
[Notable things learned during the conversation]

## Accomplished
[Work done / in progress / remaining]

## Relevant files / directories
[Files read, edited, or created — full paths]
```

This makes summaries actionable — a resumed session can immediately understand context and continue work.

### System Prompt — Persistence and Pre-Tool Narration

The `CodeAgent` system prompt now includes a **PERSISTENCE AND COMPLETION** section:

- *"Keep going until the user's query is completely resolved."*
- *"You MUST iterate and keep going until the problem is solved."*
- *"NEVER end your turn without having truly and completely solved the problem."*
- *"Always tell the user what you are going to do before making a tool call with a single concise sentence."*
- If the user says "resume / continue / try again", check conversation history and continue from the last incomplete step.
- Verify changes — run tests or the build after making changes when appropriate.

The 95% iteration wrap-up message explicitly prohibits tool calls and requires a structured summary with accomplished work, remaining tasks, and recommendations.

### edit_file Tool: Clearer Description and Targeted Error Recovery

Two improvements to prevent the common failure mode where gpt-oss-120b generates `edit_file` with `old_string` but no `new_string`:

1. **Improved description**: The tool description now opens with a **REQUIRED PARAMETERS** block listing all three required fields explicitly, with the note: *"Omitting new_string will fail with a validation error. new_string is never optional."*

2. **Specific correction message**: When the API rejects a call with `"missing properties: 'new_string'"`, the correction injection now names the missing field explicitly — instead of the previous generic message.

---

## Changes

### New Files

| File | Purpose |
|------|---------|
| `src/code/agent.ts` | `CodeAgent` — single-loop execution engine |
| `src/code/file-lock.ts` | Per-path async mutex |
| `src/code/tools/index.ts` | `ICodeTool` interface and tool registry |
| `src/code/tools/read.ts` | `read_file` / `list_directory` |
| `src/code/tools/edit.ts` | `edit_file` with 9-strategy replacement |
| `src/code/tools/write.ts` | `write_file` |
| `src/code/tools/glob.ts` | `glob` |
| `src/code/tools/grep.ts` | `grep` |
| `src/code/tools/bash.ts` | `bash` with output truncation |
| `src/code/tools/spawn.ts` | `spawn_code_agent` |
| `src/code/lsp/language.ts` | Extension → language ID map (60+ extensions) |
| `src/code/lsp/server.ts` | Spawn language server from PATH |
| `src/code/lsp/client.ts` | JSON-RPC LSP client (vscode-jsonrpc) |
| `src/code/lsp/manager.ts` | `LspManager` — lazy init, one client per language |
| `src/core/agent-interface.ts` | Shared `IAgent` / `AgentChatResponse` types |
| `docs/architecture/CODE_MODE.md` | Architecture reference for code mode |

### Modified Files

| File | Change |
|------|--------|
| `src/core/dual-agent.ts` | Removed `ClientAgent`; two-agent system; `maxIterations` default 10 → 20; conversational short-circuit |
| `src/core/manager-agent.ts` | Conversational short-circuit support (`directReply()`); improved synthesis prompts |
| `src/core/worker-agent.ts` | Adjusted to operate without Client validation layer |
| `src/core/config.ts` | Added `codeMode` config schema (`enabled`, `lsp.enabled`, `maxIterations`) |
| `src/core/conversation-manager.ts` | `condenseConversation()` now uses structured compaction format |
| `src/index.ts` | Exports `CodeAgent`, `LspManager`, `IAgent`, `AgentChatResponse` |
| `src/interfaces/cli/index.ts` | Added `--code` and `--no-lsp` flags; `reasoning_effort` defaults; `process.exit(0)` after REPL exits |
| `src/interfaces/cli/repl.ts` | Re-exports `IAgent` from core; parameters typed as `IAgent` |
| `src/interfaces/http/session-manager.ts` | Supports `JIVA_CODE_MODE=true` env var; `ActiveSession.agent` typed as `IAgent`; `reasoning_effort` defaults |
| `src/interfaces/http/routes/chat.ts` | `plan` field is now optional in responses (absent for CodeAgent) |
| `src/models/base.ts` | Added `reasoningEffort?: 'low' \| 'medium' \| 'high'` to `ChatCompletionOptions` |
| `src/models/krutrim.ts` | `reasoning_effort` dual-strategy (system prompt + API param); rate-limit backoff parses actual retry-after time |
| `src/models/harmony.ts` | `formatMessagesForHarmony` correctly converts `role: 'tool'` to user-role messages (fixes HTTP mode bug) |

### Bug Fixes

- **HTTP mode tool results**: `role: 'tool'` messages were forwarded to Groq without a `tools` array in HTTP mode. Fixed in `formatMessagesForHarmony` — they are now converted to user-role `<tool_result>` messages as Harmony requires.
- **Rate limit backoff**: Previously used fixed exponential backoff. Now parses the actual retry-after duration from Groq error messages and waits accordingly.
- **`/exit` hangs in code mode**: LSP child-process streams kept the Node.js event loop alive after cleanup. Fixed by calling `process.exit(0)` after `agent.cleanup()` returns.
- **`edit_file` missing `new_string`**: Targeted correction message now names the missing field explicitly instead of using a generic error message.

---

## Configuration Reference

### CLI Flags

```bash
jiva chat --code          # activate code mode
jiva chat --no-lsp        # disable LSP in code mode (also: --code --no-lsp)
```

### Config File

```json
{
  "codeMode": {
    "enabled": true,
    "lsp": { "enabled": true },
    "maxIterations": 50
  },
  "models": {
    "reasoning": {
      "defaultReasoningEffort": "high",
      "reasoningEffortStrategy": "both"
    }
  }
}
```

### Environment Variables (cloud deployments)

```bash
JIVA_CODE_MODE=true       # activate code mode
JIVA_CODE_LSP=false       # disable LSP
```

---

## Further Reading

- [Code Mode Architecture](../architecture/CODE_MODE.md) — full reference including tool parameters, LSP setup, and the edit strategy pipeline
- [Configuration Guide](../guides/CONFIGURATION.md) — code mode config options and LSP server installation
- [Cloud Run Deployment](../deployment/CLOUD_RUN_DEPLOYMENT.md) — using code mode in production
