### PR TITLE
v0.3.47

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,8 +22,8 @@ FROM node:20-alpine
 
 WORKDIR /app
 
-# Install dumb-init for proper signal handling
-RUN apk add --no-cache dumb-init
+# Install dumb-init and bash (bash required by zx in @mkusaka/mcp-shell-server)
+RUN apk add --no-cache dumb-init bash
 
 # Copy package files
 COPY package*.json ./
@@ -50,7 +50,7 @@ USER nodejs
 ENV NODE_ENV=production \
     PORT=8080 \
     LOG_LEVEL=info \
-    JIVA_STORAGE_PROVIDER=gcp \
+    JIVA_STORAGE_PROVIDER=gcp-bucket \
     MAX_CONCURRENT_SESSIONS=100 \
     SESSION_IDLE_TIMEOUT_MS=1800000
 

--- a/cloud-run-deploy.yaml
+++ b/cloud-run-deploy.yaml
@@ -58,7 +58,7 @@ spec:
         
         # Storage configuration
         - name: JIVA_STORAGE_PROVIDER
-          value: "gcp"
+          value: "gcp-bucket"
         - name: JIVA_GCP_BUCKET
           value: "jiva-state-gritsa-technologies"
         - name: JIVA_GCP_PROJECT

--- a/docs/release_notes/v0.3.47.md
+++ b/docs/release_notes/v0.3.47.md
@@ -1,0 +1,127 @@
+# Jiva v0.3.47 — Multimodal, Harmony, and Vertex AI Fixes
+
+**Release Date:** May 19, 2026
+
+---
+
+## Summary
+
+This release fixes a set of bugs that blocked or corrupted multimodal image analysis, Harmony-format tool-call sequences on Vertex AI MaaS, and model client construction. It also introduces Google Application Default Credentials (ADC) support so Vertex AI MaaS deployments on Cloud Run no longer require a static API key.
+
+---
+
+## Bug Fixes
+
+### 1. Groq 400 error on multimodal image requests
+
+**Symptom:** Asking the agent to analyse an image file (e.g. via `filesystem__read_media_file`) produced a cascade of identical `400` errors from the Groq API:
+
+```
+body.messages.5.tool.content : String should have at least 1 character
+```
+
+The Worker retried up to 20 times and failed every time.
+
+**Root cause:** `filesystem__read_media_file` (and similar tools) return `{ text: "", images: [...] }` — an empty text body plus the raw image bytes. The Worker stored `toolResultText = typedResult.text` (an empty string `""`) and pushed a `role: "tool"` message with `content: ""` into conversation history. Groq requires at least one character in every message's content field.
+
+**Fix:** `src/core/worker-agent.ts` — when a tool returns images with no accompanying text, `toolResultText` falls back to `'[Image content returned]'`. The image itself is still described by the multimodal model via the existing `pendingImages` path, which is unaffected.
+
+---
+
+### 2. Manager final response formatted as JSON instead of plain text
+
+**Symptom:** After completing a task, the Manager's final reply to the user was raw JSON (e.g. `{"response": "...", "reasoning": "..."}`) instead of a readable markdown answer.
+
+**Root cause:** The synthesis call included the full planning conversation history, which contains a `"Respond ONLY with valid JSON"` system instruction from the planning phase. The model correctly followed that instruction for the synthesis step, even though it was not intended for it.
+
+**Fix:** `src/core/manager-agent.ts` — synthesis now uses a fresh context consisting only of the system messages and the synthesis prompt. The planning history is excluded. A safety fallback also extracts the `response` / `content` field if the model still returns JSON despite the updated prompt.
+
+---
+
+### 3. Harmony tool-call sequences broken on Vertex AI MaaS
+
+**Symptom:** On Vertex AI MaaS (`gpt-oss-120b-maas`), tool calls in the second and subsequent turns failed — the model either ignored the tool result or repeated the same tool call in a loop.
+
+**Root cause (a) — wrong conversation history format:** After receiving a Harmony response, the Worker stored the *cleaned* `response.content` (Harmony tokens stripped) as the assistant message in history. Harmony providers need to see their own raw token markers (`<|call|>`, `<|return|>`, `<|channel|>`) in history to continue a tool-call sequence. Without them, the model could not correlate the prior tool call with its result.
+
+**Fix:** Added `rawHarmonyContent?: string` to `ModelResponse` (`src/models/base.ts`). `ModelClient` populates it whenever `useHarmonyFormat` is true. `WorkerAgent` detects the field and stores `rawHarmonyContent` as the assistant message content instead of the cleaned version. `tool_calls` are omitted from the history message in Harmony mode (the call is encoded in the raw content itself).
+
+**Root cause (b) — unrecognised Vertex AI dialect:** Vertex AI MaaS emits tool calls in a different Harmony dialect (`<|channel|>commentary to=TOOL_NAME <|constrain|>json<|message|>JSON_ARGS<|call|>`) rather than the Krutrim pipe format (`<|call|>fn(args)<|return|>`). This dialect was not parsed, so tool calls from Vertex AI were silently dropped.
+
+**Fix:** `src/models/harmony.ts` — added `vertexChannelRegex` to parse the Vertex AI dialect. The `functions.` namespace prefix emitted by Vertex AI is stripped so the tool name matches the registered MCP tool name. `extractAssistantMessage()` was also updated to clean both Krutrim and Vertex AI Harmony tokens from visible content, and to handle malformed `<|return|>` variants where the closing `|>` is missing.
+
+---
+
+### 4. `model` field ignored in CLI model client construction
+
+**Symptom:** When a model config entry used the newer `model` field (instead of `defaultModel`), the CLI passed `undefined` to `createModelClient()`, causing the client to fall back to its default model rather than the configured one.
+
+**Root cause:** `src/interfaces/cli/index.ts` passed `multimodalModelConfig.defaultModel` directly, ignoring `model`.
+
+**Fix:** Updated to `model || defaultModel || ''` for both the multimodal and tool-calling model client construction paths.
+
+---
+
+## New Features
+
+### Google Application Default Credentials (ADC) for Vertex AI MaaS
+
+A new `src/models/google-adc.ts` module fetches short-lived GCP OAuth2 tokens automatically, removing the need for a static API key when running on Cloud Run or other GCP environments.
+
+**Token source priority:**
+1. GCP metadata server at `169.254.169.254` (Cloud Run, GCE, GKE) — uses the IP directly because musl libc (node:20-alpine) cannot resolve `metadata.google.internal`.
+2. `google-auth-library` ADC — fallback for local development when `gcloud auth application-default` credentials are active.
+
+Tokens are cached in-process and refreshed 5 minutes before expiry (at most one outbound metadata call per hour).
+
+**Configuration:** Set `useGoogleADC: true` in the model config entry. The `apiKey` field is no longer required when ADC is enabled:
+
+```json
+{
+  "models": {
+    "reasoning": {
+      "endpoint": "https://{REGION}-aiplatform.googleapis.com/v1/projects/{PROJECT}/locations/{REGION}/endpoints/{ENDPOINT_ID}/chat/completions",
+      "useGoogleADC": true,
+      "useHarmonyFormat": true,
+      "model": "gpt-oss-120b-maas"
+    }
+  }
+}
+```
+
+`useGoogleADC` is supported in `src/core/config.ts`, `ModelClientConfig`, `src/interfaces/cli/index.ts`, and `src/interfaces/http/session-manager.ts`.
+
+---
+
+### Sub-agent iteration limit increased
+
+The default `maxIterations` for sub-agents spawned via `AgentSpawner` has been raised from 10 to 20. Tasks that require more back-and-forth tool use (e.g. multi-file edits, longer research tasks) no longer hit the iteration wall prematurely.
+
+---
+
+## Files Changed
+
+| File | Change |
+|------|--------|
+| `src/core/worker-agent.ts` | Empty tool content fallback; `rawHarmonyContent` history handling |
+| `src/core/manager-agent.ts` | Synthesis context isolation; JSON-response safety fallback |
+| `src/core/agent-spawner.ts` | Default `maxIterations` 10 → 20 |
+| `src/core/config.ts` | `useGoogleADC` flag; `model` field alias; validation error messages |
+| `src/models/base.ts` | `rawHarmonyContent` field on `ModelResponse` |
+| `src/models/google-adc.ts` | **New** — GCP ADC token provider |
+| `src/models/harmony.ts` | Vertex AI dialect parser; malformed `<|return|>` fix; `extractAssistantMessage` cleanup |
+| `src/models/model-client.ts` | ADC token injection; Harmony token cleanup in standard mode; tool call extraction improvements |
+| `src/interfaces/cli/index.ts` | `model \|\| defaultModel` fallback |
+| `src/interfaces/http/session-manager.ts` | `useGoogleADC` support; model config field handling |
+| `Dockerfile` | `bash` added to apk install (required by `@mkusaka/mcp-shell-server`) |
+| `cloud-run-deploy.yaml` | `JIVA_STORAGE_PROVIDER` updated to canonical `gcp-bucket` |
+
+---
+
+## Upgrade
+
+```bash
+npm install -g jiva-core@0.3.47
+```
+
+No breaking changes. All existing configs continue to work without modification.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jiva-core",
-  "version": "0.3.46",
+  "version": "0.3.47",
   "description": "Versatile autonomous AI agent with three-agent architecture (Manager, Worker, Client) powered by gpt-oss-120b. Adaptive validation, full MCP support, and intelligent quality control.",
   "main": "dist/index.js",
   "bin": {

--- a/src/core/agent-spawner.ts
+++ b/src/core/agent-spawner.ts
@@ -185,7 +185,7 @@ export class AgentSpawner {
         conversationManager: this.conversationManager || undefined,
         personaManager: subPersonaManager,
         maxSubtasks: 20,
-        maxIterations: request.maxIterations || 10,
+        maxIterations: request.maxIterations || 20,
         maxAgentDepth: this.maxDepth, // Inherit parent's max depth limit
         autoSave: false, // Sub-agents don't auto-save
       };

--- a/src/core/config.ts
+++ b/src/core/config.ts
@@ -24,16 +24,28 @@ const MCPServerConfigSchema = z.object({
 );
 
 const ModelConfigSchema = z.object({
-  name: z.string(),
+  name: z.string().optional(),
   endpoint: z.string().url(),
-  apiKey: z.string(),
-  type: z.enum(['reasoning', 'multimodal', 'tool-calling']),
-  defaultModel: z.string(),
+  /**
+   * Static API key. Not required (may be empty string) when useGoogleADC is true,
+   * in which case short-lived GCP OAuth2 tokens are fetched automatically.
+   */
+  apiKey: z.string().default(''),
+  type: z.enum(['reasoning', 'multimodal', 'tool-calling']).default('reasoning'),
+  model: z.string().optional(),
+  defaultModel: z.string().optional(),
   useHarmonyFormat: z.boolean().optional(),
   /** How to send reasoning effort: 'api_param' | 'system_prompt' | 'both' */
   reasoningEffortStrategy: z.enum(['api_param', 'system_prompt', 'both']).optional(),
   /** Default max tokens — required for reasoning models like Sarvam-105B */
   defaultMaxTokens: z.number().optional(),
+  /**
+   * Use Google Application Default Credentials instead of a static apiKey.
+   * Required for Vertex AI MaaS endpoints (aiplatform.googleapis.com).
+   * On Cloud Run the service account token is fetched automatically;
+   * locally falls back to google-auth-library / `gcloud auth application-default`.
+   */
+  useGoogleADC: z.boolean().optional(),
 });
 
 const CodeModeConfigSchema = z.object({
@@ -84,7 +96,9 @@ export class ConfigManager {
 
   isConfigured(): boolean {
     const config = this.store.store;
-    return !!(config.models?.reasoning?.apiKey || config.models?.multimodal?.apiKey);
+    const r = config.models?.reasoning;
+    const m = config.models?.multimodal;
+    return !!(r?.apiKey || r?.useGoogleADC || m?.apiKey || m?.useGoogleADC);
   }
 
   getConfig(): JivaConfig {
@@ -220,16 +234,18 @@ export class ConfigManager {
       );
     }
 
-    if (!config.models.reasoning.apiKey) {
+    if (!config.models.reasoning.apiKey && !config.models.reasoning.useGoogleADC) {
       throw new ConfigurationError(
-        'API key for reasoning model not configured.'
+        'API key for reasoning model not configured. ' +
+        'Either set apiKey or enable useGoogleADC for Vertex AI MaaS.'
       );
     }
 
     // Multimodal model is optional
-    if (config.models.multimodal && !config.models.multimodal.apiKey) {
+    if (config.models.multimodal && !config.models.multimodal.apiKey && !config.models.multimodal.useGoogleADC) {
       throw new ConfigurationError(
-        'API key for multimodal model not configured.'
+        'API key for multimodal model not configured. ' +
+        'Either set apiKey or enable useGoogleADC for Vertex AI MaaS.'
       );
     }
   }

--- a/src/core/manager-agent.ts
+++ b/src/core/manager-agent.ts
@@ -380,26 +380,44 @@ IMPORTANT: Be honest about what was and was not accomplished. Do NOT claim resul
 
 ${completedSection}${failedSection}
 
-Create a clear, honest response that accurately reflects what was accomplished. If any work failed, explain briefly what happened.`;
+RESPONSE FORMAT: Write PLAIN TEXT markdown — do NOT return JSON, code blocks, or any structured data format.
+Do not include fields like "reasoning", "subtasks", or JSON syntax.
+Write naturally as if directly addressing the user.`;
 
-    this.conversationHistory.push({
-      role: 'user',
-      content: synthesisPrompt,
-    });
+    // Use a fresh context for synthesis — do NOT include prior planning rounds.
+    // The planning conversation history contains a "Respond ONLY with valid JSON"
+    // instruction that bleeds into the synthesis if included, causing the model
+    // to format the final response as JSON instead of plain text.
+    const synthesisMessages = [
+      ...this.getSystemMessages(agentContext),
+      { role: 'user' as const, content: synthesisPrompt },
+    ];
 
     const response = await this.orchestrator.chat({
-      messages: [...this.getSystemMessages(agentContext), ...this.conversationHistory.slice(1)],
+      messages: synthesisMessages,
       temperature: 0.1, // Low temperature for deterministic synthesis
     });
 
-    this.conversationHistory.push({
-      role: 'assistant',
-      content: response.content,
-    });
+    // Append to history so future turns have context
+    this.conversationHistory.push({ role: 'user', content: synthesisPrompt });
+    this.conversationHistory.push({ role: 'assistant', content: response.content });
 
     logger.info('[Manager] Final response created');
 
-    return response.content;
+    // If the model still returned JSON despite instructions, extract the text
+    const responseText = response.content.trim();
+    if (responseText.startsWith('{') || responseText.startsWith('[')) {
+      try {
+        const parsed = JSON.parse(responseText);
+        // Extract a human-readable value
+        const text = parsed.response || parsed.final || parsed.content || parsed.reasoning || responseText;
+        return typeof text === 'string' ? text : responseText;
+      } catch {
+        // Not valid JSON — return as-is
+      }
+    }
+
+    return responseText;
   }
 
   /**

--- a/src/core/worker-agent.ts
+++ b/src/core/worker-agent.ts
@@ -635,9 +635,21 @@ Please complete this subtask and report your findings.`,
       let _postApiError = false;
       try {
 
+      // When the model responded in Harmony format, store the raw Harmony tokens
+      // as the assistant message content. Harmony providers (Vertex AI MaaS,
+      // Krutrim) need to see their own token markers in history to continue the
+      // tool-call sequence on the next turn. In Harmony mode do NOT add tool_calls
+      // in standard OpenAI format — the tool call is encoded in the content itself.
+      //
+      // For standard OpenAI providers (Groq, etc.), use the cleaned content and
+      // add tool_calls so role:'tool' messages can be matched by tool_call_id.
+      const isHarmonyResponse = !!response.rawHarmonyContent;
       conversationHistory.push({
         role: 'assistant',
-        content: response.content,
+        content: isHarmonyResponse ? response.rawHarmonyContent! : response.content,
+        ...(!isHarmonyResponse && response.toolCalls && response.toolCalls.length > 0
+          ? { tool_calls: response.toolCalls }
+          : {}),
       });
 
       // Check for tool calls
@@ -727,7 +739,7 @@ Tools used: ${spawnResult.toolsUsed.join(', ')}`;
             let hasImages = false;
             if (typeof result === 'object' && result !== null && 'images' in result) {
               const typedResult = result as ToolResultWithImages;
-              toolResultText = typedResult.text;
+              toolResultText = typedResult.text || '[Image content returned]';
 
               if (typedResult.images && typedResult.images.length > 0) {
                 hasImages = true;

--- a/src/interfaces/cli/index.ts
+++ b/src/interfaces/cli/index.ts
@@ -699,7 +699,7 @@ program
         multimodalModel = createModelClient({
           endpoint: multimodalModelConfig.endpoint,
           apiKey: multimodalModelConfig.apiKey,
-          model: multimodalModelConfig.defaultModel,
+          model: multimodalModelConfig.model || multimodalModelConfig.defaultModel || '',
           type: 'multimodal',
         });
       }
@@ -712,7 +712,7 @@ program
         toolCallingModel = createModelClient({
           endpoint: toolCallingModelCfg.endpoint,
           apiKey: toolCallingModelCfg.apiKey,
-          model: toolCallingModelCfg.defaultModel,
+          model: toolCallingModelCfg.model || toolCallingModelCfg.defaultModel || '',
           type: 'tool-calling',
           useHarmonyFormat: toolCallingModelCfg.useHarmonyFormat,
           defaultReasoningEffort: 'medium',

--- a/src/interfaces/http/session-manager.ts
+++ b/src/interfaces/http/session-manager.ts
@@ -156,46 +156,57 @@ export class SessionManager extends EventEmitter {
       // Load or create config
       let modelConfig = await storageProvider.getConfig<{
         reasoning: {
-          provider: string;
-          apiKey: string;
+          provider?: string;
+          apiKey?: string;
           endpoint: string;
-          model: string;
+          model?: string;
+          defaultModel?: string;
+          useHarmonyFormat?: boolean;
+          useGoogleADC?: boolean;
+          reasoningEffortStrategy?: 'api_param' | 'system_prompt' | 'both';
+          defaultMaxTokens?: number;
         };
         multimodal: null;
       }>('models');
       
-      // Always use environment variables if set, otherwise use stored config or defaults
+      // Environment variables are SERVER-LEVEL DEFAULTS only.
+      // Per-tenant GCS config takes full precedence — env vars are only applied
+      // when no GCS config exists for this tenant (first-ever session).
       const envEndpoint = process.env.JIVA_MODEL_BASE_URL;
       const envApiKey = process.env.JIVA_MODEL_API_KEY;
       const envModel = process.env.JIVA_MODEL_NAME;
-      
+
       if (!modelConfig) {
-        // Use environment defaults
+        // No per-tenant config yet — bootstrap from environment defaults
         modelConfig = {
           reasoning: {
-            provider: process.env.JIVA_MODEL_PROVIDER || 'krutrim',
+            provider: process.env.JIVA_MODEL_PROVIDER || 'sarvam',
             apiKey: envApiKey || '',
-            endpoint: envEndpoint || 'https://cloud.olakrutrim.com/v1/chat/completions',
-            model: envModel || 'gpt-oss-120b',
+            endpoint: envEndpoint || 'https://api.sarvam.ai/v1/chat/completions',
+            model: envModel || 'sarvam-105b',
+            useHarmonyFormat: false,
+            reasoningEffortStrategy: 'api_param' as const,
+            defaultMaxTokens: 4096,
           },
-          multimodal: null, // Optional
+          multimodal: null,
         };
         await storageProvider.setConfig('models', modelConfig);
-      } else {
-        // Override stored config with environment variables if present
-        if (envEndpoint) modelConfig.reasoning.endpoint = envEndpoint;
-        if (envApiKey) modelConfig.reasoning.apiKey = envApiKey;
-        if (envModel) modelConfig.reasoning.model = envModel;
       }
+      // Per-tenant GCS config exists → use it as-is; do NOT override with env vars.
+      // To change a tenant's model, update their config.json in GCS directly.
 
       // Create model orchestrator
+      const rm = modelConfig.reasoning as any;
       const reasoningModel = createModelClient({
-        endpoint: modelConfig.reasoning.endpoint,
-        apiKey: modelConfig.reasoning.apiKey,
-        model: modelConfig.reasoning.model || (modelConfig.reasoning as any).defaultModel,
+        endpoint: rm.endpoint,
+        apiKey: rm.apiKey || '',
+        model: rm.model || rm.defaultModel,
         type: 'reasoning',
-        useHarmonyFormat: (modelConfig.reasoning as any).useHarmonyFormat ?? false,
+        useHarmonyFormat: rm.useHarmonyFormat ?? false,
+        useGoogleADC: rm.useGoogleADC ?? false,
+        reasoningEffortStrategy: rm.reasoningEffortStrategy,
         defaultReasoningEffort: 'high',
+        defaultMaxTokens: rm.defaultMaxTokens,
       });
 
       // Tool-calling model: when configured, serves as the PRIMARY model for tool-call
@@ -327,7 +338,7 @@ export class SessionManager extends EventEmitter {
           conversationManager,
           personaManager,
           maxSubtasks: 20,
-          maxIterations: 10,
+          maxIterations: 20,
           autoSave: true,
           orchestrationLogger: orchLogger,
         });

--- a/src/models/base.ts
+++ b/src/models/base.ts
@@ -26,6 +26,14 @@ export interface MessageContent {
 
 export interface ModelResponse {
   content: string;
+  /**
+   * Raw Harmony-format response string (set only when useHarmonyFormat is true).
+   * When present, this must be used as the assistant message content in conversation
+   * history instead of the cleaned `content`, because Harmony providers (Vertex AI,
+   * Krutrim) expect the raw Harmony tokens in history to continue tool-call sequences.
+   * When rawHarmonyContent is present, do NOT add tool_calls to the history message.
+   */
+  rawHarmonyContent?: string;
   toolCalls?: ToolCall[];
   usage?: {
     promptTokens: number;

--- a/src/models/google-adc.ts
+++ b/src/models/google-adc.ts
@@ -1,0 +1,134 @@
+/**
+ * Google Application Default Credentials (ADC) token provider.
+ *
+ * Fetches short-lived OAuth2 tokens for calling Google Cloud APIs
+ * (e.g. Vertex AI MaaS endpoints) from within Cloud Run or any GCP
+ * environment that has a service account attached.
+ *
+ * Token source priority:
+ *   1. GCP metadata server at 169.254.169.254 (Cloud Run, GCE, GKE)
+ *      — uses the IP directly, not the hostname, because musl libc
+ *        (node:20-alpine) cannot resolve `metadata.google.internal`.
+ *   2. google-auth-library (ADC) — fallback for local development
+ *      when gcloud application-default credentials are active.
+ *
+ * Tokens are cached in-process and refreshed 5 minutes before expiry,
+ * so there is at most one outbound metadata call per hour.
+ */
+
+import http from 'http';
+import { logger } from '../utils/logger.js';
+
+const METADATA_IP   = '169.254.169.254';
+const METADATA_PATH = '/computeMetadata/v1/instance/service-accounts/default/token';
+const REFRESH_BUFFER_MS = 5 * 60 * 1000; // refresh 5 min before expiry
+
+interface CachedToken {
+  access_token: string;
+  expires_at: number; // epoch ms
+}
+
+let cached: CachedToken | null = null;
+let inflight: Promise<string> | null = null;
+
+function fetchFromMetadataServer(): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const req = http.request(
+      {
+        host: METADATA_IP,
+        port: 80,
+        path: METADATA_PATH,
+        method: 'GET',
+        headers: { 'Metadata-Flavor': 'Google' },
+        timeout: 3000,
+      },
+      (res) => {
+        if (res.statusCode !== 200) {
+          reject(new Error(`Metadata server returned HTTP ${res.statusCode}`));
+          return;
+        }
+        let body = '';
+        res.on('data', (chunk) => (body += chunk));
+        res.on('end', () => {
+          try {
+            const parsed: { access_token: string; expires_in: number } = JSON.parse(body);
+            cached = {
+              access_token: parsed.access_token,
+              expires_at: Date.now() + parsed.expires_in * 1000,
+            };
+            logger.debug(
+              `[GoogleADC] Token refreshed from metadata server, ` +
+              `expires in ${Math.round(parsed.expires_in / 60)} min`
+            );
+            resolve(cached.access_token);
+          } catch (e) {
+            reject(new Error('Failed to parse metadata token response'));
+          }
+        });
+      }
+    );
+    req.on('error', reject);
+    req.on('timeout', () => {
+      req.destroy();
+      reject(new Error('Metadata server request timed out'));
+    });
+    req.end();
+  });
+}
+
+async function fetchFromGoogleAuthLibrary(): Promise<string> {
+  const { GoogleAuth } = await import('google-auth-library');
+  const auth = new GoogleAuth({
+    scopes: ['https://www.googleapis.com/auth/cloud-platform'],
+  });
+  const token = await auth.getAccessToken();
+  if (!token) throw new Error('google-auth-library returned null token');
+  // Cache for 55 min (library manages its own refresh internally,
+  // but we cache to avoid re-instantiating on every call).
+  cached = { access_token: token, expires_at: Date.now() + 55 * 60 * 1000 };
+  logger.debug('[GoogleADC] Token obtained via google-auth-library (local ADC)');
+  return token;
+}
+
+/**
+ * Returns a valid GCP OAuth2 access token, refreshing from the metadata
+ * server (Cloud Run) or local ADC (development) as needed.
+ *
+ * Call this once per model API request — the call is cheap because the
+ * token is cached in-process until 5 minutes before expiry.
+ */
+export async function getGoogleADCToken(): Promise<string> {
+  // Return cached token if still fresh
+  if (cached && cached.expires_at - Date.now() > REFRESH_BUFFER_MS) {
+    return cached.access_token;
+  }
+
+  // Deduplicate concurrent refresh calls
+  if (inflight) return inflight;
+
+  inflight = (async () => {
+    try {
+      return await fetchFromMetadataServer();
+    } catch (metadataErr) {
+      logger.debug(
+        `[GoogleADC] Metadata server unavailable (${(metadataErr as Error).message}), ` +
+        `falling back to google-auth-library`
+      );
+      try {
+        return await fetchFromGoogleAuthLibrary();
+      } catch (adcErr) {
+        throw new Error(
+          `Google ADC token fetch failed.\n` +
+          `  Metadata server: ${(metadataErr as Error).message}\n` +
+          `  google-auth-library: ${(adcErr as Error).message}\n` +
+          `Ensure the service account has the 'aiplatform.endpoints.predict' permission ` +
+          `or set useGoogleADC: false and provide a static apiKey.`
+        );
+      }
+    } finally {
+      inflight = null;
+    }
+  })();
+
+  return inflight;
+}

--- a/src/models/harmony.ts
+++ b/src/models/harmony.ts
@@ -187,7 +187,8 @@ export function parseHarmonyResponse(response: string): ParsedHarmonyResponse {
   }
 
   // Parse tool calls — Harmony pipe format: <|call|>fn({"k":"v"})<|return|>
-  const toolCallRegex = /<\|call\|>([\s\S]*?)<\|return\|>/g;
+  // Also handles malformed variants where the closing |> is missing: <|return|<|end|>
+  const toolCallRegex = /<\|call\|>([\s\S]*?)<\|return\|>?(?=<|\s*$)/g;
   let toolMatch;
   let callId = 0;
 
@@ -274,6 +275,37 @@ export function parseHarmonyResponse(response: string): ParsedHarmonyResponse {
     }
   }
 
+  // Parse tool calls — Vertex AI Harmony dialect:
+  // <|channel|>commentary to=TOOL_NAME <|constrain|>json<|message|>JSON_ARGS<|call|>
+  // This dialect is emitted by gpt-oss-120b-maas on Vertex AI MaaS when it uses
+  // its native Harmony format. The tool name follows "to=" and args follow <|message|>.
+  //
+  // Vertex AI prefixes tool names with "functions." (e.g., "functions.tavily-mcp__tavily_search").
+  // Strip this prefix so the name matches the registered MCP tool name.
+  const vertexChannelRegex = /<\|channel\|>\w+\s+to=([\w.-]+(?:__[\w.-]+)?)\s+<\|constrain\|>json<\|message\|>([\s\S]*?)<\|call\|>/g;
+  let vertexMatch;
+
+  while ((vertexMatch = vertexChannelRegex.exec(response)) !== null) {
+    // Strip "functions." namespace prefix if present
+    const rawToolName = vertexMatch[1].trim();
+    const toolName = rawToolName.startsWith('functions.') ? rawToolName.slice('functions.'.length) : rawToolName;
+    const argsJson = vertexMatch[2].trim();
+    try {
+      const parsedArgs = JSON.parse(argsJson);
+      result.toolCalls.push({
+        id: `call_${callId++}`,
+        type: 'function',
+        function: {
+          name: toolName,
+          arguments: JSON.stringify(parsedArgs),
+        },
+      });
+      logger.debug(`[Harmony] Parsed Vertex AI dialect tool call: ${toolName}`);
+    } catch (e) {
+      logger.warn(`[Harmony] Failed to parse Vertex AI dialect args for ${toolName}: ${argsJson}`);
+    }
+  }
+
   // If no channels found, treat entire response as final
   if (!result.analysis && !result.commentary && !result.final && result.toolCalls.length === 0) {
     result.final = response.trim();
@@ -289,10 +321,15 @@ export function parseHarmonyResponse(response: string): ParsedHarmonyResponse {
 export function extractAssistantMessage(response: string): string {
   // Remove channel markers and tool calls to get clean message
   let cleaned = response
-    .replace(/<\|channel\|>\w+/g, '')
+    // Krutrim pipe-format tool calls: <|call|>fn(args)<|return|>
     .replace(/<\|call\|>[\s\S]*?<\|return\|>/g, '')
-    .replace(/<\|start\|>/g, '')
+    // Vertex AI dialect tool calls: <|channel|>commentary to=fn <|constrain|>json<|message|>{args}<|call|>
+    .replace(/<\|channel\|>\w+\s+to=[\w.-]+(?:__[\w.-]+)?\s+<\|constrain\|>json<\|message\|>[\s\S]*?<\|call\|>/g, '')
+    // Remaining Harmony control tokens
+    .replace(/<\|channel\|>\w+/g, '')
+    .replace(/<\|start\|>\w*/g, '')
     .replace(/<\|end\|>/g, '')
+    .replace(/<\|constrain\|>\w*/g, '')
     .replace(/<\|message\|>/g, '')
     .trim();
 

--- a/src/models/model-client.ts
+++ b/src/models/model-client.ts
@@ -2,31 +2,51 @@
  * OpenAI-Compatible Model Client
  *
  * Generic client for any OpenAI-compatible chat completion API.
- * Supports: Krutrim, Groq, Sarvam, OpenAI, and any other provider
- * that exposes a /v1/chat/completions endpoint.
+ * Supports: Krutrim, Groq, Sarvam, OpenAI, Vertex AI MaaS, and any other
+ * provider that exposes a /v1/chat/completions endpoint.
  *
  * Provider-specific behaviour is controlled entirely through config flags:
  *   - useHarmonyFormat    → Krutrim gpt-oss-120b (Harmony tool format)
  *   - reasoningEffortStrategy → how reasoning effort is communicated
  *   - defaultMaxTokens   → required for reasoning models (e.g. Sarvam-105B)
+ *   - useGoogleADC       → Vertex AI MaaS: fetch short-lived GCP OAuth2 tokens
+ *                          instead of using a static apiKey
  */
 
 import { IModel, ChatCompletionOptions, ModelResponse, Message } from './base.js';
 import {
   formatMessagesForHarmony,
   parseHarmonyResponse,
+  extractAssistantMessage,
   HarmonyToolDefinition,
   HarmonyMessage
 } from './harmony.js';
 import { ModelError } from '../utils/errors.js';
 import { logger } from '../utils/logger.js';
+import { getGoogleADCToken } from './google-adc.js';
 
 export interface ModelClientConfig {
   endpoint: string;
+  /** Static API key. Not required when useGoogleADC is true. */
   apiKey: string;
   model: string;
   defaultModel?: string; // Alias used in config store; model takes precedence
   type: 'reasoning' | 'multimodal' | 'tool-calling';
+
+  /**
+   * Use Google Application Default Credentials (ADC) for authentication.
+   *
+   * When true, a short-lived GCP OAuth2 bearer token is fetched automatically
+   * before each request (cached and refreshed every ~55 minutes). Use this for
+   * Vertex AI MaaS endpoints (aiplatform.googleapis.com) where no static API
+   * key exists — auth is handled by the Cloud Run service account.
+   *
+   * Token source: GCP metadata server IP 169.254.169.254 (Cloud Run/GCE),
+   * with fallback to google-auth-library for local development.
+   *
+   * Default: false
+   */
+  useGoogleADC?: boolean;
 
   /**
    * Use Harmony format for tool calling.
@@ -258,11 +278,16 @@ export class ModelClient implements IModel {
       logger.debug('Request size:', JSON.stringify(requestBody).length, 'bytes');
       logger.debug('Message count:', requestBody.messages.length);
 
+      // Resolve auth token — static key or dynamic GCP OAuth2 token
+      const authToken = this.config.useGoogleADC
+        ? await getGoogleADCToken()
+        : this.config.apiKey;
+
       const response = await fetch(this.config.endpoint, {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',
-          'Authorization': `Bearer ${this.config.apiKey}`,
+          'Authorization': `Bearer ${authToken}`,
           'User-Agent': 'Jiva/0.1.0',
           'Accept': 'application/json',
         },
@@ -319,11 +344,26 @@ export class ModelClient implements IModel {
       // when no tools were requested — the model may still emit tool-call tokens
       // (e.g. <|call|>…<|return|> or <tool_call>…</tool_call>) regardless.
       if (useHarmony && isReasoningModel) {
-        // Parse Harmony format response (Krutrim gpt-oss-120b only)
+        // Parse Harmony format response (Krutrim gpt-oss-120b / Vertex AI MaaS)
         const parsed = parseHarmonyResponse(messageContent);
 
+        // Determine the clean display content.
+        // Prefer the model's explicit channel outputs (final > commentary > analysis), then
+        // fall back to extractAssistantMessage() which strips all Harmony control tokens.
+        // Always run extractAssistantMessage() to clean residual Harmony tokens from
+        // channel content (e.g. <|message|> tokens that appear as channel body).
+        // Never expose raw messageContent — it would leak Harmony tokens to the user.
+        const channelContent = parsed.final || parsed.commentary || parsed.analysis || '';
+        const cleanContent = extractAssistantMessage(channelContent || messageContent);
+
         return {
-          content: parsed.final || parsed.commentary || messageContent,
+          // Cleaned display content (no Harmony tokens) — shown to the user
+          content: cleanContent,
+          // Raw Harmony response — must be stored in conversation history as the
+          // assistant message content so the model can continue the tool-call
+          // sequence on the next turn. Harmony providers (Vertex AI, Krutrim) need
+          // to see their own token markers in history.
+          rawHarmonyContent: messageContent,
           toolCalls: parsed.toolCalls.length > 0 ? parsed.toolCalls : undefined,
           usage: data.usage ? {
             promptTokens: data.usage.prompt_tokens || 0,
@@ -339,23 +379,36 @@ export class ModelClient implements IModel {
         // Standard OpenAI format response
         const nativeToolCalls = choice.message?.tool_calls;
 
-        // Some models (e.g. sarvam-105b) emit tool calls as XML in message.content
-        // instead of using the native tool_calls field. Parse and extract them.
+        // Some models emit tool calls in message.content instead of (or in addition to)
+        // the native tool_calls field. Two known content-embedded formats:
+        //   1. XML: <tool_call>name<arg_key>k</arg_key><arg_value>v</arg_value></tool_call>
+        //   2. Harmony tokens: <|call|>fn(args)<|return|>  or  <|channel|>commentary to=fn ...
+        //      gpt-oss-120b-maas on Vertex AI leaks Harmony tokens even in standard mode.
         let contentText = messageContent;
-        let xmlToolCalls = undefined;
-        if (messageContent && messageContent.includes('<tool_call>')) {
+        let embeddedToolCalls: any[] | undefined;
+
+        const hasHarmonyTokens = messageContent && (
+          messageContent.includes('<|call|>') ||
+          messageContent.includes('<|channel|>') ||
+          messageContent.includes('<tool_call>')
+        );
+
+        if (hasHarmonyTokens) {
           const parsed = parseHarmonyResponse(messageContent);
           if (parsed.toolCalls.length > 0) {
-            xmlToolCalls = parsed.toolCalls;
-            // Strip the parsed tool call XML from the visible content
-            contentText = messageContent.replace(/<tool_call>[\s\S]*?<\/tool_call>/gi, '').trim();
+            embeddedToolCalls = parsed.toolCalls;
+            // Clean Harmony/XML tokens from the visible content
+            contentText = extractAssistantMessage(messageContent);
+          } else {
+            // Tokens present but no tool calls parsed — still clean them from content
+            contentText = extractAssistantMessage(messageContent);
           }
         }
 
-        const allToolCalls = [
-          ...(nativeToolCalls && nativeToolCalls.length > 0 ? nativeToolCalls : []),
-          ...(xmlToolCalls ?? []),
-        ];
+        // Prefer native tool_calls (standard format); fall back to content-embedded calls
+        const allToolCalls = nativeToolCalls && nativeToolCalls.length > 0
+          ? nativeToolCalls
+          : (embeddedToolCalls ?? []);
 
         return {
           content: contentText,


### PR DESCRIPTION
### Release v0.3.47
#### Supersedes v0.3.45 and v0.3.46


**v0.3.47** — Multimodal & Vertex AI fixes + Google ADC support
Fixes a Groq 400 crash on image analysis requests (empty tool content), repairs Harmony tool-call sequences on Vertex AI MaaS (raw token history + Vertex dialect parser), stops the Manager from returning JSON instead of plain text on synthesis, and adds Google Application Default Credentials so Cloud Run deployments no longer need a static API key.
→ [[Release notes: v0.3.47](https://github.com/KarmaloopAI/Jiva/blob/main/docs/release_notes/v0.3.47.md)](docs/release_notes/v0.3.47.md)

**v0.3.46** — Multi-tenant concurrency fixes for Cloud Run
Fixes cross-tenant GCS path corruption caused by a shared mutable `StorageProvider` context, a TOCTOU race creating duplicate sessions, `OrchestrationLogger` mixing events across tenants, and `JIVA_STORAGE_PROVIDER=gcp` silently falling through to local storage.
→ [[Release notes: v0.3.46](https://github.com/KarmaloopAI/Jiva/blob/main/docs/release_notes/v0.3.46.md)](docs/release_notes/v0.3.46.md)

**v0.3.45** — Windows compatibility for Code Mode
Fixes Code Mode writing files to `/workspace/` instead of the real workspace on Windows, and switches the `bash` tool to PowerShell on Windows so standard shell syntax works correctly.
→ [[Release notes: v0.3.45](https://github.com/KarmaloopAI/Jiva/blob/main/docs/release_notes/v0.3.45.md)](docs/release_notes/v0.3.45.md)
