### PR TITLE
Built-in Benchmarking Suite

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,9 +17,14 @@ Jiva is an autonomous AI agent for the terminal and cloud. It works with any Ope
 ```bash
 npm install -g jiva-core
 jiva setup
+
+# Verify your model + config can do code mode well:
+jiva benchmark
 ```
 
 The setup wizard opens with a provider selection menu. Choose your provider and Jiva auto-fills the endpoint, model name, and tool format — you only supply your API key. Supported providers: **Krutrim**, **Groq**, **Sarvam**, **OpenAI**, and any **OpenAI-compatible** endpoint.
+
+After setup, run **`jiva benchmark`** to confirm your chosen model and configuration work optimally in code mode. It runs the **baseline (taskstore) suite** — a deterministic set of coding tasks — against your config; a healthy setup passes all of them. See [Benchmarking](#benchmarking) for tuning and capability comparison.
 
 ### Development install
 
@@ -204,11 +209,12 @@ Configuration is stored at `~/.config/jiva-nodejs/config.json` (Linux/macOS) or 
       "model": "sarvam-105b",
       "type": "reasoning",
       "reasoningEffortStrategy": "api_param",
-      "defaultMaxTokens": 8192
+      "defaultMaxTokens": 4096
     }
   }
 }
 ```
+> Sarvam's API caps completion output at 4096 tokens. Tasks needing larger single outputs (e.g. writing a big file in one shot) will be limited by this — the [benchmark](#benchmarking) flags such failures as `[output-limited]`.
 
 **Ollama (local)**
 ```json
@@ -239,6 +245,30 @@ Any other OpenAI-compatible endpoint works the same way — set `endpoint`, `api
 ```
 
 Full configuration reference: [Configuration Guide](docs/guides/CONFIGURATION.md)
+
+---
+
+## Benchmarking
+
+Jiva ships a built-in benchmark to measure how well your **model + configuration** performs in code mode. Tasks run in isolated throwaway workspaces and are scored deterministically with Node's built-in test runner — no LLM judge, no network.
+
+```bash
+jiva benchmark                 # baseline (taskstore) suite — verify your setup works
+jiva benchmark --list          # list available suites and tasks
+jiva benchmark --suite microcrm --max-iterations 60   # capability suite (Node 22.5+)
+jiva benchmark --output report.json                   # save a JSON report to compare configs
+```
+
+Two suites, two purposes:
+
+| Suite | Scoring | Use it to… |
+|-------|---------|-----------|
+| **`taskstore`** (baseline) | pass/fail, 8 tiers that build on each other | Confirm a model + config can do code mode at all. A healthy setup passes everything. |
+| **`microcrm`** (capability) | % of spec tests | Differentiate models and tune configuration. The agent builds a Node + SQLite REST API and adds harder features (atomic bulk, advanced queries, analytics, idempotency). |
+
+The report shows per-task iterations, tokens, and wall-time, lists exactly which spec tests were missed, and flags failures caused by a model's **output-token limit** as `[output-limited]` (distinct from logic failures). Run it after `jiva setup`, and re-run it as you tune `defaultMaxTokens`, `maxIterations`, or switch models — the config with the best score-per-token is your optimal setup.
+
+Full guide: [Benchmark Suite](docs/guides/benchmark-suite.md)
 
 ---
 

--- a/docs/guides/benchmark-suite.md
+++ b/docs/guides/benchmark-suite.md
@@ -1,0 +1,155 @@
+# Code-Mode Benchmark Suite
+
+The benchmark measures how well a given **model + configuration** performs in Jiva's
+`--code` mode. It runs coding tasks in isolated workspaces and scores them
+deterministically with Node's built-in test runner. Use it to compare models
+(e.g. `gpt-oss-120b` vs Sarvam-105b vs Krutrim) and to find the optimal setup.
+
+## Suites and the recommended strategy
+
+The benchmark is organised into **suites**, each with a distinct purpose and scoring
+mode. List them with `jiva benchmark --list`.
+
+| Suite | Level | Scoring | Purpose | Expectation |
+|-------|-------|---------|---------|-------------|
+| `taskstore` | baseline | **gating** (binary pass/fail) | Does the model + config do code mode *at all*? | Any usable config ~100% |
+| `microcrm` | capability | **scored** (% of spec tests) | Differentiate models/configs; find the *optimal* setup | Strong configs high, weak ones partial |
+
+`microcrm` is a **building** suite (51 tests, 5 tasks): tier 1 builds the base CRM API from
+scratch (a large-output test), and tiers 2-5 scaffold the working base and add one harder
+feature each — atomic bulk insert, advanced querying, weighted analytics, idempotency-key.
+A failed task that hit the model's output-token limit is flagged **`[output-limited]`** in the
+report, so an output-cap failure (e.g. a hard 4096-token model) reads distinctly from a logic
+failure. Requires Node ≥ 22.5.
+| *frontier* (future) | frontier | scored | Ceiling — ~50 tests, even optimal ~30-40%; full pass needs a frontier model | Reuses the scored mechanism |
+
+**Two scoring modes:**
+- **gating** — every task is all-or-nothing and tasks build on one another. A single
+  number (`highest tier passed`) is the capability ceiling. This is a *gate*: if the
+  baseline fails, the config is broken and the other suites' numbers are meaningless.
+- **scored** — one (or a few) larger *build-to-spec* task(s) graded by the **fraction
+  of spec tests passed**. The headline is the pass-rate, and the report lists exactly
+  which spec tests were missed (the capability gaps).
+
+**Recommended workflow:**
+1. Run `taskstore` first as a gate on every model/config you care about.
+2. Run `microcrm` to score capability; tune configuration (`--max-iterations`,
+   reasoning effort, harmony, tool-calling model) and re-run, comparing the pass-rate
+   **and** cost (tokens/time) via `--output` JSON reports. The config with the best
+   score-per-token is your optimal setup.
+3. (Later) Run the frontier suite to see how far a config is from a top-tier model.
+
+> The `microcrm` suite uses the built-in `node:sqlite` module and therefore requires
+> **Node ≥ 22.5**. The `taskstore` suite runs on Node ≥ 20.
+
+The rest of this guide describes the `taskstore` (baseline) suite in detail; the
+`microcrm` suite works the same way but is graded by pass-rate.
+
+## How it works
+
+- A single evolving Node library (`taskstore`) is the substrate for all tasks.
+- Each task is scaffolded into an **isolated temp workspace** containing the
+  canonical solution of the prior tiers plus a new **failing** test. Your repo is
+  never touched.
+- A fresh, minimal `CodeAgent` (no MCP, no persona, no conversation persistence,
+  LSP off by default) is pointed at the workspace and given the task prompt.
+- After the agent finishes (or times out), the **verifier** runs:
+  1. **Tamper check** — every `test/` file must be byte-identical to what was
+     scaffolded. Editing a test to make it pass fails the task with
+     `tests-modified`.
+  2. **`node --test`** — must exit 0 with zero failures.
+- Per-task metrics are recorded: pass/fail, iterations (with `!` when the cap was
+  hit), tests passed, token usage, and wall-time.
+
+Scoring is cumulative — tier N runs tests `1..N`, so a regression in an earlier
+tier (e.g. during the tier-5 refactor) is caught.
+
+## The tiers
+
+| Tier | id | Capability |
+|------|----|------------|
+| 1 | `t01-create` | Write a new file from scratch |
+| 2 | `t02-extend-crud` | Read & extend an existing file |
+| 3 | `t03-bugfix-toggle` | Diagnose & fix a targeted bug |
+| 4 | `t04-feature-priority` | Multi-function feature |
+| 5 | `t05-refactor-split` | Multi-file refactor without regressions |
+| 6 | `t06-algorithm-sort` | Algorithmic reasoning & edge cases |
+| 7 | `t07-storage-roundtrip` | New module + serialization |
+| 8 | `t08-debug-id-collision` | Long-horizon cross-module debugging |
+
+Tiers 5, 7 and 8 demand larger outputs and more iterations — this is where
+short-output models (e.g. Sarvam's 4096-token cap) and rate-limited providers
+typically break down.
+
+## CLI
+
+```bash
+jiva benchmark --list                # list suites and their tasks
+jiva benchmark                       # run the taskstore (baseline) suite
+jiva benchmark --suite microcrm --max-iterations 60   # run the scored micro-CRM suite
+jiva benchmark --max-tier 3          # only tiers 1–3 of the baseline suite
+jiva benchmark --tasks t05-refactor-split,t08-debug-id-collision
+jiva benchmark --output report.json  # write the full JSON report
+jiva benchmark --json                # machine-readable output only
+jiva benchmark --continuous          # carry the agent's own output forward between tiers
+jiva benchmark --keep-workspaces     # leave temp workspaces on disk for inspection
+jiva benchmark -c ./my-config.json   # use a specific config file
+```
+
+Other overrides: `--max-iterations`, `--timeout`, `--lsp`.
+
+The command exits non-zero if any task fails, so it works directly in CI. The
+output table shows status, iterations, tests, tokens and time per task, plus the
+**highest tier passed** as a single capability number.
+
+## HTTP
+
+All routes are under the existing `/api` auth middleware.
+
+```bash
+# List tasks
+curl -H "x-tenant-id: t1" -H "x-session-id: s1" \
+  http://localhost:8080/api/benchmark/tasks
+
+# Run tiers 1–4
+curl -X POST http://localhost:8080/api/benchmark/run \
+  -H "Content-Type: application/json" \
+  -H "x-tenant-id: t1" -H "x-session-id: s1" \
+  -d '{"maxTier": 4}'
+
+# Stream progress (Server-Sent Events)
+curl -N -X POST http://localhost:8080/api/benchmark/run/stream \
+  -H "Content-Type: application/json" \
+  -H "x-tenant-id: t1" -H "x-session-id: s1" \
+  -d '{"maxTier": 8}'
+```
+
+Request body fields: `maxTier`, `tasks` (array of ids), `maxIterations`,
+`timeoutMs`, `lsp`, `continuous`. With `AUTH_DISABLED=true` the `x-tenant-id` /
+`x-session-id` headers are accepted in dev mode.
+
+## Interpreting results
+
+- **highest tier passed** — the model's capability ceiling. `gpt-oss-120b` should
+  reach 8; a constrained model will plateau earlier.
+- **`hitMaxIterations` (shown as `!` after the iteration count)** — the agent ran
+  out of steps. Common with rate-limited providers and on the debug tier.
+- **`reason: tests-failed`** vs **`timeout`** vs **`tests-modified`** vs
+  **`agent-error`** — categorises *why* a task failed.
+- **tokens / time** — relative cost. A model that passes but burns far more tokens
+  or time is a weaker fit for code mode.
+
+## Adding a tier
+
+1. Add the correct implementation snippet(s) to `src/code/benchmark/fixtures.ts`
+   and extend `goldenSrcAfter` / `scaffoldSrc`.
+2. Add the cumulative `node:test` file to `src/code/benchmark/tests.ts`.
+3. Add a `TaskSpec` to `src/code/benchmark/tasks.ts`.
+4. Run the self-test to confirm the golden solution passes and the scaffold fails:
+
+```bash
+npm run build && node scripts/bench-selftest.mjs
+```
+
+The self-test runs 3 checks per tier (golden passes, scaffold fails, tamper
+detected) with no LLM involved — keep it green.

--- a/docs/release_notes/v0.3.48.md
+++ b/docs/release_notes/v0.3.48.md
@@ -1,0 +1,166 @@
+# Jiva v0.3.48 — Code-Mode Benchmark Suite
+
+**Release Date:** June 29, 2026
+
+---
+
+## Summary
+
+Jiva's `--code` mode works well with `gpt-oss-120b` but degrades with other models — Sarvam-105b (4096-token output cap) chokes on tasks that need larger writes/edits, and Krutrim struggles with longer, multi-step tasks. Until now there was **no objective way to measure** how a given model + config performs in code mode.
+
+v0.3.48 adds a built-in, **TDD-style, deterministically-scored benchmark suite**. It drives `CodeAgent` through a sequence of coding tasks of increasing complexity in isolated throwaway workspaces, scoring each task with Node's built-in test runner (`node --test`) — no LLM judge, no network, no external test framework. The result is a per-task pass/fail plus diagnostic metrics (iterations, tokens, wall-time, and whether the iteration cap was hit) that surface exactly where a model breaks down.
+
+The suite is invokable from both the **CLI** (`jiva benchmark`) and the **HTTP API** (`/api/benchmark/*`).
+
+---
+
+## The task suite
+
+A single evolving Node library (`taskstore`) is the substrate. Each tier's workspace is scaffolded from the *canonical* solution of all prior tiers plus a new failing test, so the tiers genuinely build on one another while each is measured in isolation. The suite mixes building from scratch with improving/fixing existing code:
+
+| Tier | Task | Capability exercised | Kind |
+|------|------|----------------------|------|
+| 1 | Create `createTask` | Write a new file | scratch |
+| 2 | Add `addTask` / `removeTask` / `listTasks` | Read & extend a file | extend |
+| 3 | Fix the `toggleTask` bug | Diagnose & fix a targeted bug | bugfix |
+| 4 | Add task priorities | Multi-function feature | extend |
+| 5 | Split into `model` / `query` modules | Multi-file refactor without regressions | refactor |
+| 6 | Implement `sortTasks` with edge cases | Algorithmic reasoning (nulls, stability) | extend |
+| 7 | Add JSON `serialize` / `deserialize` | New module + serialization | extend |
+| 8 | Debug the id-collision integration bug | Long-horizon cross-module debugging | bugfix |
+
+Later tiers (5/7/8) require larger outputs and more iterations — the regime where short-output and rate-limited models fail. Scoring is cumulative: tier N's workspace runs tests `1..N`, so a refactor that breaks an earlier tier is caught.
+
+**Anti-gaming:** every test file is byte-hashed before the agent runs. If the agent edits a test to make it "pass", the task fails with reason `tests-modified`.
+
+---
+
+## CLI: `jiva benchmark`
+
+```bash
+# Run tiers 1–3 against the configured model
+jiva benchmark --max-tier 3
+
+# Run the whole suite and write a JSON report
+jiva benchmark --output report.json
+
+# Run specific tasks, machine-readable output
+jiva benchmark --tasks t05-refactor-split,t08-debug-id-collision --json
+
+# Carry the agent's own output forward between tiers (cascading, like a real session)
+jiva benchmark --continuous
+```
+
+Options: `--config`, `--max-tier`, `--tasks`, `--max-iterations`, `--timeout`, `--lsp`, `--continuous`, `--output`, `--json`, `--keep-workspaces`. The process exits non-zero when any task fails, so it drops straight into CI.
+
+The CLI prints a per-task table (status, iterations, tests passed, tokens, time), a summary line with the **highest tier passed** (a single capability-ceiling number), and the diagnostic notes for any failures.
+
+---
+
+## HTTP API
+
+Registered under the existing `/api` auth middleware:
+
+| Route | Purpose |
+|-------|---------|
+| `GET /api/benchmark/tasks` | List available tasks (metadata only) |
+| `POST /api/benchmark/run` | Run the suite, return the full `SuiteResult` JSON |
+| `POST /api/benchmark/run/stream` | Run the suite, stream per-task progress via SSE (`task-start`, `task-done`, `done`, `error`) |
+
+Request body: `{ maxTier?, tasks?, maxIterations?, timeoutMs?, lsp?, continuous? }`. The orchestrator is built once from the stored config and cached across requests.
+
+---
+
+## Architecture
+
+```
+src/code/benchmark/
+  types.ts                — BenchmarkTask, TaskResult, SuiteResult, RunnerOptions
+  fixtures.ts             — canonical taskstore source (golden state per tier)
+  tests.ts                — cumulative node:test files (the protected tests)
+  tasks.ts                — the 8 ordered tiers + selection helpers
+  verify.ts               — runNodeTests(): tamper check + `node --test` (scoped to the protected tests) + parse
+  agent-factory.ts        — minimal CodeAgent per task (no MCP/persona/persistence)
+  orchestrator-factory.ts — shared ModelOrchestrator builder (CLI + HTTP)
+  runner.ts               — scaffolds workspaces, drives the agent, collects metrics
+  report.ts               — CLI table + JSON serializer
+  index.ts                — public entry point
+```
+
+Both interfaces converge on `runBenchmark(orchestrator, tasks, options, progress)`. The runner creates an isolated `mkdtemp` workspace per task (the user's repo is never touched), races `agent.chat()` against a wall-clock timeout, runs the verifier, then tears everything down.
+
+A self-test (`scripts/bench-selftest.mjs`, run after `npm run build`) validates the fixtures and verifier without any model: for every tier it asserts the golden solution passes, the scaffold fails, and tampering is detected (24 checks).
+
+---
+
+## Benchmark suites (taskstore + micro-CRM)
+
+The benchmark is now organised into **suites** with two scoring modes, laying the
+groundwork for a tiered strategy (baseline → capability → frontier):
+
+- **`taskstore` (baseline, gating).** The original 8-tier TDD suite. Binary pass/fail,
+  tasks build on one another. Answers "does this model + config do code mode at all?"
+- **`microcrm` (capability, scored).** A **building** suite that builds a CRM REST API
+  using **only Node built-ins** — `node:http` + `node:sqlite` — graded by the **fraction of
+  spec tests passed** (51 tests across 5 tasks). Tier 1 builds the base API from scratch
+  (a genuine large-output test). Tiers 2-5 scaffold the working base and add one harder
+  feature each: **atomic bulk insert** (transaction rollback), **advanced querying**
+  (combined filters + sorting + `hasMore` pagination), **weighted pipeline analytics**, and
+  **idempotency-key** dedup on create. Zero external dependencies, fully deterministic, real
+  HTTP + real SQLite. The report shows the pass-rate and lists the exact spec tests missed.
+  Requires Node ≥ 22.5.
+
+**Output-length flag.** `CodeAgent` now counts output-token truncations per turn
+(`AgentResponse.truncationEvents`), and the benchmark flags a failed task as
+`[output-limited]` when it failed *after* hitting the model's output cap — distinguishing a
+model that **can't emit a large enough response** (e.g. a hard 4096-token cap) from one that
+got the **logic** wrong.
+
+New scoring mode: `scored` suites report `Score: N/M tests (P%)` instead of all-or-nothing,
+and the runner aggregates per-suite test totals. Verifier now also captures failing test
+names. Run `jiva benchmark --list` to see all suites/tasks; `--suite <id>` to pick one.
+
+HTTP gains `GET /api/benchmark/suites` and a `suite` field on the run routes.
+
+## Code-mode compatibility fixes (surfaced by the benchmark)
+
+The first benchmark runs immediately exposed two code-mode issues that hurt every model and broke weaker ones (Sarvam-105b, Krutrim) outright. Both are fixed in this release:
+
+1. **`write_file` / `edit_file` now accept `path` as an alias for `file_path`.** Models frequently emit the common `path` argument; provider-side tool-call validation (Groq/Sarvam) then rejected the call with a 400 (`missing properties: 'file_path'`) *before* it reached the tool, wasting iterations and tokens. The schema now hard-requires only `content` (write) / `old_string`+`new_string` (edit), accepts either `path` or `file_path`, and `execute()` validates the path itself. `repairFailedToolCall` also normalizes `path`→`file_path` as a fallback.
+
+2. **Schema/argument errors are no longer misdiagnosed as output-token truncation.** Groq codes both truncated and schema-invalid tool calls as `tool_use_failed`. The handler previously treated any such error on a file tool as "content too large" and told the model to "write in stages" — the wrong remedy. It now inspects `failed_generation`: a complete, parseable payload is treated as a schema error (with a targeted, tool-specific parameter correction), and only a genuinely cut-off payload routes to the write-in-stages path.
+
+3. **Sarvam-105b output budget corrected to 4096.** The setup-wizard preset requested 8192 completion tokens, but Sarvam's API caps output at 4096 (requesting more is rejected). The preset now uses 4096.
+
+4. **Graceful "continue?" prompt at the step limit.** When code mode hits its iteration limit before finishing, the agent now reports a `stopReason: 'max-iterations'`, and the interactive CLI offers the user a choice — **Continue working…** (resumes with full history) or **Stop for now** — instead of silently emitting `[Max iterations reached without a final response]`. (HTTP behaviour is unchanged.)
+
+## Files Changed
+
+| File | Change |
+|------|--------|
+| `src/code/benchmark/*` | **New** — the benchmark module (suites, runner, verifier, report) |
+| `src/code/benchmark/suites.ts` | **New** — suite registry (taskstore + microcrm) |
+| `src/code/benchmark/microcrm/*` | **New** — micro-CRM scored suite + `node:http`/`node:sqlite` test & reference assets |
+| `scripts/copy-benchmark-assets.mjs` | **New** — copies benchmark `.mjs` assets into dist on build |
+| `src/code/tools/write.ts` | Accept `path` alias; relax schema `required` to `content` |
+| `src/code/tools/edit.ts` | Accept `path` alias; relax schema `required` to `old_string`/`new_string` |
+| `src/code/agent.ts` | Distinguish truncation vs schema errors; targeted schema-arg correction; `path`→`file_path` repair; `truncationEvents` + `stopReason` on the response |
+| `src/interfaces/cli/setup-wizard.ts` | Sarvam `defaultMaxTokens` 8192 → 4096 |
+| `src/interfaces/cli/repl.ts` | Offer Continue/Stop when code mode hits its step limit |
+| `src/core/agent-interface.ts` | `stopReason` on `AgentChatResponse` |
+| `src/interfaces/cli/index.ts` | **New** `benchmark` command |
+| `src/interfaces/http/routes/benchmark.ts` | **New** — benchmark HTTP routes |
+| `src/interfaces/http/index.ts` | Register `setupBenchmarkRoutes` |
+| `scripts/bench-selftest.mjs` | **New** — fixture/verifier self-test |
+| `docs/guides/benchmark-suite.md` | **New** — usage & extension guide |
+| `package.json` | Version `0.3.47` → `0.3.48` |
+
+---
+
+## Upgrade
+
+```bash
+npm install -g jiva-core@0.3.48
+```
+
+No config changes required. The benchmark reuses the model stack from your existing configuration.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "jiva-core",
-  "version": "0.3.46",
+  "version": "0.3.48",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "jiva-core",
-      "version": "0.3.46",
+      "version": "0.3.48",
       "license": "MIT",
       "dependencies": {
         "@google-cloud/storage": "^7.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jiva-core",
-  "version": "0.3.47",
+  "version": "0.3.48",
   "description": "Versatile autonomous AI agent with three-agent architecture (Manager, Worker, Client) powered by gpt-oss-120b. Adaptive validation, full MCP support, and intelligent quality control.",
   "main": "dist/index.js",
   "bin": {
@@ -9,7 +9,7 @@
   "type": "module",
   "scripts": {
     "test:web": "playwright test",
-    "build": "tsc",
+    "build": "tsc && node scripts/copy-benchmark-assets.mjs",
     "dev": "tsx src/interfaces/cli/index.ts",
     "dev:http": "tsx src/interfaces/http/index.ts",
     "start": "node --loader ts-node/esm src/interfaces/cli/index.ts",

--- a/scripts/bench-selftest.mjs
+++ b/scripts/bench-selftest.mjs
@@ -1,0 +1,112 @@
+/**
+ * Self-test for the benchmark harness — validates the fixtures and verifier
+ * without any LLM. For each tier it asserts:
+ *   1. The canonical golden solution PASSES the tier's tests.
+ *   2. The scaffolded starting state (missing function / planted bug) FAILS.
+ *   3. Tampering with a test file is detected (tests-modified).
+ *
+ * Run after `npm run build`:  node scripts/bench-selftest.mjs
+ */
+
+import { mkdtemp, mkdir, writeFile, rm } from 'fs/promises';
+import { tmpdir } from 'os';
+import { join, dirname } from 'path';
+
+const { goldenSrcAfter, scaffoldSrc, PACKAGE_JSON } = await import('../dist/code/benchmark/fixtures.js');
+const { cumulativeTests, cumulativeTestPaths } = await import('../dist/code/benchmark/tests.js');
+const { runNodeTests } = await import('../dist/code/benchmark/verify.js');
+const { MICROCRM_TASKS, microcrmReferenceFor } = await import('../dist/code/benchmark/microcrm/index.js');
+
+async function writeAll(dir, files) {
+  for (const [rel, content] of Object.entries(files)) {
+    const abs = join(dir, rel);
+    await mkdir(dirname(abs), { recursive: true });
+    await writeFile(abs, content, 'utf-8');
+  }
+}
+
+function protectedMap(tier) {
+  const tests = cumulativeTests(tier);
+  const map = {};
+  for (const p of cumulativeTestPaths(tier)) map[p] = tests[p];
+  return map;
+}
+
+let failures = 0;
+const ok = (cond, msg) => {
+  console.log(`${cond ? '  ✓' : '  ✗'} ${msg}`);
+  if (!cond) failures++;
+};
+
+for (let tier = 1; tier <= 8; tier++) {
+  console.log(`\nTier ${tier}`);
+
+  // 1. Golden solution passes.
+  {
+    const dir = await mkdtemp(join(tmpdir(), `bench-golden-${tier}-`));
+    await writeAll(dir, { 'package.json': PACKAGE_JSON, ...goldenSrcAfter(tier), ...cumulativeTests(tier) });
+    const r = await runNodeTests(dir, protectedMap(tier), 60000);
+    ok(r.passed, `golden passes (pass=${r.testsPassed} fail=${r.testsFailed}${r.reason ? ' reason=' + r.reason : ''})`);
+    if (!r.passed) console.log(r.output.split('\n').slice(-12).join('\n'));
+    await rm(dir, { recursive: true, force: true });
+  }
+
+  // 2. Scaffold fails (the agent has work to do).
+  {
+    const dir = await mkdtemp(join(tmpdir(), `bench-scaffold-${tier}-`));
+    await writeAll(dir, { 'package.json': PACKAGE_JSON, ...scaffoldSrc(tier), ...cumulativeTests(tier) });
+    const r = await runNodeTests(dir, protectedMap(tier), 60000);
+    ok(!r.passed, `scaffold fails as expected (pass=${r.testsPassed} fail=${r.testsFailed})`);
+    await rm(dir, { recursive: true, force: true });
+  }
+
+  // 3. Tamper detection on the newest test file.
+  {
+    const dir = await mkdtemp(join(tmpdir(), `bench-tamper-${tier}-`));
+    await writeAll(dir, { 'package.json': PACKAGE_JSON, ...goldenSrcAfter(tier), ...cumulativeTests(tier) });
+    const newest = cumulativeTestPaths(tier).slice(-1)[0];
+    await writeFile(join(dir, newest), '// tampered\n', 'utf-8');
+    const r = await runNodeTests(dir, protectedMap(tier), 60000);
+    ok(!r.passed && r.reason === 'tests-modified', `tamper detected on ${newest}`);
+    await rm(dir, { recursive: true, force: true });
+  }
+}
+
+// ── micro-CRM suite (scored, building) ────────────────────────────────────────
+for (const task of MICROCRM_TASKS) {
+  console.log(`\nmicrocrm · ${task.id}`);
+  const protectedFiles = {};
+  for (const p of task.protectedPaths) protectedFiles[p] = task.scaffold[p];
+
+  // 1. Reference (base for crm-build, full for extends) passes the task's tests.
+  {
+    const dir = await mkdtemp(join(tmpdir(), `bench-${task.id}-ref-`));
+    await writeAll(dir, microcrmReferenceFor(task));
+    const r = await runNodeTests(dir, protectedFiles, 120000);
+    ok(r.passed, `reference passes (pass=${r.testsPassed} fail=${r.testsFailed}${r.reason ? ' reason=' + r.reason : ''})`);
+    if (!r.passed) console.log(r.output.split('\n').slice(-15).join('\n'));
+    await rm(dir, { recursive: true, force: true });
+  }
+
+  // 2. Scaffold (no work done yet) fails — the agent has the feature to build.
+  {
+    const dir = await mkdtemp(join(tmpdir(), `bench-${task.id}-scaffold-`));
+    await writeAll(dir, task.scaffold);
+    const r = await runNodeTests(dir, protectedFiles, 120000);
+    ok(!r.passed, `scaffold fails as expected (reason=${r.reason})`);
+    await rm(dir, { recursive: true, force: true });
+  }
+
+  // 3. Tamper detection on the spec test file.
+  {
+    const dir = await mkdtemp(join(tmpdir(), `bench-${task.id}-tamper-`));
+    await writeAll(dir, microcrmReferenceFor(task));
+    await writeFile(join(dir, task.protectedPaths[0]), '// tampered\n', 'utf-8');
+    const r = await runNodeTests(dir, protectedFiles, 120000);
+    ok(!r.passed && r.reason === 'tests-modified', `tamper detected on ${task.protectedPaths[0]}`);
+    await rm(dir, { recursive: true, force: true });
+  }
+}
+
+console.log(`\n${failures === 0 ? 'ALL GOOD' : failures + ' FAILURE(S)'}`);
+process.exit(failures === 0 ? 0 : 1);

--- a/scripts/copy-benchmark-assets.mjs
+++ b/scripts/copy-benchmark-assets.mjs
@@ -1,0 +1,17 @@
+/**
+ * Copy non-TypeScript benchmark assets (the micro-CRM test + reference `.mjs`
+ * files) into dist, since `tsc` only emits compiled TypeScript. Run after `tsc`.
+ */
+import { cpSync, existsSync, mkdirSync } from 'fs';
+import { dirname } from 'path';
+
+const copies = [
+  ['src/code/benchmark/microcrm/assets', 'dist/code/benchmark/microcrm/assets'],
+];
+
+for (const [src, dst] of copies) {
+  if (!existsSync(src)) continue;
+  mkdirSync(dirname(dst), { recursive: true });
+  cpSync(src, dst, { recursive: true });
+  console.log(`[copy-benchmark-assets] ${src} -> ${dst}`);
+}

--- a/src/code/agent.ts
+++ b/src/code/agent.ts
@@ -33,6 +33,19 @@ export interface AgentResponse {
   toolsUsed: string[];
   iterations: number;
   tokenUsage?: import('../models/token-tracker.js').TokenUsageSnapshot;
+  /**
+   * Number of times the model hit its output-token limit mid tool-call this turn
+   * (a write/edit was cut off and had to be re-attempted in stages). A non-zero
+   * count on a failed task indicates an output-length limitation, not a logic gap.
+   */
+  truncationEvents?: number;
+  /**
+   * How the turn ended:
+   *   'completed'      — the model produced a final response on its own.
+   *   'max-iterations' — the step limit was hit before finishing (caller may offer to continue).
+   *   'stopped'        — the user cooperatively stopped the run.
+   */
+  stopReason?: 'completed' | 'max-iterations' | 'stopped';
 }
 
 /**
@@ -58,6 +71,12 @@ function repairFailedToolCall(
     const rawName: string = failed.name || '';
     const args: Record<string, unknown> =
       typeof failed.arguments === 'object' ? failed.arguments : {};
+
+    // Normalize the common `path` alias to `file_path` so a repaired write_file/edit_file
+    // call actually executes (the tools accept either, but downstream consumers expect file_path).
+    if (args && typeof args === 'object' && 'path' in args && !('file_path' in args)) {
+      args.file_path = args.path;
+    }
 
     // Strategy 1: strip all <|...|> tokens from the tool name and try exact match
     const stripped = rawName
@@ -448,6 +467,10 @@ ${directive ? `\n${directive}` : ''}`;
 
     let iterations = 0;
     let finalContent = '';
+    // Count output-token-limit truncations this turn (surfaced in the response so
+    // benchmarks can flag output-length limitations vs genuine logic failures).
+    let truncationEvents = 0;
+    let stopReason: AgentResponse['stopReason'] = 'completed';
 
     // Iteration limit management — two phases (ported from opencode):
     // Phase 1 (0–84%): normal operation, all tools available.
@@ -468,6 +491,7 @@ ${directive ? `\n${directive}` : ''}`;
       if (this._stopped) {
         logger.info('[CodeAgent] Stop requested — exiting after current step');
         finalContent = '[Task stopped by user]';
+        stopReason = 'stopped';
         break;
       }
       iterations = i + 1;
@@ -584,14 +608,66 @@ ${directive ? `\n${directive}` : ''}`;
             continue;
           }
 
+          // Distinguish genuine output-token truncation from schema/argument errors.
+          // Groq codes BOTH as tool_use_failed, so we inspect failed_generation directly:
+          // a complete, parseable failed_generation means the JSON was NOT cut off (a schema
+          // error); an unparseable one means it was truncated mid-content.
+          const failedGenIsTruncated = (() => {
+            try {
+              const m = msg.match(/API error \(\d+\): (.+)/s);
+              if (!m) return null;
+              const body = JSON.parse(m[1]);
+              const fg: string | undefined = body?.error?.failed_generation;
+              if (typeof fg !== 'string') return null;
+              try { JSON.parse(fg); return false; } // complete JSON → schema error, not truncation
+              catch { return true; }                // cut-off JSON → truncated
+            } catch { return null; }
+          })();
+
+          const mentionsFileTool = msg.includes('write_file') || msg.includes('edit_file');
+
+          // --- Specific correction: schema / argument-name error (well-formed JSON, wrong args) ---
+          // The tool call parsed fine but violated the schema (e.g. an unexpected or misspelled
+          // argument name). Name the offending tool's exact parameters rather than mistaking it
+          // for truncation or falling through to a generic strategy reset.
+          const isSchemaArgError =
+            failedGenIsTruncated === false &&
+            (msg.includes('did not match schema') || msg.includes('missing propert'));
+
+          if (isSchemaArgError) {
+            let failedToolName = '';
+            try {
+              const m = msg.match(/API error \(\d+\): (.+)/s);
+              if (m) {
+                const body = JSON.parse(m[1]);
+                const fg: string | undefined = body?.error?.failed_generation;
+                if (fg) { const parsed = JSON.parse(fg); if (parsed?.name) failedToolName = parsed.name; }
+              }
+            } catch { /* ignore extraction errors */ }
+            const tool = this.tools.find((t) => t.name === failedToolName);
+            const expected = tool
+              ? `${tool.name} accepts: ${Object.keys((tool.parameters.properties as Record<string, unknown>) ?? {}).join(', ')}` +
+                ` (required: ${(tool.parameters.required ?? []).join(', ') || 'none'}).`
+              : `Check the tool's required parameters and use their exact names.`;
+            logger.warn(`[CodeAgent] schema/argument error for ${failedToolName || 'tool'} — injecting parameter correction`);
+            messages.push({
+              role: 'user',
+              content:
+                `Your ${failedToolName || 'tool'} call failed schema validation (wrong or missing arguments).\n\n` +
+                `${expected}\n\n` +
+                `Call it again using those exact parameter names.`,
+            });
+            consecutiveToolCallErrors = 0;
+            emptyResponseCount = 0;
+            continue;
+          }
+
           // --- Specific correction: tool content too large (output token limit hit) ---
-          // When the model generates a very large write_file or edit_file call, the API cuts off
-          // the JSON mid-content because the response exceeds the output token limit. The resulting
-          // JSON is unparseable. Detect by tool name appearing in the failed_generation field.
-          // Note: failed_generation is a JSON-encoded string so quotes are escaped (\"tool_name\").
+          // Only genuine truncation routes here: the provider explicitly failed to parse the call,
+          // or failed_generation is present but cut off mid-content (unparseable JSON).
           const isContentTooLarge =
-            (msg.includes('write_file') || msg.includes('edit_file')) &&
-            (msg.includes('Failed to parse tool call') || msg.includes('tool_use_failed'));
+            mentionsFileTool &&
+            (msg.includes('Failed to parse tool call') || failedGenIsTruncated === true);
 
           if (isContentTooLarge) {
             // Parse the actual tool name from failed_generation to distinguish write_file vs edit_file
@@ -612,6 +688,7 @@ ${directive ? `\n${directive}` : ''}`;
             } catch { /* ignore extraction errors */ }
             const isEditFile = failedToolName === 'edit_file';
 
+            truncationEvents++;
             logger.warn(`[CodeAgent] ${isEditFile ? 'edit_file' : 'write_file'}${targetFile} content truncated (exceeded output token limit) — asking model to write in stages`);
             const correctionContent = isEditFile
               ? `Your edit_file call${targetFile} failed: new_string was too large and the response was cut off mid-JSON.\n\n` +
@@ -771,6 +848,7 @@ ${directive ? `\n${directive}` : ''}`;
           const isEditFile = response.content!.includes('edit_file') && !response.content!.includes('write_file');
           const fpMatch = response.content!.match(/<arg_key>file_path<\/arg_key>\s*<arg_value>([^<]+)<\/arg_value>/);
           const targetFile = fpMatch ? ` for \`${fpMatch[1]}\`` : '';
+          truncationEvents++;
           logger.warn(`[CodeAgent] Truncated XML tool call${targetFile} — injecting staged-writing correction`);
 
           const correctionContent = isEditFile
@@ -941,6 +1019,7 @@ ${directive ? `\n${directive}` : ''}`;
 
     if (!finalContent) {
       finalContent = '[Max iterations reached without a final response]';
+      stopReason = 'max-iterations';
     }
 
     // Update conversation history (trim system prompt from what we store)
@@ -959,7 +1038,7 @@ ${directive ? `\n${directive}` : ''}`;
       );
     }
 
-    return { content: finalContent, toolsUsed, iterations, tokenUsage: this.orchestrator.getTokenUsage() };
+    return { content: finalContent, toolsUsed, iterations, tokenUsage: this.orchestrator.getTokenUsage(), truncationEvents, stopReason };
   }
 
   /**

--- a/src/code/benchmark/agent-factory.ts
+++ b/src/code/benchmark/agent-factory.ts
@@ -1,0 +1,31 @@
+/**
+ * Builds a minimal CodeAgent for a single benchmark task.
+ *
+ * The agent is deliberately stripped down — no MCP servers, no persona, no
+ * conversation persistence, LSP off by default — so the benchmark measures the
+ * model's raw code-mode capability with as little environmental variance as
+ * possible.
+ */
+
+import { CodeAgent } from '../agent.js';
+import { WorkspaceManager } from '../../core/workspace.js';
+import type { ModelOrchestrator } from '../../models/orchestrator.js';
+
+export interface BenchmarkAgentOptions {
+  orchestrator: ModelOrchestrator;
+  workspaceDir: string;
+  maxIterations: number;
+  lspEnabled?: boolean;
+}
+
+export async function buildBenchmarkAgent(opts: BenchmarkAgentOptions): Promise<CodeAgent> {
+  const workspace = new WorkspaceManager({ workspaceDir: opts.workspaceDir });
+  await workspace.initialize();
+
+  return new CodeAgent({
+    orchestrator: opts.orchestrator,
+    workspace,
+    maxIterations: opts.maxIterations,
+    lspEnabled: opts.lspEnabled ?? false,
+  });
+}

--- a/src/code/benchmark/fixtures.ts
+++ b/src/code/benchmark/fixtures.ts
@@ -1,0 +1,193 @@
+/**
+ * Canonical "taskstore" library fixtures.
+ *
+ * A single evolving Node library is the substrate for the whole benchmark. Each
+ * tier's scaffold is the canonical (golden) state of the prior tiers plus the
+ * new failing test(s). These helpers are the single source of truth for that
+ * golden state, so the suite stays DRY and the tiers genuinely build on one
+ * another.
+ *
+ * Layout in the workspace:
+ *   package.json        { "type": "module" }
+ *   src/index.js        public entry (single file for tiers 1-4, re-export after)
+ *   src/model.js        mutation functions (after the tier-5 refactor)
+ *   src/query.js        read functions (after the tier-5 refactor)
+ *   src/storage.js      serialize/deserialize (after tier 7)
+ *   test/tNN.test.mjs   cumulative node:test files
+ */
+
+import type { TaskFile } from './types.js';
+
+export const PACKAGE_JSON = JSON.stringify({ name: 'taskstore', type: 'module', private: true }, null, 2) + '\n';
+
+// ---------------------------------------------------------------------------
+// Function source snippets (correct + buggy variants)
+// ---------------------------------------------------------------------------
+
+const createTaskFn = `export function createTask(title) {
+  if (typeof title !== 'string' || title.trim() === '') {
+    throw new Error('title is required');
+  }
+  return { title, done: false, priority: 'normal', due: null };
+}`;
+
+const addTaskFn = `export function addTask(list, title) {
+  const task = createTask(title);
+  const nextId = list.reduce((max, t) => Math.max(max, t.id || 0), 0) + 1;
+  return [...list, { ...task, id: nextId }];
+}`;
+
+/** Tier-8 planted bug: length-based id collides after a removal. */
+const addTaskBuggyFn = `export function addTask(list, title) {
+  const task = createTask(title);
+  // BUG: uses list length for the id, which collides after a removal.
+  const nextId = list.length + 1;
+  return [...list, { ...task, id: nextId }];
+}`;
+
+const removeTaskFn = `export function removeTask(list, id) {
+  return list.filter((t) => t.id !== id);
+}`;
+
+const listTasksFn = `export function listTasks(list) {
+  return [...list];
+}`;
+
+const toggleTaskFn = `export function toggleTask(list, id) {
+  return list.map((t) => (t.id === id ? { ...t, done: !t.done } : t));
+}`;
+
+/** Tier-3 planted bug: treats id as an array index. */
+const toggleTaskBuggyFn = `export function toggleTask(list, id) {
+  // BUG: treats id as an array index instead of matching task.id.
+  return list.map((t, index) => (index === id ? { ...t, done: !t.done } : t));
+}`;
+
+const setPriorityFn = `const PRIORITIES = ['low', 'normal', 'high'];
+export function setPriority(list, id, priority) {
+  if (!PRIORITIES.includes(priority)) {
+    throw new Error('invalid priority: ' + priority);
+  }
+  return list.map((t) => (t.id === id ? { ...t, priority } : t));
+}`;
+
+const tasksByPriorityFn = `export function tasksByPriority(list, priority) {
+  return list.filter((t) => t.priority === priority);
+}`;
+
+const sortTasksFn = `export function sortTasks(list, options = {}) {
+  const by = options.by || 'due';
+  if (by !== 'due') throw new Error('unsupported sort key: ' + by);
+  // Array.prototype.sort is stable in Node, so equal keys keep their order.
+  return [...list].sort((a, b) => {
+    const av = a.due ?? null;
+    const bv = b.due ?? null;
+    if (av === null && bv === null) return 0;
+    if (av === null) return 1; // tasks without a due date sort last
+    if (bv === null) return -1;
+    if (av < bv) return -1;
+    if (av > bv) return 1;
+    return 0;
+  });
+}`;
+
+const storageFns = `export function serialize(list) {
+  return JSON.stringify(list);
+}
+
+export function deserialize(str) {
+  const data = JSON.parse(str);
+  if (!Array.isArray(data)) throw new Error('expected an array');
+  return data;
+}`;
+
+// ---------------------------------------------------------------------------
+// Golden src builders
+// ---------------------------------------------------------------------------
+
+/** Single-file `src/index.js` containing every function up to `tier` (<=4). */
+function singleFileSrc(tier: number, opts: { buggyToggle?: boolean } = {}): TaskFile {
+  const parts = [createTaskFn];
+  if (tier >= 2) parts.push(addTaskFn, removeTaskFn, listTasksFn);
+  if (opts.buggyToggle) parts.push(toggleTaskBuggyFn);
+  else if (tier >= 3) parts.push(toggleTaskFn);
+  if (tier >= 4) parts.push(setPriorityFn, tasksByPriorityFn);
+  return { 'src/index.js': parts.join('\n\n') + '\n' };
+}
+
+/** Multi-file layout (after the tier-5 refactor). */
+function multiFileSrc(opts: { sort?: boolean; storage?: boolean; buggyAdd?: boolean } = {}): TaskFile {
+  const model = [
+    createTaskFn,
+    opts.buggyAdd ? addTaskBuggyFn : addTaskFn,
+    removeTaskFn,
+    toggleTaskFn,
+    setPriorityFn,
+  ].join('\n\n') + '\n';
+
+  const query = [listTasksFn, tasksByPriorityFn, ...(opts.sort ? [sortTasksFn] : [])].join('\n\n') + '\n';
+
+  const reexports = [`export * from './model.js';`, `export * from './query.js';`];
+  if (opts.storage) reexports.push(`export * from './storage.js';`);
+
+  const files: TaskFile = {
+    'src/model.js': model,
+    'src/query.js': query,
+    'src/index.js': reexports.join('\n') + '\n',
+  };
+  if (opts.storage) files['src/storage.js'] = storageFns + '\n';
+  return files;
+}
+
+/**
+ * Canonical golden source state *after* a tier is completed. Used both as the
+ * baseline scaffold for the next tier and (by the harness self-test) as a
+ * "known-good" set of files a mock agent can write to prove the verifier works.
+ */
+export function goldenSrcAfter(tier: number): TaskFile {
+  switch (tier) {
+    case 0:
+      return {};
+    case 1:
+      return singleFileSrc(1);
+    case 2:
+      return singleFileSrc(2);
+    case 3:
+      return singleFileSrc(3);
+    case 4:
+      return singleFileSrc(4);
+    case 5:
+      return multiFileSrc();
+    case 6:
+      return multiFileSrc({ sort: true });
+    case 7:
+    case 8:
+      return multiFileSrc({ sort: true, storage: true });
+    default:
+      throw new Error(`no golden state for tier ${tier}`);
+  }
+}
+
+/** The scaffolded (pre-agent) src state for a given tier — golden(N-1) plus any planted bug. */
+export function scaffoldSrc(tier: number): TaskFile {
+  switch (tier) {
+    case 1:
+      return {}; // nothing yet — the agent creates src/index.js from scratch
+    case 2:
+      return singleFileSrc(1);
+    case 3:
+      return singleFileSrc(2, { buggyToggle: true }); // planted toggle bug
+    case 4:
+      return singleFileSrc(3);
+    case 5:
+      return singleFileSrc(4);
+    case 6:
+      return multiFileSrc();
+    case 7:
+      return multiFileSrc({ sort: true });
+    case 8:
+      return multiFileSrc({ sort: true, storage: true, buggyAdd: true }); // planted add bug
+    default:
+      throw new Error(`no scaffold for tier ${tier}`);
+  }
+}

--- a/src/code/benchmark/index.ts
+++ b/src/code/benchmark/index.ts
@@ -1,0 +1,25 @@
+/**
+ * Code-mode benchmark suite — public entry point.
+ *
+ * Drives CodeAgent through a TDD-style suite of increasing complexity in
+ * isolated workspaces, scoring each task deterministically with Node's built-in
+ * test runner. Invokable from the CLI (`jiva benchmark`) and the HTTP API
+ * (`/api/benchmark/*`).
+ */
+
+export { BENCHMARK_TASKS, listTaskMetadata, selectTasks } from './tasks.js';
+export { BENCHMARK_SUITES, DEFAULT_SUITE_ID, getSuite, listSuiteMetadata } from './suites.js';
+export { runBenchmark, BenchmarkRunner } from './runner.js';
+export { createOrchestrator } from './orchestrator-factory.js';
+export type { OrchestratorInput, OrchestratorBundle, ModelConfigInput } from './orchestrator-factory.js';
+export { formatReportForCLI, toReportJSON } from './report.js';
+export type {
+  BenchmarkTask,
+  BenchmarkSuite,
+  ScoringMode,
+  TaskResult,
+  SuiteResult,
+  RunnerOptions,
+  ProgressEvents,
+  VerifyResult,
+} from './types.js';

--- a/src/code/benchmark/microcrm/assets/api.test.mjs
+++ b/src/code/benchmark/microcrm/assets/api.test.mjs
@@ -1,0 +1,254 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { createApp } from '../src/app.js';
+
+// Each test gets a fresh in-memory app on an ephemeral port, so tests are
+// independent and a partial implementation still passes the subset it supports.
+async function withServer(run) {
+  const server = createApp(':memory:');
+  await new Promise((res) => server.listen(0, res));
+  const { port } = server.address();
+  try {
+    await run(`http://127.0.0.1:${port}`);
+  } finally {
+    await new Promise((res) => server.close(res));
+  }
+}
+
+async function req(base, method, path, body, raw) {
+  const init = { method, headers: {} };
+  if (raw !== undefined) { init.headers['content-type'] = 'application/json'; init.body = raw; }
+  else if (body !== undefined) { init.headers['content-type'] = 'application/json'; init.body = JSON.stringify(body); }
+  const res = await fetch(base + path, init);
+  const text = await res.text();
+  let json = null;
+  try { json = text ? JSON.parse(text) : null; } catch { json = null; }
+  return { status: res.status, body: json };
+}
+
+const mkContact = (over = {}) => ({ name: 'Ada Lovelace', email: `ada${Math.random().toString(36).slice(2)}@example.com`, company: 'Analytical', ...over });
+
+// ── Contacts: create & validation ─────────────────────────────────────────────
+test('POST /contacts creates a contact (201) with id and created_at', () =>
+  withServer(async (base) => {
+    const c = mkContact();
+    const r = await req(base, 'POST', '/contacts', c);
+    assert.equal(r.status, 201);
+    assert.ok(Number.isInteger(r.body.id));
+    assert.equal(r.body.name, c.name);
+    assert.equal(r.body.email, c.email);
+    assert.ok(typeof r.body.created_at === 'string' && r.body.created_at.length > 0);
+  }));
+
+test('POST /contacts without name → 400', () =>
+  withServer(async (base) => {
+    const r = await req(base, 'POST', '/contacts', { email: 'x@y.com' });
+    assert.equal(r.status, 400);
+  }));
+
+test('POST /contacts without email → 400', () =>
+  withServer(async (base) => {
+    const r = await req(base, 'POST', '/contacts', { name: 'No Email' });
+    assert.equal(r.status, 400);
+  }));
+
+test('POST /contacts with malformed email → 400', () =>
+  withServer(async (base) => {
+    const r = await req(base, 'POST', '/contacts', { name: 'Bad', email: 'not-an-email' });
+    assert.equal(r.status, 400);
+  }));
+
+test('POST /contacts with duplicate email → 409', () =>
+  withServer(async (base) => {
+    const c = mkContact();
+    assert.equal((await req(base, 'POST', '/contacts', c)).status, 201);
+    const r = await req(base, 'POST', '/contacts', c);
+    assert.equal(r.status, 409);
+  }));
+
+test('POST /contacts with malformed JSON body → 400', () =>
+  withServer(async (base) => {
+    const r = await req(base, 'POST', '/contacts', undefined, '{ not json');
+    assert.equal(r.status, 400);
+  }));
+
+// ── Contacts: read ─────────────────────────────────────────────────────────────
+test('GET /contacts/:id returns the contact (200)', () =>
+  withServer(async (base) => {
+    const created = await req(base, 'POST', '/contacts', mkContact());
+    const r = await req(base, 'GET', `/contacts/${created.body.id}`);
+    assert.equal(r.status, 200);
+    assert.equal(r.body.id, created.body.id);
+  }));
+
+test('GET /contacts/:id unknown → 404', () =>
+  withServer(async (base) => {
+    const r = await req(base, 'GET', '/contacts/99999');
+    assert.equal(r.status, 404);
+  }));
+
+test('GET /contacts returns { data, total }', () =>
+  withServer(async (base) => {
+    await req(base, 'POST', '/contacts', mkContact());
+    await req(base, 'POST', '/contacts', mkContact());
+    const r = await req(base, 'GET', '/contacts');
+    assert.equal(r.status, 200);
+    assert.ok(Array.isArray(r.body.data));
+    assert.equal(r.body.total, 2);
+    assert.equal(r.body.data.length, 2);
+  }));
+
+test('GET /contacts?q= filters by name or email substring', () =>
+  withServer(async (base) => {
+    await req(base, 'POST', '/contacts', mkContact({ name: 'Grace Hopper', email: 'grace@navy.mil' }));
+    await req(base, 'POST', '/contacts', mkContact({ name: 'Alan Turing', email: 'alan@bletchley.uk' }));
+    const r = await req(base, 'GET', '/contacts?q=Hopper');
+    assert.equal(r.status, 200);
+    assert.equal(r.body.total, 1);
+    assert.equal(r.body.data[0].name, 'Grace Hopper');
+  }));
+
+test('GET /contacts?limit=&offset= paginates while total reflects the full count', () =>
+  withServer(async (base) => {
+    for (let i = 0; i < 5; i++) await req(base, 'POST', '/contacts', mkContact());
+    const r = await req(base, 'GET', '/contacts?limit=2&offset=0');
+    assert.equal(r.status, 200);
+    assert.equal(r.body.data.length, 2);
+    assert.equal(r.body.total, 5);
+  }));
+
+// ── Contacts: update & delete ──────────────────────────────────────────────────
+test('PATCH /contacts/:id updates a field (200)', () =>
+  withServer(async (base) => {
+    const created = await req(base, 'POST', '/contacts', mkContact({ company: 'Old' }));
+    const r = await req(base, 'PATCH', `/contacts/${created.body.id}`, { company: 'New Co' });
+    assert.equal(r.status, 200);
+    assert.equal(r.body.company, 'New Co');
+  }));
+
+test('PATCH /contacts/:id to an existing email → 409', () =>
+  withServer(async (base) => {
+    const a = await req(base, 'POST', '/contacts', mkContact());
+    const b = await req(base, 'POST', '/contacts', mkContact());
+    const r = await req(base, 'PATCH', `/contacts/${b.body.id}`, { email: a.body.email });
+    assert.equal(r.status, 409);
+  }));
+
+test('PATCH /contacts/:id unknown → 404', () =>
+  withServer(async (base) => {
+    const r = await req(base, 'PATCH', '/contacts/99999', { company: 'x' });
+    assert.equal(r.status, 404);
+  }));
+
+test('DELETE /contacts/:id → 204 then GET → 404', () =>
+  withServer(async (base) => {
+    const created = await req(base, 'POST', '/contacts', mkContact());
+    const del = await req(base, 'DELETE', `/contacts/${created.body.id}`);
+    assert.equal(del.status, 204);
+    const r = await req(base, 'GET', `/contacts/${created.body.id}`);
+    assert.equal(r.status, 404);
+  }));
+
+test('DELETE /contacts/:id unknown → 404', () =>
+  withServer(async (base) => {
+    const r = await req(base, 'DELETE', '/contacts/99999');
+    assert.equal(r.status, 404);
+  }));
+
+// ── Deals ──────────────────────────────────────────────────────────────────────
+test('POST /contacts/:id/deals creates a deal (201) defaulting stage to "lead"', () =>
+  withServer(async (base) => {
+    const c = await req(base, 'POST', '/contacts', mkContact());
+    const r = await req(base, 'POST', `/contacts/${c.body.id}/deals`, { title: 'Big deal', amount: 1000 });
+    assert.equal(r.status, 201);
+    assert.equal(r.body.stage, 'lead');
+    assert.equal(r.body.amount, 1000);
+    assert.equal(r.body.contact_id, c.body.id);
+  }));
+
+test('POST deal for unknown contact → 404', () =>
+  withServer(async (base) => {
+    const r = await req(base, 'POST', '/contacts/99999/deals', { title: 'x' });
+    assert.equal(r.status, 404);
+  }));
+
+test('POST deal without title → 400', () =>
+  withServer(async (base) => {
+    const c = await req(base, 'POST', '/contacts', mkContact());
+    const r = await req(base, 'POST', `/contacts/${c.body.id}/deals`, { amount: 10 });
+    assert.equal(r.status, 400);
+  }));
+
+test('POST deal with invalid stage → 400', () =>
+  withServer(async (base) => {
+    const c = await req(base, 'POST', '/contacts', mkContact());
+    const r = await req(base, 'POST', `/contacts/${c.body.id}/deals`, { title: 'x', stage: 'banana' });
+    assert.equal(r.status, 400);
+  }));
+
+test('POST deal with negative amount → 400', () =>
+  withServer(async (base) => {
+    const c = await req(base, 'POST', '/contacts', mkContact());
+    const r = await req(base, 'POST', `/contacts/${c.body.id}/deals`, { title: 'x', amount: -5 });
+    assert.equal(r.status, 400);
+  }));
+
+test('GET /contacts/:id/deals lists only that contact’s deals', () =>
+  withServer(async (base) => {
+    const a = await req(base, 'POST', '/contacts', mkContact());
+    const b = await req(base, 'POST', '/contacts', mkContact());
+    await req(base, 'POST', `/contacts/${a.body.id}/deals`, { title: 'A1' });
+    await req(base, 'POST', `/contacts/${a.body.id}/deals`, { title: 'A2' });
+    await req(base, 'POST', `/contacts/${b.body.id}/deals`, { title: 'B1' });
+    const r = await req(base, 'GET', `/contacts/${a.body.id}/deals`);
+    assert.equal(r.status, 200);
+    assert.equal(r.body.data.length, 2);
+  }));
+
+test('GET /deals?stage= filters by stage', () =>
+  withServer(async (base) => {
+    const c = await req(base, 'POST', '/contacts', mkContact());
+    await req(base, 'POST', `/contacts/${c.body.id}/deals`, { title: 'won1', stage: 'won', amount: 100 });
+    await req(base, 'POST', `/contacts/${c.body.id}/deals`, { title: 'lead1', stage: 'lead' });
+    const r = await req(base, 'GET', '/deals?stage=won');
+    assert.equal(r.status, 200);
+    assert.equal(r.body.data.length, 1);
+    assert.equal(r.body.data[0].stage, 'won');
+  }));
+
+test('PATCH /deals/:id updates the stage (200)', () =>
+  withServer(async (base) => {
+    const c = await req(base, 'POST', '/contacts', mkContact());
+    const d = await req(base, 'POST', `/contacts/${c.body.id}/deals`, { title: 'x', stage: 'lead' });
+    const r = await req(base, 'PATCH', `/deals/${d.body.id}`, { stage: 'won' });
+    assert.equal(r.status, 200);
+    assert.equal(r.body.stage, 'won');
+  }));
+
+test('GET /deals/summary aggregates count and totalAmount per stage', () =>
+  withServer(async (base) => {
+    const c = await req(base, 'POST', '/contacts', mkContact());
+    await req(base, 'POST', `/contacts/${c.body.id}/deals`, { title: 'w1', stage: 'won', amount: 100 });
+    await req(base, 'POST', `/contacts/${c.body.id}/deals`, { title: 'w2', stage: 'won', amount: 250 });
+    const r = await req(base, 'GET', '/deals/summary');
+    assert.equal(r.status, 200);
+    assert.equal(r.body.summary.won.count, 2);
+    assert.equal(r.body.summary.won.totalAmount, 350);
+    assert.equal(r.body.summary.lead.count, 0);
+  }));
+
+test('DELETE contact cascades to its deals', () =>
+  withServer(async (base) => {
+    const c = await req(base, 'POST', '/contacts', mkContact());
+    await req(base, 'POST', `/contacts/${c.body.id}/deals`, { title: 'd1', stage: 'won', amount: 10 });
+    await req(base, 'DELETE', `/contacts/${c.body.id}`);
+    const r = await req(base, 'GET', '/deals');
+    assert.equal(r.status, 200);
+    assert.equal(r.body.data.length, 0);
+  }));
+
+test('unknown route → 404', () =>
+  withServer(async (base) => {
+    const r = await req(base, 'GET', '/nope');
+    assert.equal(r.status, 404);
+  }));

--- a/src/code/benchmark/microcrm/assets/app.full.reference.mjs
+++ b/src/code/benchmark/microcrm/assets/app.full.reference.mjs
@@ -1,0 +1,267 @@
+import http from 'node:http';
+import { DatabaseSync } from 'node:sqlite';
+
+const STAGES = ['lead', 'qualified', 'won', 'lost'];
+const STAGE_PROBABILITY = { lead: 0.1, qualified: 0.4, won: 1.0, lost: 0.0 };
+const EMAIL_RE = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+const round = (n, dp) => Math.round(n * 10 ** dp) / 10 ** dp;
+
+export function createApp(dbPath = ':memory:') {
+  const db = new DatabaseSync(dbPath);
+  db.exec('PRAGMA foreign_keys = ON;');
+  db.exec(`
+    CREATE TABLE IF NOT EXISTS contacts (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      name TEXT NOT NULL,
+      email TEXT NOT NULL UNIQUE,
+      company TEXT,
+      created_at TEXT NOT NULL
+    );
+    CREATE TABLE IF NOT EXISTS deals (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      contact_id INTEGER NOT NULL,
+      title TEXT NOT NULL,
+      amount REAL NOT NULL DEFAULT 0,
+      stage TEXT NOT NULL DEFAULT 'lead',
+      created_at TEXT NOT NULL,
+      FOREIGN KEY (contact_id) REFERENCES contacts(id) ON DELETE CASCADE
+    );
+  `);
+
+  // In-memory idempotency-key store: key -> contact id (per app instance).
+  const idempotency = new Map();
+
+  const getContact = (id) => db.prepare('SELECT * FROM contacts WHERE id = ?').get(id) ?? null;
+  const getDeal = (id) => db.prepare('SELECT * FROM deals WHERE id = ?').get(id) ?? null;
+
+  function validateContact(b, requireAll) {
+    if (requireAll || b.name !== undefined) {
+      if (typeof b.name !== 'string' || b.name.trim() === '') return 'name is required';
+    }
+    if (requireAll || b.email !== undefined) {
+      if (typeof b.email !== 'string' || !EMAIL_RE.test(b.email)) return 'a valid email is required';
+    }
+    return null;
+  }
+  function validateDeal(b, requireAll) {
+    if (requireAll || b.title !== undefined) {
+      if (typeof b.title !== 'string' || b.title.trim() === '') return 'title is required';
+    }
+    if (b.amount !== undefined) {
+      if (typeof b.amount !== 'number' || Number.isNaN(b.amount) || b.amount < 0) return 'amount must be a number >= 0';
+    }
+    if (b.stage !== undefined) {
+      if (!STAGES.includes(b.stage)) return 'invalid stage';
+    }
+    return null;
+  }
+
+  const send = (res, status, obj) => {
+    res.writeHead(status, { 'content-type': 'application/json' });
+    res.end(obj === undefined ? '' : JSON.stringify(obj));
+  };
+  const readBody = (req) =>
+    new Promise((resolve, reject) => {
+      let data = '';
+      req.on('data', (c) => (data += c));
+      req.on('end', () => {
+        if (!data) return resolve({});
+        try { resolve(JSON.parse(data)); } catch { reject(new Error('invalid json')); }
+      });
+      req.on('error', reject);
+    });
+
+  const insertDeal = (contactId, d) =>
+    db.prepare('INSERT INTO deals (contact_id, title, amount, stage, created_at) VALUES (?, ?, ?, ?, ?)')
+      .run(contactId, d.title, d.amount ?? 0, d.stage ?? 'lead', new Date().toISOString());
+
+  const handler = async (req, res) => {
+    const url = new URL(req.url, 'http://localhost');
+    const parts = url.pathname.split('/').filter(Boolean);
+    const method = req.method;
+
+    try {
+      if (parts[0] === 'contacts') {
+        // POST /contacts (with optional Idempotency-Key)
+        if (parts.length === 1 && method === 'POST') {
+          const key = req.headers['idempotency-key'];
+          if (key && idempotency.has(key)) {
+            return send(res, 200, getContact(idempotency.get(key)));
+          }
+          let body;
+          try { body = await readBody(req); } catch { return send(res, 400, { error: 'invalid json' }); }
+          const err = validateContact(body, true);
+          if (err) return send(res, 400, { error: err });
+          try {
+            const info = db
+              .prepare('INSERT INTO contacts (name, email, company, created_at) VALUES (?, ?, ?, ?)')
+              .run(body.name, body.email, body.company ?? null, new Date().toISOString());
+            const id = Number(info.lastInsertRowid);
+            if (key) idempotency.set(key, id);
+            return send(res, 201, getContact(id));
+          } catch (e) {
+            if (String(e.message).includes('UNIQUE')) return send(res, 409, { error: 'email already exists' });
+            throw e;
+          }
+        }
+        if (parts.length === 1 && method === 'GET') {
+          const q = url.searchParams.get('q');
+          const limit = Math.max(0, parseInt(url.searchParams.get('limit') ?? '50', 10) || 50);
+          const offset = Math.max(0, parseInt(url.searchParams.get('offset') ?? '0', 10) || 0);
+          let where = '';
+          const args = [];
+          if (q) { where = 'WHERE name LIKE ? OR email LIKE ?'; args.push('%' + q + '%', '%' + q + '%'); }
+          const total = db.prepare(`SELECT COUNT(*) AS c FROM contacts ${where}`).get(...args).c;
+          const data = db.prepare(`SELECT * FROM contacts ${where} ORDER BY id LIMIT ? OFFSET ?`).all(...args, limit, offset);
+          return send(res, 200, { data, total });
+        }
+        if (parts.length === 2) {
+          const id = Number(parts[1]);
+          const existing = getContact(id);
+          if (method === 'GET') return existing ? send(res, 200, existing) : send(res, 404, { error: 'not found' });
+          if (method === 'PATCH') {
+            if (!existing) return send(res, 404, { error: 'not found' });
+            let body;
+            try { body = await readBody(req); } catch { return send(res, 400, { error: 'invalid json' }); }
+            const err = validateContact(body, false);
+            if (err) return send(res, 400, { error: err });
+            const name = body.name ?? existing.name;
+            const email = body.email ?? existing.email;
+            const company = body.company !== undefined ? body.company : existing.company;
+            try {
+              db.prepare('UPDATE contacts SET name = ?, email = ?, company = ? WHERE id = ?').run(name, email, company, id);
+            } catch (e) {
+              if (String(e.message).includes('UNIQUE')) return send(res, 409, { error: 'email already exists' });
+              throw e;
+            }
+            return send(res, 200, getContact(id));
+          }
+          if (method === 'DELETE') {
+            if (!existing) return send(res, 404, { error: 'not found' });
+            db.prepare('DELETE FROM contacts WHERE id = ?').run(id);
+            return send(res, 204);
+          }
+        }
+        // GET /contacts/:id/stats
+        if (parts.length === 3 && parts[2] === 'stats' && method === 'GET') {
+          const id = Number(parts[1]);
+          if (!getContact(id)) return send(res, 404, { error: 'contact not found' });
+          const deals = db.prepare('SELECT * FROM deals WHERE contact_id = ?').all(id);
+          const totalDeals = deals.length;
+          const totalValue = deals.reduce((s, d) => s + d.amount, 0);
+          const wonDeals = deals.filter((d) => d.stage === 'won');
+          const wonValue = wonDeals.reduce((s, d) => s + d.amount, 0);
+          const winRate = totalDeals === 0 ? 0 : round(wonDeals.length / totalDeals, 4);
+          const weightedPipeline = round(deals.reduce((s, d) => s + d.amount * (STAGE_PROBABILITY[d.stage] ?? 0), 0), 2);
+          return send(res, 200, { totalDeals, totalValue, wonValue, winRate, weightedPipeline });
+        }
+        // /contacts/:id/deals  and  /contacts/:id/deals/bulk
+        if ((parts.length === 3 || parts.length === 4) && parts[2] === 'deals') {
+          const id = Number(parts[1]);
+          const contact = getContact(id);
+          if (!contact) return send(res, 404, { error: 'contact not found' });
+
+          // POST /contacts/:id/deals/bulk — atomic
+          if (parts.length === 4 && parts[3] === 'bulk' && method === 'POST') {
+            let body;
+            try { body = await readBody(req); } catch { return send(res, 400, { error: 'invalid json' }); }
+            const list = body?.deals;
+            if (!Array.isArray(list) || list.length === 0) return send(res, 400, { error: 'deals must be a non-empty array' });
+            for (const d of list) {
+              const err = validateDeal(d, true);
+              if (err) return send(res, 400, { error: err }); // reject whole batch, insert nothing
+            }
+            db.exec('BEGIN');
+            try {
+              const created = [];
+              for (const d of list) created.push(getDeal(Number(insertDeal(id, d).lastInsertRowid)));
+              db.exec('COMMIT');
+              return send(res, 201, { data: created, total: created.length });
+            } catch (e) {
+              db.exec('ROLLBACK');
+              throw e;
+            }
+          }
+
+          if (parts.length === 3 && method === 'POST') {
+            let body;
+            try { body = await readBody(req); } catch { return send(res, 400, { error: 'invalid json' }); }
+            const err = validateDeal(body, true);
+            if (err) return send(res, 400, { error: err });
+            return send(res, 201, getDeal(Number(insertDeal(id, body).lastInsertRowid)));
+          }
+          if (parts.length === 3 && method === 'GET') {
+            const data = db.prepare('SELECT * FROM deals WHERE contact_id = ? ORDER BY id').all(id);
+            return send(res, 200, { data, total: data.length });
+          }
+        }
+      }
+
+      if (parts[0] === 'deals') {
+        if (parts.length === 2 && parts[1] === 'summary' && method === 'GET') {
+          const summary = {};
+          for (const s of STAGES) summary[s] = { count: 0, totalAmount: 0 };
+          const rows = db
+            .prepare('SELECT stage, COUNT(*) AS count, COALESCE(SUM(amount), 0) AS totalAmount FROM deals GROUP BY stage')
+            .all();
+          for (const r of rows) summary[r.stage] = { count: r.count, totalAmount: r.totalAmount };
+          return send(res, 200, { summary });
+        }
+        // GET /deals — advanced filtering / sorting / pagination
+        if (parts.length === 1 && method === 'GET') {
+          const sp = url.searchParams;
+          const where = [];
+          const args = [];
+          const stage = sp.get('stage');
+          if (stage !== null) { where.push('stage = ?'); args.push(stage); }
+          for (const [param, op] of [['minAmount', '>='], ['maxAmount', '<=']]) {
+            const v = sp.get(param);
+            if (v !== null) {
+              const n = Number(v);
+              if (Number.isNaN(n)) return send(res, 400, { error: `invalid ${param}` });
+              where.push(`amount ${op} ?`);
+              args.push(n);
+            }
+          }
+          let orderBy = 'id';
+          let dir = 'ASC';
+          const sort = sp.get('sort');
+          if (sort !== null) {
+            const [field, d = 'asc'] = sort.split(':');
+            if (!['amount', 'created_at', 'id'].includes(field) || !['asc', 'desc'].includes(d.toLowerCase())) {
+              return send(res, 400, { error: 'invalid sort' });
+            }
+            orderBy = field;
+            dir = d.toUpperCase();
+          }
+          const whereSql = where.length ? `WHERE ${where.join(' AND ')}` : '';
+          const total = db.prepare(`SELECT COUNT(*) AS c FROM deals ${whereSql}`).get(...args).c;
+          const limit = Math.max(0, parseInt(sp.get('limit') ?? '50', 10) || 50);
+          const offset = Math.max(0, parseInt(sp.get('offset') ?? '0', 10) || 0);
+          const data = db.prepare(`SELECT * FROM deals ${whereSql} ORDER BY ${orderBy} ${dir} LIMIT ? OFFSET ?`).all(...args, limit, offset);
+          return send(res, 200, { data, total, hasMore: offset + data.length < total });
+        }
+        if (parts.length === 2 && method === 'PATCH') {
+          const id = Number(parts[1]);
+          const existing = getDeal(id);
+          if (!existing) return send(res, 404, { error: 'not found' });
+          let body;
+          try { body = await readBody(req); } catch { return send(res, 400, { error: 'invalid json' }); }
+          const err = validateDeal(body, false);
+          if (err) return send(res, 400, { error: err });
+          const title = body.title ?? existing.title;
+          const amount = body.amount ?? existing.amount;
+          const stage = body.stage ?? existing.stage;
+          db.prepare('UPDATE deals SET title = ?, amount = ?, stage = ? WHERE id = ?').run(title, amount, stage, id);
+          return send(res, 200, getDeal(id));
+        }
+      }
+
+      return send(res, 404, { error: 'not found' });
+    } catch (e) {
+      return send(res, 500, { error: 'internal error: ' + (e?.message || String(e)) });
+    }
+  };
+
+  return http.createServer(handler);
+}

--- a/src/code/benchmark/microcrm/assets/app.reference.mjs
+++ b/src/code/benchmark/microcrm/assets/app.reference.mjs
@@ -1,0 +1,191 @@
+import http from 'node:http';
+import { DatabaseSync } from 'node:sqlite';
+
+const STAGES = ['lead', 'qualified', 'won', 'lost'];
+const EMAIL_RE = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+
+export function createApp(dbPath = ':memory:') {
+  const db = new DatabaseSync(dbPath);
+  db.exec('PRAGMA foreign_keys = ON;');
+  db.exec(`
+    CREATE TABLE IF NOT EXISTS contacts (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      name TEXT NOT NULL,
+      email TEXT NOT NULL UNIQUE,
+      company TEXT,
+      created_at TEXT NOT NULL
+    );
+    CREATE TABLE IF NOT EXISTS deals (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      contact_id INTEGER NOT NULL,
+      title TEXT NOT NULL,
+      amount REAL NOT NULL DEFAULT 0,
+      stage TEXT NOT NULL DEFAULT 'lead',
+      created_at TEXT NOT NULL,
+      FOREIGN KEY (contact_id) REFERENCES contacts(id) ON DELETE CASCADE
+    );
+  `);
+
+  const getContact = (id) => db.prepare('SELECT * FROM contacts WHERE id = ?').get(id) ?? null;
+  const getDeal = (id) => db.prepare('SELECT * FROM deals WHERE id = ?').get(id) ?? null;
+
+  function validateContact(b, requireAll) {
+    if (requireAll || b.name !== undefined) {
+      if (typeof b.name !== 'string' || b.name.trim() === '') return 'name is required';
+    }
+    if (requireAll || b.email !== undefined) {
+      if (typeof b.email !== 'string' || !EMAIL_RE.test(b.email)) return 'a valid email is required';
+    }
+    return null;
+  }
+  function validateDeal(b, requireAll) {
+    if (requireAll || b.title !== undefined) {
+      if (typeof b.title !== 'string' || b.title.trim() === '') return 'title is required';
+    }
+    if (b.amount !== undefined) {
+      if (typeof b.amount !== 'number' || Number.isNaN(b.amount) || b.amount < 0) return 'amount must be a number >= 0';
+    }
+    if (b.stage !== undefined) {
+      if (!STAGES.includes(b.stage)) return 'invalid stage';
+    }
+    return null;
+  }
+
+  const send = (res, status, obj) => {
+    res.writeHead(status, { 'content-type': 'application/json' });
+    res.end(obj === undefined ? '' : JSON.stringify(obj));
+  };
+  const readBody = (req) =>
+    new Promise((resolve, reject) => {
+      let data = '';
+      req.on('data', (c) => (data += c));
+      req.on('end', () => {
+        if (!data) return resolve({});
+        try { resolve(JSON.parse(data)); } catch { reject(new Error('invalid json')); }
+      });
+      req.on('error', reject);
+    });
+
+  const handler = async (req, res) => {
+    const url = new URL(req.url, 'http://localhost');
+    const parts = url.pathname.split('/').filter(Boolean);
+    const method = req.method;
+
+    try {
+      if (parts[0] === 'contacts') {
+        if (parts.length === 1 && method === 'POST') {
+          let body;
+          try { body = await readBody(req); } catch { return send(res, 400, { error: 'invalid json' }); }
+          const err = validateContact(body, true);
+          if (err) return send(res, 400, { error: err });
+          try {
+            const info = db
+              .prepare('INSERT INTO contacts (name, email, company, created_at) VALUES (?, ?, ?, ?)')
+              .run(body.name, body.email, body.company ?? null, new Date().toISOString());
+            return send(res, 201, getContact(Number(info.lastInsertRowid)));
+          } catch (e) {
+            if (String(e.message).includes('UNIQUE')) return send(res, 409, { error: 'email already exists' });
+            throw e;
+          }
+        }
+        if (parts.length === 1 && method === 'GET') {
+          const q = url.searchParams.get('q');
+          const limit = Math.max(0, parseInt(url.searchParams.get('limit') ?? '50', 10) || 50);
+          const offset = Math.max(0, parseInt(url.searchParams.get('offset') ?? '0', 10) || 0);
+          let where = '';
+          const args = [];
+          if (q) { where = 'WHERE name LIKE ? OR email LIKE ?'; args.push('%' + q + '%', '%' + q + '%'); }
+          const total = db.prepare(`SELECT COUNT(*) AS c FROM contacts ${where}`).get(...args).c;
+          const data = db.prepare(`SELECT * FROM contacts ${where} ORDER BY id LIMIT ? OFFSET ?`).all(...args, limit, offset);
+          return send(res, 200, { data, total });
+        }
+        if (parts.length === 2) {
+          const id = Number(parts[1]);
+          const existing = getContact(id);
+          if (method === 'GET') return existing ? send(res, 200, existing) : send(res, 404, { error: 'not found' });
+          if (method === 'PATCH') {
+            if (!existing) return send(res, 404, { error: 'not found' });
+            let body;
+            try { body = await readBody(req); } catch { return send(res, 400, { error: 'invalid json' }); }
+            const err = validateContact(body, false);
+            if (err) return send(res, 400, { error: err });
+            const name = body.name ?? existing.name;
+            const email = body.email ?? existing.email;
+            const company = body.company !== undefined ? body.company : existing.company;
+            try {
+              db.prepare('UPDATE contacts SET name = ?, email = ?, company = ? WHERE id = ?').run(name, email, company, id);
+            } catch (e) {
+              if (String(e.message).includes('UNIQUE')) return send(res, 409, { error: 'email already exists' });
+              throw e;
+            }
+            return send(res, 200, getContact(id));
+          }
+          if (method === 'DELETE') {
+            if (!existing) return send(res, 404, { error: 'not found' });
+            db.prepare('DELETE FROM contacts WHERE id = ?').run(id);
+            return send(res, 204);
+          }
+        }
+        if (parts.length === 3 && parts[2] === 'deals') {
+          const id = Number(parts[1]);
+          const contact = getContact(id);
+          if (!contact) return send(res, 404, { error: 'contact not found' });
+          if (method === 'POST') {
+            let body;
+            try { body = await readBody(req); } catch { return send(res, 400, { error: 'invalid json' }); }
+            const err = validateDeal(body, true);
+            if (err) return send(res, 400, { error: err });
+            const info = db
+              .prepare('INSERT INTO deals (contact_id, title, amount, stage, created_at) VALUES (?, ?, ?, ?, ?)')
+              .run(id, body.title, body.amount ?? 0, body.stage ?? 'lead', new Date().toISOString());
+            return send(res, 201, getDeal(Number(info.lastInsertRowid)));
+          }
+          if (method === 'GET') {
+            const data = db.prepare('SELECT * FROM deals WHERE contact_id = ? ORDER BY id').all(id);
+            return send(res, 200, { data, total: data.length });
+          }
+        }
+      }
+
+      if (parts[0] === 'deals') {
+        if (parts.length === 2 && parts[1] === 'summary' && method === 'GET') {
+          const summary = {};
+          for (const s of STAGES) summary[s] = { count: 0, totalAmount: 0 };
+          const rows = db
+            .prepare('SELECT stage, COUNT(*) AS count, COALESCE(SUM(amount), 0) AS totalAmount FROM deals GROUP BY stage')
+            .all();
+          for (const r of rows) summary[r.stage] = { count: r.count, totalAmount: r.totalAmount };
+          return send(res, 200, { summary });
+        }
+        if (parts.length === 1 && method === 'GET') {
+          const stage = url.searchParams.get('stage');
+          let where = '';
+          const args = [];
+          if (stage) { where = 'WHERE stage = ?'; args.push(stage); }
+          const data = db.prepare(`SELECT * FROM deals ${where} ORDER BY id`).all(...args);
+          return send(res, 200, { data, total: data.length });
+        }
+        if (parts.length === 2 && method === 'PATCH') {
+          const id = Number(parts[1]);
+          const existing = getDeal(id);
+          if (!existing) return send(res, 404, { error: 'not found' });
+          let body;
+          try { body = await readBody(req); } catch { return send(res, 400, { error: 'invalid json' }); }
+          const err = validateDeal(body, false);
+          if (err) return send(res, 400, { error: err });
+          const title = body.title ?? existing.title;
+          const amount = body.amount ?? existing.amount;
+          const stage = body.stage ?? existing.stage;
+          db.prepare('UPDATE deals SET title = ?, amount = ?, stage = ? WHERE id = ?').run(title, amount, stage, id);
+          return send(res, 200, getDeal(id));
+        }
+      }
+
+      return send(res, 404, { error: 'not found' });
+    } catch (e) {
+      return send(res, 500, { error: 'internal error: ' + (e?.message || String(e)) });
+    }
+  };
+
+  return http.createServer(handler);
+}

--- a/src/code/benchmark/microcrm/assets/bulk.test.mjs
+++ b/src/code/benchmark/microcrm/assets/bulk.test.mjs
@@ -1,0 +1,63 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { createApp } from '../src/app.js';
+
+async function withServer(run) {
+  const server = createApp(':memory:');
+  await new Promise((res) => server.listen(0, res));
+  const { port } = server.address();
+  try { await run(`http://127.0.0.1:${port}`); } finally { await new Promise((res) => server.close(res)); }
+}
+async function req(base, method, path, body) {
+  const init = { method, headers: {} };
+  if (body !== undefined) { init.headers['content-type'] = 'application/json'; init.body = JSON.stringify(body); }
+  const res = await fetch(base + path, init);
+  const text = await res.text();
+  let json = null; try { json = text ? JSON.parse(text) : null; } catch { json = null; }
+  return { status: res.status, body: json };
+}
+const mkContact = () => ({ name: 'A', email: `a${Math.random().toString(36).slice(2)}@x.com` });
+
+test('bulk create inserts all deals (201) and returns them', () =>
+  withServer(async (base) => {
+    const c = await req(base, 'POST', '/contacts', mkContact());
+    const r = await req(base, 'POST', `/contacts/${c.body.id}/deals/bulk`, { deals: [{ title: 'a', amount: 1 }, { title: 'b', amount: 2 }, { title: 'c' }] });
+    assert.equal(r.status, 201);
+    assert.equal(r.body.data.length, 3);
+    assert.equal(r.body.total, 3);
+  }));
+
+test('bulk for unknown contact → 404', () =>
+  withServer(async (base) => {
+    const r = await req(base, 'POST', '/contacts/99999/deals/bulk', { deals: [{ title: 'a' }] });
+    assert.equal(r.status, 404);
+  }));
+
+test('bulk with empty array → 400', () =>
+  withServer(async (base) => {
+    const c = await req(base, 'POST', '/contacts', mkContact());
+    const r = await req(base, 'POST', `/contacts/${c.body.id}/deals/bulk`, { deals: [] });
+    assert.equal(r.status, 400);
+  }));
+
+test('bulk with non-array deals → 400', () =>
+  withServer(async (base) => {
+    const c = await req(base, 'POST', '/contacts', mkContact());
+    const r = await req(base, 'POST', `/contacts/${c.body.id}/deals/bulk`, { deals: 'nope' });
+    assert.equal(r.status, 400);
+  }));
+
+test('bulk with one invalid item → 400', () =>
+  withServer(async (base) => {
+    const c = await req(base, 'POST', '/contacts', mkContact());
+    const r = await req(base, 'POST', `/contacts/${c.body.id}/deals/bulk`, { deals: [{ title: 'ok' }, { title: '' }] });
+    assert.equal(r.status, 400);
+  }));
+
+test('bulk is atomic — an invalid item inserts NOTHING', () =>
+  withServer(async (base) => {
+    const c = await req(base, 'POST', '/contacts', mkContact());
+    await req(base, 'POST', `/contacts/${c.body.id}/deals/bulk`, { deals: [{ title: 'ok', amount: 10 }, { title: 'bad', amount: -1 }] });
+    const list = await req(base, 'GET', `/contacts/${c.body.id}/deals`);
+    assert.equal(list.body.total, 0);
+  }));

--- a/src/code/benchmark/microcrm/assets/idempotency.test.mjs
+++ b/src/code/benchmark/microcrm/assets/idempotency.test.mjs
@@ -1,0 +1,64 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { createApp } from '../src/app.js';
+
+async function withServer(run) {
+  const server = createApp(':memory:');
+  await new Promise((res) => server.listen(0, res));
+  const { port } = server.address();
+  try { await run(`http://127.0.0.1:${port}`); } finally { await new Promise((res) => server.close(res)); }
+}
+async function req(base, method, path, body, headers = {}) {
+  const init = { method, headers: { ...headers } };
+  if (body !== undefined) { init.headers['content-type'] = 'application/json'; init.body = JSON.stringify(body); }
+  const res = await fetch(base + path, init);
+  const text = await res.text();
+  let json = null; try { json = text ? JSON.parse(text) : null; } catch { json = null; }
+  return { status: res.status, body: json };
+}
+const mkContact = (over = {}) => ({ name: 'A', email: `a${Math.random().toString(36).slice(2)}@x.com`, ...over });
+
+test('repeating a POST with the same Idempotency-Key does not create a duplicate', () =>
+  withServer(async (base) => {
+    const c = mkContact();
+    const first = await req(base, 'POST', '/contacts', c, { 'idempotency-key': 'abc' });
+    assert.equal(first.status, 201);
+    const second = await req(base, 'POST', '/contacts', c, { 'idempotency-key': 'abc' });
+    assert.equal(second.body.id, first.body.id);
+    const list = await req(base, 'GET', '/contacts');
+    assert.equal(list.body.total, 1);
+  }));
+
+test('replay with the same key returns 200 (not a new 201)', () =>
+  withServer(async (base) => {
+    const c = mkContact();
+    await req(base, 'POST', '/contacts', c, { 'idempotency-key': 'k1' });
+    const replay = await req(base, 'POST', '/contacts', c, { 'idempotency-key': 'k1' });
+    assert.equal(replay.status, 200);
+  }));
+
+test('different keys create different contacts', () =>
+  withServer(async (base) => {
+    await req(base, 'POST', '/contacts', mkContact(), { 'idempotency-key': 'k1' });
+    await req(base, 'POST', '/contacts', mkContact(), { 'idempotency-key': 'k2' });
+    const list = await req(base, 'GET', '/contacts');
+    assert.equal(list.body.total, 2);
+  }));
+
+test('no key behaves normally — each POST creates', () =>
+  withServer(async (base) => {
+    await req(base, 'POST', '/contacts', mkContact());
+    await req(base, 'POST', '/contacts', mkContact());
+    const list = await req(base, 'GET', '/contacts');
+    assert.equal(list.body.total, 2);
+  }));
+
+test('replayed key returns the original even if the body changed (no 409)', () =>
+  withServer(async (base) => {
+    const original = mkContact();
+    const first = await req(base, 'POST', '/contacts', original, { 'idempotency-key': 'same' });
+    const replay = await req(base, 'POST', '/contacts', mkContact(), { 'idempotency-key': 'same' });
+    assert.equal(replay.status, 200);
+    assert.equal(replay.body.id, first.body.id);
+    assert.equal(replay.body.email, original.email);
+  }));

--- a/src/code/benchmark/microcrm/assets/query.test.mjs
+++ b/src/code/benchmark/microcrm/assets/query.test.mjs
@@ -1,0 +1,96 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { createApp } from '../src/app.js';
+
+async function withServer(run) {
+  const server = createApp(':memory:');
+  await new Promise((res) => server.listen(0, res));
+  const { port } = server.address();
+  try { await run(`http://127.0.0.1:${port}`); } finally { await new Promise((res) => server.close(res)); }
+}
+async function req(base, method, path, body) {
+  const init = { method, headers: {} };
+  if (body !== undefined) { init.headers['content-type'] = 'application/json'; init.body = JSON.stringify(body); }
+  const res = await fetch(base + path, init);
+  const text = await res.text();
+  let json = null; try { json = text ? JSON.parse(text) : null; } catch { json = null; }
+  return { status: res.status, body: json };
+}
+
+// Seed one contact with deals of known amounts/stages.
+async function seed(base) {
+  const c = await req(base, 'POST', '/contacts', { name: 'A', email: `a${Math.random().toString(36).slice(2)}@x.com` });
+  const id = c.body.id;
+  const deals = [
+    { title: 'd1', amount: 100, stage: 'lead' },
+    { title: 'd2', amount: 200, stage: 'qualified' },
+    { title: 'd3', amount: 300, stage: 'won' },
+    { title: 'd4', amount: 400, stage: 'won' },
+  ];
+  for (const d of deals) await req(base, 'POST', `/contacts/${id}/deals`, d);
+  return id;
+}
+
+test('minAmount filters deals', () =>
+  withServer(async (base) => {
+    await seed(base);
+    const r = await req(base, 'GET', '/deals?minAmount=300');
+    assert.equal(r.status, 200);
+    assert.equal(r.body.total, 2);
+    assert.ok(r.body.data.every((d) => d.amount >= 300));
+  }));
+
+test('maxAmount filters deals', () =>
+  withServer(async (base) => {
+    await seed(base);
+    const r = await req(base, 'GET', '/deals?maxAmount=200');
+    assert.equal(r.body.total, 2);
+    assert.ok(r.body.data.every((d) => d.amount <= 200));
+  }));
+
+test('minAmount + maxAmount form a range', () =>
+  withServer(async (base) => {
+    await seed(base);
+    const r = await req(base, 'GET', '/deals?minAmount=200&maxAmount=300');
+    assert.deepEqual(r.body.data.map((d) => d.amount).sort((a, b) => a - b), [200, 300]);
+  }));
+
+test('sort=amount:desc orders descending', () =>
+  withServer(async (base) => {
+    await seed(base);
+    const r = await req(base, 'GET', '/deals?sort=amount:desc');
+    assert.deepEqual(r.body.data.map((d) => d.amount), [400, 300, 200, 100]);
+  }));
+
+test('sort=amount:asc orders ascending', () =>
+  withServer(async (base) => {
+    await seed(base);
+    const r = await req(base, 'GET', '/deals?sort=amount:asc');
+    assert.deepEqual(r.body.data.map((d) => d.amount), [100, 200, 300, 400]);
+  }));
+
+test('invalid sort field → 400', () =>
+  withServer(async (base) => {
+    await seed(base);
+    const r = await req(base, 'GET', '/deals?sort=banana:asc');
+    assert.equal(r.status, 400);
+  }));
+
+test('filters combine with stage', () =>
+  withServer(async (base) => {
+    await seed(base);
+    const r = await req(base, 'GET', '/deals?stage=won&minAmount=350');
+    assert.equal(r.body.total, 1);
+    assert.equal(r.body.data[0].amount, 400);
+  }));
+
+test('pagination returns hasMore and a full filtered total', () =>
+  withServer(async (base) => {
+    await seed(base);
+    const page1 = await req(base, 'GET', '/deals?limit=2&offset=0&sort=amount:asc');
+    assert.equal(page1.body.total, 4);
+    assert.equal(page1.body.data.length, 2);
+    assert.equal(page1.body.hasMore, true);
+    const page2 = await req(base, 'GET', '/deals?limit=2&offset=2&sort=amount:asc');
+    assert.equal(page2.body.hasMore, false);
+  }));

--- a/src/code/benchmark/microcrm/assets/stats.test.mjs
+++ b/src/code/benchmark/microcrm/assets/stats.test.mjs
@@ -1,0 +1,67 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { createApp } from '../src/app.js';
+
+async function withServer(run) {
+  const server = createApp(':memory:');
+  await new Promise((res) => server.listen(0, res));
+  const { port } = server.address();
+  try { await run(`http://127.0.0.1:${port}`); } finally { await new Promise((res) => server.close(res)); }
+}
+async function req(base, method, path, body) {
+  const init = { method, headers: {} };
+  if (body !== undefined) { init.headers['content-type'] = 'application/json'; init.body = JSON.stringify(body); }
+  const res = await fetch(base + path, init);
+  const text = await res.text();
+  let json = null; try { json = text ? JSON.parse(text) : null; } catch { json = null; }
+  return { status: res.status, body: json };
+}
+const mkContact = () => ({ name: 'A', email: `a${Math.random().toString(36).slice(2)}@x.com` });
+
+test('stats for unknown contact → 404', () =>
+  withServer(async (base) => {
+    const r = await req(base, 'GET', '/contacts/99999/stats');
+    assert.equal(r.status, 404);
+  }));
+
+test('stats for a contact with no deals are all zero', () =>
+  withServer(async (base) => {
+    const c = await req(base, 'POST', '/contacts', mkContact());
+    const r = await req(base, 'GET', `/contacts/${c.body.id}/stats`);
+    assert.equal(r.status, 200);
+    assert.deepEqual(r.body, { totalDeals: 0, totalValue: 0, wonValue: 0, winRate: 0, weightedPipeline: 0 });
+  }));
+
+test('totalValue and wonValue sum the right deals', () =>
+  withServer(async (base) => {
+    const c = await req(base, 'POST', '/contacts', mkContact());
+    const id = c.body.id;
+    await req(base, 'POST', `/contacts/${id}/deals`, { title: 'a', amount: 100, stage: 'won' });
+    await req(base, 'POST', `/contacts/${id}/deals`, { title: 'b', amount: 50, stage: 'lead' });
+    const r = await req(base, 'GET', `/contacts/${id}/stats`);
+    assert.equal(r.body.totalDeals, 2);
+    assert.equal(r.body.totalValue, 150);
+    assert.equal(r.body.wonValue, 100);
+  }));
+
+test('winRate is won deals over total deals', () =>
+  withServer(async (base) => {
+    const c = await req(base, 'POST', '/contacts', mkContact());
+    const id = c.body.id;
+    await req(base, 'POST', `/contacts/${id}/deals`, { title: 'a', amount: 10, stage: 'won' });
+    for (const s of ['lead', 'qualified', 'lost']) await req(base, 'POST', `/contacts/${id}/deals`, { title: s, amount: 10, stage: s });
+    const r = await req(base, 'GET', `/contacts/${id}/stats`);
+    assert.equal(r.body.winRate, 0.25); // 1 of 4
+  }));
+
+test('weightedPipeline applies per-stage probabilities (lead .1, qualified .4, won 1, lost 0)', () =>
+  withServer(async (base) => {
+    const c = await req(base, 'POST', '/contacts', mkContact());
+    const id = c.body.id;
+    await req(base, 'POST', `/contacts/${id}/deals`, { title: 'l', amount: 100, stage: 'lead' });       // 10
+    await req(base, 'POST', `/contacts/${id}/deals`, { title: 'q', amount: 100, stage: 'qualified' });  // 40
+    await req(base, 'POST', `/contacts/${id}/deals`, { title: 'w', amount: 100, stage: 'won' });        // 100
+    await req(base, 'POST', `/contacts/${id}/deals`, { title: 'x', amount: 100, stage: 'lost' });       // 0
+    const r = await req(base, 'GET', `/contacts/${id}/stats`);
+    assert.equal(r.body.weightedPipeline, 150);
+  }));

--- a/src/code/benchmark/microcrm/index.ts
+++ b/src/code/benchmark/microcrm/index.ts
@@ -1,0 +1,92 @@
+/**
+ * The micro-CRM benchmark suite — a building, scored suite.
+ *
+ * Tier 1 (`crm-build`) builds the base Node + SQLite REST API from scratch (large single
+ * output — a genuine test of whether the model can emit a sizeable file). Tiers 2-5 each
+ * scaffold the WORKING base implementation and ask the agent to add one harder feature
+ * (atomic bulk insert, advanced querying, weighted analytics, idempotency). Each task is
+ * graded by its own hidden test file; the suite score is the fraction of all spec tests
+ * passed.
+ *
+ * Test files and reference implementations live as plain `.mjs` assets (read verbatim at
+ * runtime; copied into dist by scripts/copy-benchmark-assets.mjs).
+ */
+
+import { readFileSync } from 'fs';
+import { fileURLToPath } from 'url';
+import { dirname, join } from 'path';
+import type { BenchmarkTask, TaskFile } from '../types.js';
+import {
+  MICROCRM_SPEC,
+  MICROCRM_BULK_SPEC,
+  MICROCRM_QUERY_SPEC,
+  MICROCRM_STATS_SPEC,
+  MICROCRM_IDEMPOTENCY_SPEC,
+} from './spec.js';
+
+const assetsDir = join(dirname(fileURLToPath(import.meta.url)), 'assets');
+const readAsset = (name: string): string => readFileSync(join(assetsDir, name), 'utf-8');
+
+export const MICROCRM_PACKAGE_JSON = JSON.stringify({ name: 'microcrm', type: 'module', private: true }, null, 2) + '\n';
+/** Base API the agent builds in tier 1 and that scaffolds the extend tasks. */
+export const MICROCRM_BASE_APP = readAsset('app.reference.mjs');
+/** Reference with every extension implemented — used only by the harness self-test. */
+export const MICROCRM_FULL_APP = readAsset('app.full.reference.mjs');
+
+/** A base-build task (from scratch) — no src provided. */
+function buildTask(): BenchmarkTask {
+  return {
+    id: 'crm-build',
+    tier: 1,
+    title: 'Build the micro-CRM REST API',
+    capability: 'Build a spec-defined Node + SQLite REST API (large output)',
+    kind: 'scratch',
+    prompt: MICROCRM_SPEC,
+    scaffold: { 'package.json': MICROCRM_PACKAGE_JSON, 'test/api.test.mjs': readAsset('api.test.mjs') },
+    protectedPaths: ['test/api.test.mjs'],
+    maxIterations: 60,
+    timeoutMs: 600_000,
+  };
+}
+
+/** An extend task — scaffolds the working base app and adds one feature. */
+function extendTask(
+  id: string,
+  tier: number,
+  title: string,
+  capability: string,
+  prompt: string,
+  testFile: string,
+): BenchmarkTask {
+  return {
+    id,
+    tier,
+    title,
+    capability,
+    kind: 'extend',
+    prompt,
+    scaffold: {
+      'package.json': MICROCRM_PACKAGE_JSON,
+      'src/app.js': MICROCRM_BASE_APP,
+      [`test/${testFile}`]: readAsset(testFile),
+    },
+    protectedPaths: [`test/${testFile}`],
+    maxIterations: 40,
+    timeoutMs: 360_000,
+  };
+}
+
+export const MICROCRM_TASKS: BenchmarkTask[] = [
+  buildTask(),
+  extendTask('crm-bulk', 2, 'Atomic bulk deal insert', 'Transactions / atomicity', MICROCRM_BULK_SPEC, 'bulk.test.mjs'),
+  extendTask('crm-query', 3, 'Advanced deal querying', 'Filtering, sorting & pagination', MICROCRM_QUERY_SPEC, 'query.test.mjs'),
+  extendTask('crm-stats', 4, 'Pipeline analytics', 'Aggregation & weighted arithmetic', MICROCRM_STATS_SPEC, 'stats.test.mjs'),
+  extendTask('crm-idempotency', 5, 'Idempotency-Key on create', 'Idempotency / dedup reasoning', MICROCRM_IDEMPOTENCY_SPEC, 'idempotency.test.mjs'),
+];
+
+/** Self-test helper: the known-good files that should pass a given task's tests. */
+export function microcrmReferenceFor(task: BenchmarkTask): TaskFile {
+  const src = task.id === 'crm-build' ? MICROCRM_BASE_APP : MICROCRM_FULL_APP;
+  // Keep the task's test files, but override src/app.js with the reference implementation.
+  return { ...task.scaffold, 'package.json': MICROCRM_PACKAGE_JSON, 'src/app.js': src };
+}

--- a/src/code/benchmark/microcrm/spec.ts
+++ b/src/code/benchmark/microcrm/spec.ts
@@ -1,0 +1,121 @@
+/**
+ * The micro-CRM specification handed to the agent. It pins the exact module
+ * contract the hidden test suite depends on (entry file, exported factory, the
+ * built-in `node:http` + `node:sqlite` stack) and then enumerates every endpoint
+ * with its status codes and response shapes. Ambiguity here would unfairly fail a
+ * competent model, so the spec mirrors the test expectations precisely.
+ */
+
+export const MICROCRM_SPEC = `Build a small REST API for a "micro CRM" using ONLY Node.js built-in modules — no npm install, no external packages.
+
+STACK (mandatory):
+- HTTP server: the built-in \`node:http\` module.
+- Database: the built-in \`node:sqlite\` module (import { DatabaseSync } from 'node:sqlite').
+- The project is an ES module (package.json has "type": "module").
+
+MODULE CONTRACT (the test suite imports exactly this):
+- Create the file src/app.js.
+- Export a function: \`export function createApp(dbPath = ':memory:')\`.
+- createApp must create the database (initialise the schema if needed) and return a
+  Node http.Server created with http.createServer(handler). DO NOT call .listen() —
+  the caller starts it. Each call to createApp uses its own database connection.
+- All request and response bodies are JSON. Always set Content-Type: application/json
+  (except for 204 responses, which have no body).
+
+DATA MODEL:
+- contact: { id (auto int), name (string, required, non-empty), email (string, required,
+  unique, must look like an email), company (string or null), created_at (ISO string) }
+- deal: { id (auto int), contact_id (int), title (string, required, non-empty),
+  amount (number >= 0, default 0), stage (one of "lead" | "qualified" | "won" | "lost",
+  default "lead"), created_at (ISO string) }
+
+ENDPOINTS:
+
+Contacts:
+- POST /contacts → create. 201 with the created contact. 400 if name or email missing/invalid.
+  409 if the email already exists. 400 if the request body is not valid JSON.
+- GET /contacts → 200 with { data: [...contacts], total }. Supports:
+    ?q=<text>   case-insensitive substring match on name OR email
+    ?limit=&?offset=   pagination; "total" is the FULL count ignoring limit/offset.
+- GET /contacts/:id → 200 with the contact, or 404.
+- PATCH /contacts/:id → partial update (any subset of name/email/company). 200 with the
+  updated contact. 404 if not found. 400 if a provided field is invalid. 409 if the new
+  email belongs to another contact.
+- DELETE /contacts/:id → 204 (no body), or 404. Deleting a contact also deletes its deals.
+
+Deals:
+- POST /contacts/:id/deals → create a deal for that contact. 201 with the created deal
+  (stage defaults to "lead", amount defaults to 0). 404 if the contact does not exist.
+  400 if title is missing, amount is negative, or stage is not one of the four allowed values.
+- GET /contacts/:id/deals → 200 with { data: [...deals], total } for that contact only.
+- GET /deals → 200 with { data: [...deals], total }. Supports ?stage=<stage> to filter.
+- GET /deals/summary → 200 with { summary: { lead: { count, totalAmount }, qualified: {...},
+  won: {...}, lost: {...} } } — every stage present, zeros when there are no deals.
+- PATCH /deals/:id → partial update (title/amount/stage). 200 with the updated deal, or 404.
+  400 on invalid amount/stage.
+
+Anything else (unknown path) → 404 with a JSON body.
+
+GOAL: make the hidden test suite in test/api.test.mjs pass. Run it with: node --test
+Do NOT modify anything under test/. Implement everything in src/.`;
+
+/**
+ * The extend tasks scaffold a WORKING base API (src/app.js) and ask the agent to add
+ * one harder feature. Each prompt pins the precise contract its hidden test depends on.
+ */
+const EXTEND_PREAMBLE =
+  'src/app.js already contains a working micro-CRM REST API (contacts + deals) built on ' +
+  'node:http + node:sqlite, exporting createApp(dbPath). Extend it — do not rewrite it, and ' +
+  'keep all existing behaviour working. Run the tests with: node --test. Do NOT modify test/.';
+
+export const MICROCRM_BULK_SPEC = `${EXTEND_PREAMBLE}
+
+Add an ATOMIC bulk deal endpoint:
+- POST /contacts/:id/deals/bulk with body { deals: [ { title, amount?, stage? }, ... ] }.
+- 404 if the contact does not exist.
+- 400 if "deals" is missing, not an array, or empty.
+- Validate every deal with the same rules as a single deal (title required & non-empty,
+  amount a number >= 0, stage one of lead/qualified/won/lost). If ANY item is invalid,
+  respond 400 and insert NOTHING (the operation must be all-or-nothing / atomic).
+- On success → 201 with { data: [...createdDeals], total }. Each created deal applies the
+  same defaults as the single-deal endpoint (stage "lead", amount 0).
+Make test/bulk.test.mjs pass.`;
+
+export const MICROCRM_QUERY_SPEC = `${EXTEND_PREAMBLE}
+
+Upgrade GET /deals with filtering, sorting and pagination metadata:
+- ?minAmount= and ?maxAmount= filter by amount (inclusive). A non-numeric value → 400.
+- ?stage= filters by stage (already supported); all filters combine with AND.
+- ?sort=<field>:<dir> where field is one of amount | created_at | id and dir is asc | desc.
+  Any other field or direction → 400. Default order is by id ascending.
+- ?limit= and ?offset= paginate. The response is { data, total, hasMore } where "total" is
+  the FULL count of rows matching the filters (ignoring limit/offset) and "hasMore" is true
+  when there are more rows after the current page (offset + data.length < total).
+Make test/query.test.mjs pass.`;
+
+export const MICROCRM_STATS_SPEC = `${EXTEND_PREAMBLE}
+
+Add a per-contact analytics endpoint:
+- GET /contacts/:id/stats → 404 if the contact does not exist, else 200 with:
+  { totalDeals, totalValue, wonValue, winRate, weightedPipeline }
+  where:
+    - totalDeals  = number of deals for the contact
+    - totalValue  = sum of all deal amounts
+    - wonValue    = sum of amounts of deals whose stage is "won"
+    - winRate     = wonDeals / totalDeals (0 when there are no deals), rounded to 4 decimals
+    - weightedPipeline = sum over deals of amount * P(stage), rounded to 2 decimals, where
+      P = { lead: 0.1, qualified: 0.4, won: 1.0, lost: 0.0 }
+  A contact with no deals returns all zeros.
+Make test/stats.test.mjs pass.`;
+
+export const MICROCRM_IDEMPOTENCY_SPEC = `${EXTEND_PREAMBLE}
+
+Add idempotency to contact creation via the "Idempotency-Key" request header:
+- POST /contacts with an Idempotency-Key header: the FIRST request with a given key creates
+  the contact as normal (201) and remembers the key.
+- A REPEAT request with the SAME key must NOT create a duplicate — return the originally
+  created contact with status 200 (even if the new request body differs; do not validate or
+  conflict-check it).
+- Different keys create different contacts. Requests with no Idempotency-Key behave exactly
+  as before (each creates a contact). The key store may be in-memory (per createApp instance).
+Make test/idempotency.test.mjs pass.`;

--- a/src/code/benchmark/orchestrator-factory.ts
+++ b/src/code/benchmark/orchestrator-factory.ts
@@ -1,0 +1,95 @@
+/**
+ * Shared ModelOrchestrator builder for the benchmark, used by both the CLI
+ * command and the HTTP route. Mirrors the model-construction logic in the CLI
+ * `run` command so benchmarks exercise exactly the same model stack a real
+ * code-mode session would.
+ */
+
+import { createModelClient } from '../../models/model-client.js';
+import { ModelOrchestrator } from '../../models/orchestrator.js';
+
+/** Subset of the stored ModelConfig shape we need to build a client. */
+export interface ModelConfigInput {
+  endpoint: string;
+  apiKey?: string;
+  /** Preferred model id; `defaultModel` is the config-store alias. */
+  model?: string;
+  defaultModel?: string;
+  useHarmonyFormat?: boolean;
+  defaultReasoningEffort?: 'low' | 'medium' | 'high';
+  reasoningEffortStrategy?: 'api_param' | 'system_prompt' | 'both';
+  defaultMaxTokens?: number;
+  useGoogleADC?: boolean;
+}
+
+export interface OrchestratorInput {
+  reasoning: ModelConfigInput;
+  multimodal?: ModelConfigInput;
+  toolCalling?: ModelConfigInput;
+  /** When true, ping each model first; throws if the reasoning model is unreachable. */
+  testConnectivity?: boolean;
+  /** Optional progress logger. */
+  log?: (msg: string) => void;
+}
+
+export interface OrchestratorBundle {
+  orchestrator: ModelOrchestrator;
+  /** A short label for reports, e.g. the reasoning model id. */
+  modelLabel: string;
+}
+
+function resolveModelId(cfg: ModelConfigInput): string {
+  return cfg.model || cfg.defaultModel || '';
+}
+
+function buildClient(cfg: ModelConfigInput, type: 'reasoning' | 'multimodal' | 'tool-calling') {
+  return createModelClient({
+    endpoint: cfg.endpoint,
+    apiKey: cfg.apiKey ?? '',
+    model: resolveModelId(cfg),
+    type,
+    useHarmonyFormat: cfg.useHarmonyFormat,
+    defaultReasoningEffort: cfg.defaultReasoningEffort,
+    reasoningEffortStrategy: cfg.reasoningEffortStrategy,
+    defaultMaxTokens: cfg.defaultMaxTokens,
+    useGoogleADC: cfg.useGoogleADC,
+  });
+}
+
+export async function createOrchestrator(input: OrchestratorInput): Promise<OrchestratorBundle> {
+  const log = input.log ?? (() => {});
+
+  if (!input.reasoning?.endpoint) {
+    throw new Error('A reasoning model configuration is required for the benchmark');
+  }
+
+  const reasoningModel = buildClient(input.reasoning, 'reasoning');
+  if (input.testConnectivity) {
+    const t = await reasoningModel.testConnectivity();
+    if (!t.success) {
+      throw new Error(`Reasoning model connection failed: ${t.error}`);
+    }
+    log(`Reasoning model connected (${t.latency}ms)`);
+  }
+
+  let multimodalModel = input.multimodal ? buildClient(input.multimodal, 'multimodal') : undefined;
+  if (multimodalModel && input.testConnectivity) {
+    const t = await multimodalModel.testConnectivity();
+    if (!t.success) {
+      log(`Multimodal model unreachable, continuing without it: ${t.error}`);
+      multimodalModel = undefined;
+    }
+  }
+
+  let toolCallingModel = input.toolCalling ? buildClient(input.toolCalling, 'tool-calling') : undefined;
+  if (toolCallingModel && input.testConnectivity) {
+    const t = await toolCallingModel.testConnectivity();
+    if (!t.success) {
+      log(`Tool-calling model unreachable, continuing without it: ${t.error}`);
+      toolCallingModel = undefined;
+    }
+  }
+
+  const orchestrator = new ModelOrchestrator({ reasoningModel, multimodalModel, toolCallingModel });
+  return { orchestrator, modelLabel: resolveModelId(input.reasoning) || 'unknown' };
+}

--- a/src/code/benchmark/report.ts
+++ b/src/code/benchmark/report.ts
@@ -1,0 +1,123 @@
+/**
+ * Report formatting for benchmark results — a chalk table for the CLI and a
+ * plain JSON serializer for files / HTTP.
+ */
+
+import chalk from 'chalk';
+import type { SuiteResult, TaskResult } from './types.js';
+
+function fmtMs(ms: number): string {
+  return ms < 1000 ? `${ms}ms` : `${(ms / 1000).toFixed(1)}s`;
+}
+
+function pad(s: string, n: number): string {
+  return s.length >= n ? s.slice(0, n) : s + ' '.repeat(n - s.length);
+}
+
+function statusCell(r: TaskResult): string {
+  if (r.passed) return chalk.green('PASS');
+  const reason = r.reason ?? 'fail';
+  return chalk.red('FAIL') + chalk.gray(` ${reason}`);
+}
+
+export function formatReportForCLI(suite: SuiteResult): string {
+  const lines: string[] = [];
+  lines.push('');
+  const scored = suite.scoring === 'scored';
+  lines.push(chalk.bold(`  Jiva Code-Mode Benchmark — ${suite.suiteName ?? 'taskstore'}`));
+  if (suite.model) lines.push(chalk.gray(`  Model: ${suite.model}`));
+  lines.push(chalk.gray(`  ${suite.startedAt} → ${suite.finishedAt}`));
+  lines.push('');
+
+  // Header
+  lines.push(
+    chalk.gray(
+      '  ' +
+        pad('Tier', 5) +
+        pad('Task', 26) +
+        pad('Status', 18) +
+        pad('Iters', 7) +
+        pad('Tests', 9) +
+        pad('Tokens', 10) +
+        'Time',
+    ),
+  );
+  lines.push(chalk.gray('  ' + '─'.repeat(86)));
+
+  for (const r of suite.tasks) {
+    const iters = `${r.iterations}${r.hitMaxIterations ? '!' : ''}`;
+    const tests = `${r.testsPassed}/${r.testsPassed + r.testsFailed}`;
+    const tokens = r.tokenUsage?.totalTokens ? String(r.tokenUsage.totalTokens) : '-';
+    lines.push(
+      '  ' +
+        pad(String(r.tier), 5) +
+        pad(r.title, 26) +
+        pad(statusCell(r), 18 + 10) + // +10 to absorb chalk color codes width
+        pad(iters, 7) +
+        pad(tests, 9) +
+        pad(tokens, 10) +
+        fmtMs(r.wallTimeMs),
+    );
+  }
+
+  lines.push(chalk.gray('  ' + '─'.repeat(86)));
+
+  if (scored) {
+    // Headline for scored suites is the spec-test pass-rate, not all-or-nothing.
+    const score = `${suite.totalTestsPassed}/${suite.totalTestsRun} tests (${suite.scorePct}%)`;
+    const colour = suite.scorePct >= 90 ? chalk.green : suite.scorePct >= 50 ? chalk.yellow : chalk.red;
+    lines.push(colour(`  Score: ${score}`));
+  } else {
+    const ratio = `${suite.passed}/${suite.totalTasks}`;
+    const summary =
+      suite.passed === suite.totalTasks ? chalk.green(`  ${ratio} passed`) : chalk.yellow(`  ${ratio} passed`);
+    lines.push(summary + chalk.gray(`  ·  highest tier passed: ${suite.highestTierPassed}`));
+  }
+  lines.push(
+    chalk.gray(
+      `  total time: ${fmtMs(suite.totalWallTimeMs)}` +
+        (suite.totalTokens ? `  ·  total tokens: ${suite.totalTokens}` : ''),
+    ),
+  );
+
+  // Scored suites: list the specific spec tests the model missed (the capability gaps).
+  if (scored) {
+    const missed = suite.tasks.flatMap((t) => t.failingTests ?? []);
+    if (missed.length > 0) {
+      lines.push('');
+      lines.push(chalk.bold(`  Missed (${missed.length})`));
+      for (const name of missed) lines.push(chalk.red('  ✗ ') + chalk.gray(name));
+    }
+  }
+
+  // Output-length limitation flag: failures driven by output-token truncation are a
+  // model capacity limit (e.g. a hard 4096-token cap), distinct from a logic gap.
+  const outputLimited = suite.tasks.filter((t) => t.outputLimited);
+  if (outputLimited.length > 0) {
+    lines.push('');
+    lines.push(chalk.yellow('  ⚠ Output-length limited') +
+      chalk.gray(`  — ${outputLimited.length} task(s) failed after hitting the model's output-token limit:`));
+    for (const t of outputLimited) {
+      lines.push(chalk.gray(`      ${t.id} (${t.truncationEvents}× truncation) — couldn't emit a large enough response`));
+    }
+  }
+
+  // Surface failures with their diagnostic notes (infra/agent errors, not per-test).
+  const failures = suite.tasks.filter((t) => !t.passed);
+  if (failures.length > 0) {
+    lines.push('');
+    lines.push(chalk.bold('  Failures'));
+    for (const f of failures) {
+      const tag = f.outputLimited ? chalk.yellow(' [output-limited]') : '';
+      lines.push(chalk.red(`  • ${f.id}`) + chalk.gray(` (${f.reason ?? 'fail'})`) + tag);
+      if (f.notes) lines.push(chalk.gray(`    ${f.notes}`));
+    }
+  }
+
+  lines.push('');
+  return lines.join('\n');
+}
+
+export function toReportJSON(suite: SuiteResult): string {
+  return JSON.stringify(suite, null, 2);
+}

--- a/src/code/benchmark/runner.ts
+++ b/src/code/benchmark/runner.ts
@@ -1,0 +1,263 @@
+/**
+ * Benchmark runner — drives CodeAgent through the suite in isolated workspaces
+ * and collects deterministic pass/fail plus diagnostic metrics.
+ *
+ * Each task (default mode):
+ *   1. mkdtemp an isolated workspace and write the scaffold (golden baseline +
+ *      cumulative tests + any planted bug).
+ *   2. Build a fresh minimal CodeAgent pointed at it.
+ *   3. Run agent.chat(prompt) under a wall-clock timeout.
+ *   4. Run the deterministic verifier (node --test + tamper check).
+ *   5. Record metrics and tear everything down.
+ *
+ * In `continuous` mode the agent's own workspace is carried forward between
+ * tiers: only the new test files (and planted source the agent hasn't written
+ * yet) are overlaid, so cascading failures surface the way a real session would.
+ */
+
+import { mkdtemp, mkdir, writeFile, rm, access } from 'fs/promises';
+import { tmpdir } from 'os';
+import { join, dirname } from 'path';
+import type { ModelOrchestrator } from '../../models/orchestrator.js';
+import { logger } from '../../utils/logger.js';
+import { buildBenchmarkAgent } from './agent-factory.js';
+import { runNodeTests } from './verify.js';
+import type {
+  BenchmarkTask,
+  RunnerOptions,
+  ProgressEvents,
+  TaskResult,
+  SuiteResult,
+} from './types.js';
+
+async function exists(path: string): Promise<boolean> {
+  try {
+    await access(path);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function writeWorkspaceFile(workspaceDir: string, relPath: string, content: string): Promise<void> {
+  const abs = join(workspaceDir, relPath);
+  await mkdir(dirname(abs), { recursive: true });
+  await writeFile(abs, content, 'utf-8');
+}
+
+const delay = (ms: number) => new Promise<void>((resolve) => setTimeout(resolve, ms));
+
+export class BenchmarkRunner {
+  constructor(private orchestrator: ModelOrchestrator) {}
+
+  /** Run a selected set of tasks. `tasks` must already be filtered/ordered by tier. */
+  async run(
+    tasks: BenchmarkTask[],
+    options: RunnerOptions = {},
+    progress: ProgressEvents = {},
+  ): Promise<SuiteResult> {
+    const startedAt = new Date().toISOString();
+    const results: TaskResult[] = [];
+    let carriedWorkspace: string | undefined;
+
+    for (let i = 0; i < tasks.length; i++) {
+      const task = tasks[i];
+      progress.onTaskStart?.(task, i, tasks.length);
+
+      const maxIterations = options.maxIterations ?? task.maxIterations;
+      const timeoutMs = options.timeoutMs ?? task.timeoutMs;
+
+      // Resolve the workspace and write the scaffold.
+      let workspaceDir: string;
+      let ephemeral = false;
+      if (options.continuous && carriedWorkspace) {
+        workspaceDir = carriedWorkspace;
+        // Overlay new tests always; overlay planted source only where absent.
+        for (const [rel, content] of Object.entries(task.scaffold)) {
+          const isTest = rel.startsWith('test/');
+          const isPkg = rel === 'package.json';
+          if (isTest || isPkg || !(await exists(join(workspaceDir, rel)))) {
+            await writeWorkspaceFile(workspaceDir, rel, content);
+          }
+        }
+      } else {
+        workspaceDir = await mkdtemp(join(tmpdir(), `jiva-bench-${task.id}-`));
+        ephemeral = !options.continuous;
+        for (const [rel, content] of Object.entries(task.scaffold)) {
+          await writeWorkspaceFile(workspaceDir, rel, content);
+        }
+        if (options.continuous) carriedWorkspace = workspaceDir;
+      }
+
+      // Snapshot the protected test files (from the task's own scaffold) for the tamper check.
+      const protectedFiles: Record<string, string> = {};
+      for (const p of task.protectedPaths) {
+        protectedFiles[p] = task.scaffold[p] ?? '';
+      }
+
+      const result = await this.runTask(task, workspaceDir, maxIterations, timeoutMs, protectedFiles, !!options.lspEnabled);
+      results.push(result);
+      progress.onTaskDone?.(result, i, tasks.length);
+
+      // Clean up ephemeral (non-continuous) workspaces unless asked to keep them.
+      if (ephemeral && !options.keepWorkspaces) {
+        await rm(workspaceDir, { recursive: true, force: true }).catch(() => {});
+      }
+    }
+
+    // Clean up the carried-forward workspace at the very end.
+    if (options.continuous && carriedWorkspace && !options.keepWorkspaces) {
+      await rm(carriedWorkspace, { recursive: true, force: true }).catch(() => {});
+    }
+
+    const finishedAt = new Date().toISOString();
+    return this.aggregate(tasks, results, startedAt, finishedAt, options);
+  }
+
+  private async runTask(
+    task: BenchmarkTask,
+    workspaceDir: string,
+    maxIterations: number,
+    timeoutMs: number,
+    protectedFiles: Record<string, string>,
+    lspEnabled: boolean,
+  ): Promise<TaskResult> {
+    const agent = await buildBenchmarkAgent({
+      orchestrator: this.orchestrator,
+      workspaceDir,
+      maxIterations,
+      lspEnabled,
+    });
+
+    const base = {
+      id: task.id,
+      tier: task.tier,
+      title: task.title,
+      capability: task.capability,
+      kind: task.kind,
+    };
+
+    const start = Date.now();
+    let iterations = 0;
+    let toolsUsed: string[] = [];
+    let timedOut = false;
+    let agentError: string | undefined;
+    let truncationEvents = 0;
+
+    try {
+      const chatPromise = agent.chat(task.prompt);
+      const raced = await Promise.race([
+        chatPromise.then((r) => ({ kind: 'ok' as const, r })),
+        delay(timeoutMs).then(() => ({ kind: 'timeout' as const })),
+      ]);
+
+      if (raced.kind === 'ok') {
+        iterations = raced.r.iterations;
+        toolsUsed = raced.r.toolsUsed;
+        truncationEvents = raced.r.truncationEvents ?? 0;
+      } else {
+        timedOut = true;
+        agent.stop();
+        chatPromise.catch(() => {}); // swallow the late rejection/resolution
+        iterations = maxIterations;
+      }
+    } catch (err) {
+      agentError = err instanceof Error ? err.message : String(err);
+    }
+
+    const wallTimeMs = Date.now() - start;
+    let tokenUsage;
+    try {
+      tokenUsage = agent.getTokenUsage();
+    } catch {
+      tokenUsage = undefined;
+    }
+
+    // Verify regardless — the agent may have completed the files even on timeout.
+    const verify = await runNodeTests(workspaceDir, protectedFiles, 60_000);
+    await agent.cleanup().catch(() => {});
+
+    const passed = verify.passed && !agentError;
+    let reason: TaskResult['reason'];
+    if (!passed) {
+      if (agentError) reason = 'agent-error';
+      else if (timedOut && !verify.passed) reason = 'timeout';
+      else reason = verify.reason;
+    }
+
+    const outputLimited = !passed && truncationEvents > 0;
+    const notes = [
+      agentError ? `agent error: ${agentError}` : '',
+      timedOut ? `timed out after ${timeoutMs}ms` : '',
+      outputLimited ? `hit output-token limit ${truncationEvents}×` : '',
+      verify.output ? `verifier: ${verify.output.split('\n').slice(-6).join(' ').slice(0, 300)}` : '',
+    ]
+      .filter(Boolean)
+      .join(' | ');
+
+    return {
+      ...base,
+      passed,
+      reason,
+      iterations,
+      hitMaxIterations: iterations >= maxIterations,
+      toolsUsed,
+      tokenUsage,
+      wallTimeMs,
+      testsPassed: verify.testsPassed,
+      testsFailed: verify.testsFailed,
+      failingTests: verify.failingTests,
+      truncationEvents,
+      outputLimited,
+      notes: notes || undefined,
+    };
+  }
+
+  private aggregate(
+    tasks: BenchmarkTask[],
+    results: TaskResult[],
+    startedAt: string,
+    finishedAt: string,
+    options: RunnerOptions,
+  ): SuiteResult {
+    const passed = results.filter((r) => r.passed).length;
+    const highestTierPassed = results.filter((r) => r.passed).reduce((m, r) => Math.max(m, r.tier), 0);
+    const totalWallTimeMs = results.reduce((s, r) => s + r.wallTimeMs, 0);
+    const totalTokens = results.reduce((s, r) => s + (r.tokenUsage?.totalTokens ?? 0), 0);
+    const totalTestsPassed = results.reduce((s, r) => s + r.testsPassed, 0);
+    const totalTestsRun = results.reduce((s, r) => s + r.testsPassed + r.testsFailed, 0);
+    const scorePct = totalTestsRun > 0 ? Math.round((totalTestsPassed / totalTestsRun) * 100) : 0;
+
+    return {
+      startedAt,
+      finishedAt,
+      suiteId: options.suiteId,
+      suiteName: options.suiteName,
+      scoring: options.scoring,
+      model: options.model,
+      totalTasks: tasks.length,
+      passed,
+      failed: results.length - passed,
+      highestTierPassed,
+      totalTestsPassed,
+      totalTestsRun,
+      scorePct,
+      totalWallTimeMs,
+      totalTokens: totalTokens || undefined,
+      tasks: results,
+    };
+  }
+}
+
+/** Convenience entry point used by both the CLI command and the HTTP route. */
+export async function runBenchmark(
+  orchestrator: ModelOrchestrator,
+  tasks: BenchmarkTask[],
+  options: RunnerOptions = {},
+  progress: ProgressEvents = {},
+): Promise<SuiteResult> {
+  if (tasks.length === 0) {
+    logger.warn('[benchmark] no tasks selected');
+  }
+  return new BenchmarkRunner(orchestrator).run(tasks, options, progress);
+}

--- a/src/code/benchmark/suites.ts
+++ b/src/code/benchmark/suites.ts
@@ -1,0 +1,55 @@
+/**
+ * Benchmark suite registry.
+ *
+ * Three tiers of suites with distinct purposes (see docs/guides/benchmark-suite.md):
+ *  - taskstore (baseline)  — gating: does code mode work at all? Most usable configs ~100%.
+ *  - microcrm  (capability)— scored: build a Node+SQLite REST API to spec; differentiates
+ *                            models and configurations by pass-rate.
+ *  - frontier  (future)    — scored: ~50 tests, even an optimal config only ~30-40%; full
+ *                            pass needs a frontier model.
+ */
+
+import type { BenchmarkSuite } from './types.js';
+import { BENCHMARK_TASKS } from './tasks.js';
+import { MICROCRM_TASKS } from './microcrm/index.js';
+
+export const BENCHMARK_SUITES: BenchmarkSuite[] = [
+  {
+    id: 'taskstore',
+    name: 'Taskstore (baseline)',
+    description:
+      'TDD smoke/regression suite over an evolving in-memory library. Binary pass/fail, tasks ' +
+      'build on one another. Confirms a model + config can do code mode at all.',
+    level: 'baseline',
+    scoring: 'gating',
+    tasks: BENCHMARK_TASKS,
+  },
+  {
+    id: 'microcrm',
+    name: 'micro-CRM API (capability)',
+    description:
+      'Build a Node + SQLite REST API to a fixed spec, graded by the fraction of spec tests ' +
+      'passed. Differentiates models and configurations; use it to find the optimal setup.',
+    level: 'capability',
+    scoring: 'scored',
+    tasks: MICROCRM_TASKS,
+  },
+];
+
+/** Default suite when none is specified (preserves prior `jiva benchmark` behaviour). */
+export const DEFAULT_SUITE_ID = 'taskstore';
+
+export function getSuite(id: string): BenchmarkSuite | undefined {
+  return BENCHMARK_SUITES.find((s) => s.id === id);
+}
+
+export function listSuiteMetadata(): Array<Pick<BenchmarkSuite, 'id' | 'name' | 'description' | 'level' | 'scoring'> & { taskCount: number }> {
+  return BENCHMARK_SUITES.map(({ id, name, description, level, scoring, tasks }) => ({
+    id,
+    name,
+    description,
+    level,
+    scoring,
+    taskCount: tasks.length,
+  }));
+}

--- a/src/code/benchmark/tasks.ts
+++ b/src/code/benchmark/tasks.ts
@@ -1,0 +1,181 @@
+/**
+ * The benchmark suite — 8 TDD-style coding tasks of increasing complexity over a
+ * single evolving `taskstore` library. Tier 1 is a from-scratch one-liner; tier 8
+ * is a long-horizon cross-module debug that stresses iteration count and output
+ * length — the regime where rate-limited or short-output models fall down.
+ */
+
+import type { BenchmarkTask, TaskFile } from './types.js';
+import { PACKAGE_JSON, scaffoldSrc } from './fixtures.js';
+import { cumulativeTests, cumulativeTestPaths } from './tests.js';
+
+const COMMON_RULES = `
+Rules:
+- The workspace is a Node ES-module project. Run the test suite with: node --test
+- Make ALL tests pass. Do not stop until "node --test" reports zero failures.
+- You MUST NOT modify, delete or move anything under the test/ directory.
+- Keep existing passing tests green — only change source files under src/.`;
+
+function buildScaffold(tier: number): TaskFile {
+  return {
+    'package.json': PACKAGE_JSON,
+    ...scaffoldSrc(tier),
+    ...cumulativeTests(tier),
+  };
+}
+
+interface TaskSpec {
+  id: string;
+  tier: number;
+  title: string;
+  capability: string;
+  kind: BenchmarkTask['kind'];
+  instruction: string;
+  maxIterations: number;
+  timeoutMs: number;
+}
+
+const SPECS: TaskSpec[] = [
+  {
+    id: 't01-create',
+    tier: 1,
+    title: 'Create createTask from scratch',
+    capability: 'Write a new file',
+    kind: 'scratch',
+    instruction:
+      'Create src/index.js exporting a function `createTask(title)` that returns an object ' +
+      '`{ title, done: false }` and throws an Error when the title is empty or only whitespace.',
+    maxIterations: 15,
+    timeoutMs: 120_000,
+  },
+  {
+    id: 't02-extend-crud',
+    tier: 2,
+    title: 'Add addTask / removeTask / listTasks',
+    capability: 'Read & extend an existing file',
+    kind: 'extend',
+    instruction:
+      'src/index.js already has createTask. Add and export `addTask(list, title)` (returns a NEW ' +
+      'list with an appended task that has a unique incrementing numeric `id` starting at 1, without ' +
+      'mutating the input), `removeTask(list, id)` (returns a new list without that task), and ' +
+      '`listTasks(list)` (returns all tasks).',
+    maxIterations: 20,
+    timeoutMs: 180_000,
+  },
+  {
+    id: 't03-bugfix-toggle',
+    tier: 3,
+    title: 'Fix the toggleTask bug',
+    capability: 'Diagnose & fix a targeted bug',
+    kind: 'bugfix',
+    instruction:
+      'src/index.js contains a `toggleTask(list, id)` function that is supposed to flip the `done` ' +
+      'flag of the task whose `id` matches, but the tests are failing. Find and fix the bug. ' +
+      'Do not rewrite unrelated code.',
+    maxIterations: 20,
+    timeoutMs: 180_000,
+  },
+  {
+    id: 't04-feature-priority',
+    tier: 4,
+    title: 'Add task priorities',
+    capability: 'Multi-function feature',
+    kind: 'extend',
+    instruction:
+      'Add priority support to src/index.js. New tasks must default to priority "normal". Export ' +
+      '`setPriority(list, id, priority)` that updates the matching task (allowed values: "low", ' +
+      '"normal", "high"; throw on anything else) and `tasksByPriority(list, priority)` that filters ' +
+      'tasks by priority.',
+    maxIterations: 25,
+    timeoutMs: 240_000,
+  },
+  {
+    id: 't05-refactor-split',
+    tier: 5,
+    title: 'Split into model / query modules',
+    capability: 'Multi-file refactor without regressions',
+    kind: 'refactor',
+    instruction:
+      'Refactor the single src/index.js into three files WITHOUT changing behaviour: ' +
+      '`src/model.js` exporting the mutation functions (createTask, addTask, removeTask, toggleTask, ' +
+      'setPriority), `src/query.js` exporting the read functions (listTasks, tasksByPriority), and ' +
+      '`src/index.js` re-exporting everything from both so the existing public API is unchanged. ' +
+      'All previously passing tests must remain green.',
+    maxIterations: 30,
+    timeoutMs: 300_000,
+  },
+  {
+    id: 't06-algorithm-sort',
+    tier: 6,
+    title: 'Implement sortTasks with edge cases',
+    capability: 'Algorithmic reasoning & edge cases',
+    kind: 'extend',
+    instruction:
+      'Add and export `sortTasks(list, { by })` (currently only `by: "due"` is supported — throw on ' +
+      'anything else). It returns a NEW array sorted by the `due` field (an ISO date string) ascending. ' +
+      'Tasks whose `due` is null or undefined must sort to the end, and the sort must be stable for ' +
+      'tasks with equal due dates. Put it in the appropriate module and re-export it from src/index.js.',
+    maxIterations: 30,
+    timeoutMs: 300_000,
+  },
+  {
+    id: 't07-storage-roundtrip',
+    tier: 7,
+    title: 'Add JSON serialize / deserialize',
+    capability: 'New module + serialization',
+    kind: 'extend',
+    instruction:
+      'Create `src/storage.js` exporting `serialize(list)` (returns a JSON string) and ' +
+      '`deserialize(str)` (parses it back into a task list, throwing if the parsed value is not an ' +
+      'array). A serialize→deserialize round-trip must preserve every field of every task. Re-export ' +
+      'both from src/index.js.',
+    maxIterations: 30,
+    timeoutMs: 300_000,
+  },
+  {
+    id: 't08-debug-id-collision',
+    tier: 8,
+    title: 'Debug the id-collision integration bug',
+    capability: 'Long-horizon cross-module debugging',
+    kind: 'bugfix',
+    instruction:
+      'The integration tests in test/t08.test.mjs are failing: after a task is removed (or a list is ' +
+      'restored from storage) and a new task is added, the new task can collide with an existing id. ' +
+      'Run the tests, read the failure, find the root cause across the source modules, and fix it so ' +
+      'ids are always unique. Do not weaken or change any test.',
+    maxIterations: 40,
+    timeoutMs: 420_000,
+  },
+];
+
+export const BENCHMARK_TASKS: BenchmarkTask[] = SPECS.map((s) => ({
+  id: s.id,
+  tier: s.tier,
+  title: s.title,
+  capability: s.capability,
+  kind: s.kind,
+  prompt: `${s.instruction}\n${COMMON_RULES}`,
+  scaffold: buildScaffold(s.tier),
+  protectedPaths: cumulativeTestPaths(s.tier),
+  maxIterations: s.maxIterations,
+  timeoutMs: s.timeoutMs,
+}));
+
+/** Lightweight metadata for listing endpoints (no scaffold/test payloads). */
+export function listTaskMetadata(
+  tasks: BenchmarkTask[],
+): Array<Pick<BenchmarkTask, 'id' | 'tier' | 'title' | 'capability' | 'kind'>> {
+  return tasks.map(({ id, tier, title, capability, kind }) => ({ id, tier, title, capability, kind }));
+}
+
+/** Resolve which tasks to run from a suite's task list, given runner filters. */
+export function selectTasks(tasks: BenchmarkTask[], opts: { maxTier?: number; taskIds?: string[] }): BenchmarkTask[] {
+  if (opts.taskIds && opts.taskIds.length > 0) {
+    const set = new Set(opts.taskIds);
+    return tasks.filter((t) => set.has(t.id));
+  }
+  if (typeof opts.maxTier === 'number') {
+    return tasks.filter((t) => t.tier <= opts.maxTier!);
+  }
+  return [...tasks];
+}

--- a/src/code/benchmark/tests.ts
+++ b/src/code/benchmark/tests.ts
@@ -1,0 +1,237 @@
+/**
+ * Cumulative node:test files for the benchmark suite.
+ *
+ * Tier N's workspace contains every test file test1..testN, so the verifier
+ * catches regressions in earlier tiers (critical for the tier-5 refactor and
+ * the tier-8 debug task). All tests import the library through `../src/index.js`
+ * except the tier-5 structural test, which deliberately imports the split
+ * modules to force the refactor.
+ *
+ * The agent must NOT modify any of these files (see BenchmarkTask.protectedPaths).
+ */
+
+import type { TaskFile } from './types.js';
+
+const TEST_FILES: Record<number, { path: string; content: string }> = {
+  1: {
+    path: 'test/t01.test.mjs',
+    content: `import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { createTask } from '../src/index.js';
+
+test('createTask sets the title and defaults done to false', () => {
+  const t = createTask('Buy milk');
+  assert.equal(t.title, 'Buy milk');
+  assert.equal(t.done, false);
+});
+
+test('createTask rejects empty or blank titles', () => {
+  assert.throws(() => createTask(''));
+  assert.throws(() => createTask('   '));
+});
+`,
+  },
+  2: {
+    path: 'test/t02.test.mjs',
+    content: `import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { addTask, removeTask, listTasks } from '../src/index.js';
+
+test('addTask appends a task with an incrementing id', () => {
+  let list = [];
+  list = addTask(list, 'a');
+  assert.equal(list.length, 1);
+  assert.equal(list[0].id, 1);
+  list = addTask(list, 'b');
+  assert.equal(list.length, 2);
+  assert.equal(list[1].id, 2);
+});
+
+test('addTask does not mutate the input list', () => {
+  const original = [];
+  const next = addTask(original, 'a');
+  assert.equal(original.length, 0);
+  assert.equal(next.length, 1);
+});
+
+test('removeTask removes the task with the given id', () => {
+  let list = addTask(addTask(addTask([], 'a'), 'b'), 'c'); // ids 1,2,3
+  list = removeTask(list, 2);
+  assert.deepEqual(list.map((t) => t.id), [1, 3]);
+});
+
+test('listTasks returns all tasks', () => {
+  const list = addTask(addTask([], 'a'), 'b');
+  assert.equal(listTasks(list).length, 2);
+});
+`,
+  },
+  3: {
+    path: 'test/t03.test.mjs',
+    content: `import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { addTask, toggleTask } from '../src/index.js';
+
+test('toggleTask flips done for the task with the matching id', () => {
+  let list = addTask(addTask([], 'a'), 'b'); // ids 1,2
+  list = toggleTask(list, 2);
+  assert.equal(list.find((t) => t.id === 1).done, false);
+  assert.equal(list.find((t) => t.id === 2).done, true);
+});
+
+test('toggleTask toggles back to false when called twice', () => {
+  let list = addTask([], 'a'); // id 1
+  list = toggleTask(list, 1);
+  list = toggleTask(list, 1);
+  assert.equal(list.find((t) => t.id === 1).done, false);
+});
+`,
+  },
+  4: {
+    path: 'test/t04.test.mjs',
+    content: `import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { addTask, setPriority, tasksByPriority } from '../src/index.js';
+
+test('new tasks default to normal priority', () => {
+  const list = addTask([], 'a');
+  assert.equal(list[0].priority, 'normal');
+});
+
+test('setPriority updates the priority of the matching task', () => {
+  let list = addTask(addTask([], 'a'), 'b'); // ids 1,2
+  list = setPriority(list, 2, 'high');
+  assert.equal(list.find((t) => t.id === 2).priority, 'high');
+  assert.equal(list.find((t) => t.id === 1).priority, 'normal');
+});
+
+test('setPriority rejects an invalid priority', () => {
+  const list = addTask([], 'a');
+  assert.throws(() => setPriority(list, 1, 'urgent'));
+});
+
+test('tasksByPriority filters by priority', () => {
+  let list = addTask(addTask([], 'a'), 'b');
+  list = setPriority(list, 1, 'high');
+  assert.equal(tasksByPriority(list, 'high').length, 1);
+  assert.equal(tasksByPriority(list, 'normal').length, 1);
+});
+`,
+  },
+  5: {
+    path: 'test/t05.test.mjs',
+    content: `import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import * as model from '../src/model.js';
+import * as query from '../src/query.js';
+import * as index from '../src/index.js';
+
+test('model module exposes the mutation functions', () => {
+  for (const fn of ['createTask', 'addTask', 'removeTask', 'toggleTask', 'setPriority']) {
+    assert.equal(typeof model[fn], 'function', 'model.' + fn);
+  }
+});
+
+test('query module exposes the read functions', () => {
+  for (const fn of ['listTasks', 'tasksByPriority']) {
+    assert.equal(typeof query[fn], 'function', 'query.' + fn);
+  }
+});
+
+test('index re-exports the full public API', () => {
+  for (const fn of ['createTask', 'addTask', 'removeTask', 'toggleTask', 'setPriority', 'listTasks', 'tasksByPriority']) {
+    assert.equal(typeof index[fn], 'function', 'index.' + fn);
+  }
+});
+`,
+  },
+  6: {
+    path: 'test/t06.test.mjs',
+    content: `import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { sortTasks } from '../src/index.js';
+
+const mk = (id, due) => ({ id, title: 't' + id, done: false, priority: 'normal', due });
+
+test('sorts by due date ascending', () => {
+  const list = [mk(1, '2026-03-01'), mk(2, '2026-01-01'), mk(3, '2026-02-01')];
+  assert.deepEqual(sortTasks(list, { by: 'due' }).map((t) => t.id), [2, 3, 1]);
+});
+
+test('places tasks without a due date last', () => {
+  const list = [mk(1, null), mk(2, '2026-01-01'), mk(3, undefined)];
+  const ids = sortTasks(list, { by: 'due' }).map((t) => t.id);
+  assert.equal(ids[0], 2);
+  assert.deepEqual(ids.slice(1).sort(), [1, 3]);
+});
+
+test('is stable for equal due dates', () => {
+  const list = [mk(1, '2026-01-01'), mk(2, '2026-01-01'), mk(3, '2026-01-01')];
+  assert.deepEqual(sortTasks(list, { by: 'due' }).map((t) => t.id), [1, 2, 3]);
+});
+
+test('does not mutate the input list', () => {
+  const list = [mk(2, '2026-02-01'), mk(1, '2026-01-01')];
+  sortTasks(list, { by: 'due' });
+  assert.deepEqual(list.map((t) => t.id), [2, 1]);
+});
+`,
+  },
+  7: {
+    path: 'test/t07.test.mjs',
+    content: `import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { addTask, setPriority, serialize, deserialize } from '../src/index.js';
+
+test('serialize/deserialize round-trips a list preserving all fields', () => {
+  let list = addTask(addTask([], 'a'), 'b');
+  list = setPriority(list, 1, 'high');
+  const restored = deserialize(serialize(list));
+  assert.deepEqual(restored, list);
+});
+
+test('deserialize rejects JSON that is not an array', () => {
+  assert.throws(() => deserialize('{}'));
+});
+`,
+  },
+  8: {
+    path: 'test/t08.test.mjs',
+    content: `import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { addTask, removeTask, serialize, deserialize } from '../src/index.js';
+
+test('ids stay unique after a removal and re-add', () => {
+  let list = addTask(addTask(addTask([], 'a'), 'b'), 'c'); // ids 1,2,3
+  list = removeTask(list, 2); // ids 1,3
+  list = addTask(list, 'd');
+  const ids = list.map((t) => t.id);
+  assert.equal(new Set(ids).size, ids.length, 'duplicate ids: ' + ids.join(','));
+});
+
+test('ids stay unique after a serialize round-trip and add', () => {
+  let list = addTask(addTask(addTask([], 'a'), 'b'), 'c');
+  list = removeTask(list, 2);
+  list = deserialize(serialize(list));
+  list = addTask(list, 'e');
+  const ids = list.map((t) => t.id);
+  assert.equal(new Set(ids).size, ids.length, 'duplicate ids: ' + ids.join(','));
+});
+`,
+  },
+};
+
+/** All test files for tiers 1..tier (cumulative). */
+export function cumulativeTests(tier: number): TaskFile {
+  const files: TaskFile = {};
+  for (let t = 1; t <= tier; t++) {
+    const entry = TEST_FILES[t];
+    if (entry) files[entry.path] = entry.content;
+  }
+  return files;
+}
+
+/** Paths of all test files for tiers 1..tier (the protected set). */
+export function cumulativeTestPaths(tier: number): string[] {
+  return Object.keys(cumulativeTests(tier));
+}

--- a/src/code/benchmark/types.ts
+++ b/src/code/benchmark/types.ts
@@ -1,0 +1,170 @@
+/**
+ * Benchmark types — shared by the runner, the CLI command and the HTTP routes.
+ *
+ * The benchmark measures how well a given model + config performs in code mode
+ * across a TDD-style suite of increasing complexity. Each task scaffolds an
+ * isolated workspace containing failing tests; the agent must make them pass
+ * without editing the protected test files. Scoring is deterministic — it is the
+ * exit status of Node's built-in test runner, not an LLM judgement.
+ */
+
+import type { TokenUsageSnapshot } from '../../models/token-tracker.js';
+
+/** A map of workspace-relative path → file content, written before the agent runs. */
+export type TaskFile = Record<string, string>;
+
+/**
+ * A single benchmark task. Tasks are ordered by `tier` (1 = easiest) and build
+ * on one another: the scaffold for tier N is the canonical solution of tiers
+ * 1..N-1 plus the new failing test(s) for tier N.
+ */
+export interface BenchmarkTask {
+  /** Stable identifier, e.g. "t03-bugfix-toggle". */
+  id: string;
+  /** Complexity tier, 1 (trivial) .. 8 (long-horizon debug). */
+  tier: number;
+  /** Short human title. */
+  title: string;
+  /** The capability this tier primarily exercises (shown in reports). */
+  capability: string;
+  /** Whether the task builds from scratch or improves/fixes existing code. */
+  kind: 'scratch' | 'extend' | 'bugfix' | 'refactor';
+  /** The instruction handed to the agent. */
+  prompt: string;
+  /** Files written into the workspace before the agent runs (the scaffold). */
+  scaffold: TaskFile;
+  /**
+   * Workspace-relative paths the agent must NOT modify (the tests). If any of
+   * these differ after the run, the task fails with reason `tests-modified`.
+   */
+  protectedPaths: string[];
+  /** Per-task iteration cap (overridable globally). */
+  maxIterations: number;
+  /** Per-task wall-clock timeout in ms (overridable globally). */
+  timeoutMs: number;
+}
+
+/**
+ * Scoring mode for a suite:
+ *  - 'gating' : binary pass/fail per task; tasks build on one another (the baseline
+ *    taskstore suite). Measures "does code mode work at all".
+ *  - 'scored' : graded by the FRACTION of spec tests passed (the capability/frontier
+ *    suites). The headline metric is the pass-rate, not all-or-nothing.
+ */
+export type ScoringMode = 'gating' | 'scored';
+
+/** A named collection of tasks with a shared purpose and scoring philosophy. */
+export interface BenchmarkSuite {
+  id: string;
+  name: string;
+  description: string;
+  /** Difficulty/intent tier of the whole suite. */
+  level: 'baseline' | 'capability' | 'frontier';
+  scoring: ScoringMode;
+  tasks: BenchmarkTask[];
+}
+
+/** Outcome of running the deterministic verifier against a workspace. */
+export interface VerifyResult {
+  passed: boolean;
+  /** Number of passing / failing test cases parsed from the runner output. */
+  testsPassed: number;
+  testsFailed: number;
+  /** Names of failing test cases (parsed from `not ok` lines) — drives scored reports. */
+  failingTests: string[];
+  /** Categorised failure reason when !passed. */
+  reason?: 'tests-failed' | 'tests-modified' | 'runner-error' | 'timeout';
+  /** Trimmed runner output (stdout+stderr), useful for diagnosis. */
+  output: string;
+}
+
+/** Per-task result with diagnostic metrics. */
+export interface TaskResult {
+  id: string;
+  tier: number;
+  title: string;
+  capability: string;
+  kind: BenchmarkTask['kind'];
+  passed: boolean;
+  /** Categorised reason when !passed (mirrors VerifyResult.reason or 'agent-error'). */
+  reason?: VerifyResult['reason'] | 'agent-error';
+  /** Agent loop iterations consumed. */
+  iterations: number;
+  /** True when the agent hit its iteration cap (a strong "struggling" signal). */
+  hitMaxIterations: boolean;
+  /** Tool names the agent invoked. */
+  toolsUsed: string[];
+  /** Token usage accumulated by the agent during this task. */
+  tokenUsage?: TokenUsageSnapshot;
+  /** Wall-clock duration of the agent turn (not counting verification). */
+  wallTimeMs: number;
+  testsPassed: number;
+  testsFailed: number;
+  /** Names of failing test cases (for scored suites, this is the per-capability gap list). */
+  failingTests?: string[];
+  /** Times the model hit its output-token limit mid tool-call (write/edit cut off). */
+  truncationEvents?: number;
+  /** True when this task failed AND hit output-token limits — an output-length limitation. */
+  outputLimited?: boolean;
+  /** Free-form diagnostic notes (errors, truncation hints, verifier output head). */
+  notes?: string;
+}
+
+/** Aggregate result for a full suite run. */
+export interface SuiteResult {
+  startedAt: string;
+  finishedAt: string;
+  /** Suite identity and scoring mode (drives report rendering). */
+  suiteId?: string;
+  suiteName?: string;
+  scoring?: ScoringMode;
+  /** Model label, when resolvable from the orchestrator config. */
+  model?: string;
+  totalTasks: number;
+  passed: number;
+  failed: number;
+  /** Highest tier reached with a pass (a single capability ceiling number). */
+  highestTierPassed: number;
+  /** Aggregate spec-test counts across the suite (the headline for scored suites). */
+  totalTestsPassed: number;
+  totalTestsRun: number;
+  /** Percentage of spec tests passed (0–100). */
+  scorePct: number;
+  totalWallTimeMs: number;
+  totalTokens?: number;
+  tasks: TaskResult[];
+}
+
+/** Options controlling a suite run. */
+export interface RunnerOptions {
+  /** Run only tiers 1..maxTier. */
+  maxTier?: number;
+  /** Run only these task ids (overrides maxTier). */
+  taskIds?: string[];
+  /** Global override for each task's iteration cap. */
+  maxIterations?: number;
+  /** Global override for each task's timeout. */
+  timeoutMs?: number;
+  /** Enable LSP during the run (default: off, to reduce variance). */
+  lspEnabled?: boolean;
+  /**
+   * Carry the agent's own resulting workspace forward to the next tier instead
+   * of scaffolding from the canonical golden baseline. Surfaces cascading
+   * failures the way a real session would.
+   */
+  continuous?: boolean;
+  /** Keep temp workspaces on disk for debugging. */
+  keepWorkspaces?: boolean;
+  /** Model label for reporting. */
+  model?: string;
+  /** Suite identity + scoring, embedded into the result for reporting. */
+  suiteId?: string;
+  suiteName?: string;
+  scoring?: ScoringMode;
+}
+
+/** Progress callback fired around each task (enables CLI lines and SSE). */
+export interface ProgressEvents {
+  onTaskStart?: (task: BenchmarkTask, index: number, total: number) => void;
+  onTaskDone?: (result: TaskResult, index: number, total: number) => void;
+}

--- a/src/code/benchmark/verify.ts
+++ b/src/code/benchmark/verify.ts
@@ -1,0 +1,120 @@
+/**
+ * Deterministic verifier — runs Node's built-in test runner against a workspace
+ * and reports pass/fail. No external test framework, no network.
+ *
+ * Two checks gate a pass:
+ *   1. Tamper check — the protected test files must be byte-identical to what was
+ *      scaffolded. If the agent edited a test to make it pass, the task fails
+ *      with reason `tests-modified`.
+ *   2. Test run — `node --test` must exit 0 with at least one passing test and
+ *      zero failures.
+ */
+
+import { spawn } from 'child_process';
+import { readFile } from 'fs/promises';
+import { join } from 'path';
+import type { VerifyResult } from './types.js';
+
+/** Read a workspace file, returning null if it is missing. */
+async function tryRead(workspaceDir: string, relPath: string): Promise<string | null> {
+  try {
+    return await readFile(join(workspaceDir, relPath), 'utf-8');
+  } catch {
+    return null;
+  }
+}
+
+/** Parse `# pass N` / `# fail N` from Node's TAP-ish test output. */
+function parseCounts(output: string): { passed: number; failed: number } {
+  const pass = output.match(/^# pass (\d+)/m);
+  const fail = output.match(/^# fail (\d+)/m);
+  return {
+    passed: pass ? parseInt(pass[1], 10) : 0,
+    failed: fail ? parseInt(fail[1], 10) : 0,
+  };
+}
+
+/** Parse failing top-level test names from the TAP `not ok N - <name>` lines. */
+function parseFailingTests(output: string): string[] {
+  const names: string[] = [];
+  for (const line of output.split('\n')) {
+    const m = line.match(/^not ok \d+ - (.+?)(?: # .*)?$/);
+    if (m) names.push(m[1].trim());
+  }
+  return names;
+}
+
+/**
+ * Run the verifier.
+ *
+ * @param workspaceDir absolute path of the task workspace
+ * @param protectedFiles map of relative path → original content (the scaffolded tests)
+ * @param timeoutMs hard cap for the test process
+ */
+export async function runNodeTests(
+  workspaceDir: string,
+  protectedFiles: Record<string, string>,
+  timeoutMs = 60_000,
+): Promise<VerifyResult> {
+  // 1. Tamper check.
+  for (const [relPath, original] of Object.entries(protectedFiles)) {
+    const current = await tryRead(workspaceDir, relPath);
+    if (current === null) {
+      return { passed: false, testsPassed: 0, testsFailed: 0, failingTests: [], reason: 'tests-modified', output: `Protected test file was removed: ${relPath}` };
+    }
+    if (current !== original) {
+      return { passed: false, testsPassed: 0, testsFailed: 0, failingTests: [], reason: 'tests-modified', output: `Protected test file was modified: ${relPath}` };
+    }
+  }
+
+  // 2. Run `node --test`, scoped to ONLY the canonical protected test files.
+  // Bare `node --test` discovers any test file in the workspace, so an agent's own
+  // scratch tests would pollute the counts and could cause false failures. Passing the
+  // protected paths explicitly makes scoring depend solely on the canonical suite.
+  const testPaths = Object.keys(protectedFiles);
+  const args = testPaths.length > 0 ? ['--test', ...testPaths] : ['--test'];
+  return new Promise<VerifyResult>((resolve) => {
+    const child = spawn(process.execPath, args, {
+      cwd: workspaceDir,
+      env: { ...process.env, NODE_OPTIONS: '' },
+    });
+
+    let out = '';
+    const append = (buf: Buffer) => {
+      out += buf.toString();
+      if (out.length > 200_000) out = out.slice(-200_000); // cap memory
+    };
+    child.stdout.on('data', append);
+    child.stderr.on('data', append);
+
+    const timer = setTimeout(() => {
+      child.kill('SIGKILL');
+      resolve({ passed: false, testsPassed: 0, testsFailed: 0, failingTests: parseFailingTests(out), reason: 'timeout', output: trimOutput(out) });
+    }, timeoutMs);
+
+    child.on('error', (err) => {
+      clearTimeout(timer);
+      resolve({ passed: false, testsPassed: 0, testsFailed: 0, failingTests: [], reason: 'runner-error', output: `${err.message}\n${trimOutput(out)}` });
+    });
+
+    child.on('close', (code) => {
+      clearTimeout(timer);
+      const { passed, failed } = parseCounts(out);
+      const ok = code === 0 && failed === 0 && passed > 0;
+      resolve({
+        passed: ok,
+        testsPassed: passed,
+        testsFailed: failed,
+        failingTests: parseFailingTests(out),
+        reason: ok ? undefined : 'tests-failed',
+        output: trimOutput(out),
+      });
+    });
+  });
+}
+
+/** Keep the most relevant tail of the runner output for diagnostics. */
+function trimOutput(out: string): string {
+  const max = 4_000;
+  return out.length > max ? out.slice(-max) : out;
+}

--- a/src/code/tools/edit.ts
+++ b/src/code/tools/edit.ts
@@ -43,7 +43,11 @@ Returns a diff of the changes made, plus any LSP errors detected.`,
     properties: {
       file_path: {
         type: 'string',
-        description: 'Absolute path to the file to edit',
+        description: 'Absolute path to the file to edit (preferred). The alias "path" is also accepted.',
+      },
+      path: {
+        type: 'string',
+        description: 'Alias for file_path. Prefer file_path; either is accepted.',
       },
       old_string: {
         type: 'string',
@@ -58,11 +62,16 @@ Returns a diff of the changes made, plus any LSP errors detected.`,
         description: 'Replace all occurrences of old_string (default: false)',
       },
     },
-    required: ['file_path', 'old_string', 'new_string'],
+    // file_path is intentionally not in `required` so the `path` alias is accepted by
+    // provider-side validation; it is validated in execute() below.
+    required: ['old_string', 'new_string'],
   },
 
   async execute(args, ctx: CodeToolContext): Promise<string> {
-    const rawPath = args.file_path as string;
+    const rawPath = (args.file_path ?? args.path) as string | undefined;
+    if (typeof rawPath !== 'string' || rawPath.trim() === '') {
+      return 'Error: file_path is required — provide the absolute path to the file to edit.';
+    }
     const filePath = path.isAbsolute(rawPath) ? rawPath : path.resolve(ctx.workspaceDir, rawPath);
     const oldString = args.old_string as string;
     const newString = args.new_string as string;

--- a/src/code/tools/write.ts
+++ b/src/code/tools/write.ts
@@ -21,18 +21,28 @@ Returns a summary of changes and LSP diagnostics (if any errors).`,
     properties: {
       file_path: {
         type: 'string',
-        description: 'Absolute path to the file to write',
+        description: 'Absolute path to the file to write (preferred). The alias "path" is also accepted.',
+      },
+      path: {
+        type: 'string',
+        description: 'Alias for file_path. Prefer file_path; either is accepted.',
       },
       content: {
         type: 'string',
         description: 'The full content to write to the file',
       },
     },
-    required: ['file_path', 'content'],
+    // Only `content` is hard-required at the schema level so that models which emit
+    // the common `path` alias instead of `file_path` are not rejected by provider-side
+    // tool-call validation (Groq/Sarvam). The path is validated in execute() below.
+    required: ['content'],
   },
 
   async execute(args, ctx: CodeToolContext): Promise<string> {
-    const rawPath = args.file_path as string;
+    const rawPath = (args.file_path ?? args.path) as string | undefined;
+    if (typeof rawPath !== 'string' || rawPath.trim() === '') {
+      return 'Error: file_path is required — provide the absolute path to the file to write.';
+    }
     const filePath = path.isAbsolute(rawPath) ? rawPath : path.resolve(ctx.workspaceDir, rawPath);
     const content = args.content as string;
 

--- a/src/core/agent-interface.ts
+++ b/src/core/agent-interface.ts
@@ -24,6 +24,11 @@ export interface AgentChatResponse {
   };
   /** Token usage accumulated by the agent's orchestrator during this chat() call. */
   tokenUsage?: TokenUsageSnapshot;
+  /**
+   * How the turn ended. Code mode sets 'max-iterations' when the step limit was hit
+   * before finishing, so the CLI can offer the user the option to continue.
+   */
+  stopReason?: 'completed' | 'max-iterations' | 'stopped';
 }
 
 export interface IAgent {

--- a/src/interfaces/cli/index.ts
+++ b/src/interfaces/cli/index.ts
@@ -923,6 +923,140 @@ program
     }
   });
 
+// Benchmark command — measure code-mode capability of the configured model
+program
+  .command('benchmark')
+  .description('Run a code-mode benchmark suite (taskstore baseline, microcrm capability, …)')
+  .option('-c, --config <path>', 'Path to configuration JSON file')
+  .option('--suite <id>', 'Suite to run (taskstore | microcrm). Default: taskstore')
+  .option('--list', 'List available suites and their tasks, then exit')
+  .option('--max-tier <number>', 'Run only tiers 1..N within the suite', parseInt)
+  .option('--tasks <ids>', 'Comma-separated task ids to run (overrides --max-tier)')
+  .option('--max-iterations <number>', 'Override the per-task iteration cap', parseInt)
+  .option('--timeout <ms>', 'Override the per-task wall-clock timeout (ms)', parseInt)
+  .option('--lsp', 'Enable LSP during the benchmark (default: off)')
+  .option('--continuous', "Carry the agent's own output forward between tiers")
+  .option('--output <path>', 'Write the full JSON report to a file')
+  .option('--json', 'Print JSON only (machine-readable, suppresses progress)')
+  .option('--keep-workspaces', 'Keep temp workspaces on disk for debugging')
+  .action(async (options) => {
+    try {
+      // --list: print the suite/task catalogue and exit (no model needed).
+      if (options.list) {
+        const { BENCHMARK_SUITES, listTaskMetadata } = await import('../../code/benchmark/index.js');
+        for (const s of BENCHMARK_SUITES) {
+          console.log(chalk.bold(`\n${s.id}`) + chalk.gray(`  [${s.level} · ${s.scoring}]  ${s.name}`));
+          console.log(chalk.gray(`  ${s.description}`));
+          for (const t of listTaskMetadata(s.tasks)) {
+            console.log(`    ${chalk.cyan(t.id)} ${chalk.gray(`(tier ${t.tier}, ${t.kind})`)} — ${t.title}`);
+          }
+        }
+        console.log('');
+        process.exit(0);
+      }
+
+      // Resolve model configuration (from a config file or the stored config).
+      let modelConfig: any;
+      if (options.config) {
+        const configFile = await import('fs/promises').then((fs) => fs.readFile(options.config, 'utf-8'));
+        modelConfig = JSON.parse(configFile).models;
+      } else {
+        if (!configManager.isConfigured()) {
+          console.log(chalk.red('✗ Jiva is not configured. Please run: jiva setup\n'));
+          process.exit(1);
+        }
+        configManager.validateConfig();
+        modelConfig = {
+          reasoning: configManager.getReasoningModel(),
+          multimodal: configManager.getMultimodalModel(),
+          toolCalling: configManager.getToolCallingModel(),
+        };
+      }
+      if (!modelConfig?.reasoning) {
+        throw new Error('A reasoning model configuration is required');
+      }
+
+      const jsonOnly = !!options.json;
+      const log = (m: string) => {
+        if (!jsonOnly) console.log(chalk.gray('  ' + m));
+      };
+
+      const { createOrchestrator, selectTasks, runBenchmark, formatReportForCLI, toReportJSON, getSuite, DEFAULT_SUITE_ID, BENCHMARK_SUITES } =
+        await import('../../code/benchmark/index.js');
+
+      const suiteId = options.suite || DEFAULT_SUITE_ID;
+      const benchSuite = getSuite(suiteId);
+      if (!benchSuite) {
+        console.log(chalk.red(`Unknown suite "${suiteId}". Available: ${BENCHMARK_SUITES.map((s) => s.id).join(', ')}`));
+        process.exit(1);
+      }
+
+      if (!jsonOnly) console.log(chalk.gray('Testing model connectivity...'));
+      const { orchestrator, modelLabel } = await createOrchestrator({
+        reasoning: modelConfig.reasoning,
+        multimodal: modelConfig.multimodal,
+        toolCalling: modelConfig.toolCalling,
+        testConnectivity: true,
+        log,
+      });
+
+      const taskIds = options.tasks
+        ? options.tasks.split(',').map((s: string) => s.trim()).filter(Boolean)
+        : undefined;
+      const tasks = selectTasks(benchSuite.tasks, { maxTier: options.maxTier, taskIds });
+      if (tasks.length === 0) {
+        console.log(chalk.red('No benchmark tasks match the given filters.'));
+        process.exit(1);
+      }
+
+      if (!jsonOnly) {
+        console.log(chalk.cyan(`\nRunning suite "${benchSuite.id}" — ${tasks.length} task(s) with ${modelLabel}...\n`));
+      }
+
+      const suite = await runBenchmark(
+        orchestrator,
+        tasks,
+        {
+          maxIterations: options.maxIterations,
+          timeoutMs: options.timeout,
+          lspEnabled: !!options.lsp,
+          continuous: !!options.continuous,
+          keepWorkspaces: !!options.keepWorkspaces,
+          model: modelLabel,
+          suiteId: benchSuite.id,
+          suiteName: benchSuite.name,
+          scoring: benchSuite.scoring,
+        },
+        {
+          onTaskStart: (task, i, total) => {
+            if (!jsonOnly) process.stdout.write(chalk.gray(`  [${i + 1}/${total}] tier ${task.tier} · ${task.id} ... `));
+          },
+          onTaskDone: (r) => {
+            if (!jsonOnly) console.log(r.passed ? chalk.green('PASS') : chalk.red(`FAIL (${r.reason ?? 'fail'})`));
+          },
+        },
+      );
+
+      if (options.output) {
+        await import('fs/promises').then((fs) => fs.writeFile(options.output, toReportJSON(suite), 'utf-8'));
+        if (!jsonOnly) console.log(chalk.gray(`\nReport written to ${options.output}`));
+      }
+
+      if (jsonOnly) console.log(toReportJSON(suite));
+      else console.log(formatReportForCLI(suite));
+
+      // Gating suites: non-zero exit on any failure (CI gate). Scored suites are a
+      // measurement — exit 0 unless an infra/agent error prevented tests from running.
+      const exitCode = benchSuite.scoring === 'scored'
+        ? (suite.tasks.some((t) => t.reason === 'agent-error' || t.reason === 'runner-error') ? 1 : 0)
+        : (suite.failed > 0 ? 1 : 0);
+      process.exit(exitCode);
+    } catch (error) {
+      logger.error('Benchmark failed', error);
+      process.exit(1);
+    }
+  });
+
 // Default command (interactive chat)
 program.action(async (options) => {
   // If no command specified, run chat with the same options

--- a/src/interfaces/cli/repl.ts
+++ b/src/interfaces/cli/repl.ts
@@ -351,29 +351,57 @@ export async function startREPL(options: REPLOptions): Promise<void> {
         console.log('');
       } else {
         // ── Standard mode ────────────────────────────────────────────────
-        const response = await agent.chat(messageToSend);
+        // The agent may hit its step limit before finishing. When it does we let
+        // the user decide whether to keep going, resuming with the same history.
+        let turnMessage = messageToSend;
+        while (true) {
+          const response = await agent.chat(turnMessage);
 
-        spinner.stop();
+          spinner.stop();
 
-        console.log(chalk.bold.green('\nJiva:'));
+          console.log(chalk.bold.green('\nJiva:'));
 
-        // Render markdown for prettier output
-        const formattedContent = formatForCLI(response.content);
-        console.log(formattedContent);
+          // Render markdown for prettier output
+          const formattedContent = formatForCLI(response.content);
+          console.log(formattedContent);
 
-        if (response.toolsUsed.length > 0) {
-          console.log(chalk.gray(`\n[Used tools: ${response.toolsUsed.join(', ')}]`));
+          if (response.toolsUsed.length > 0) {
+            console.log(chalk.gray(`\n[Used tools: ${response.toolsUsed.join(', ')}]`));
+          }
+
+          console.log(chalk.gray(`[Iterations: ${response.iterations}]`));
+
+          if (response.tokenUsage) {
+            const k = (n: number) => n >= 1000 ? `${(n / 1000).toFixed(1)}k` : String(n);
+            const tu = response.tokenUsage;
+            console.log(chalk.gray(`[Tokens: ${k(tu.promptTokens)}p + ${k(tu.completionTokens)}c = ${k(tu.totalTokens)} total (this turn: ${k(tu.lastPromptTokens)}p prompt)]`));
+          }
+
+          console.log('');
+
+          // Ran out of steps before finishing — offer to continue.
+          if (response.stopReason !== 'max-iterations') break;
+
+          rl.pause();
+          const { choice } = await inquirer.prompt([{
+            type: 'list',
+            name: 'choice',
+            message: chalk.yellow('Jiva reached its step limit before finishing this task.'),
+            choices: [
+              { name: 'Continue working…', value: 'continue' },
+              { name: 'Stop for now', value: 'stop' },
+            ],
+            default: 'continue',
+            prefix: '',
+          }]);
+          rl.resume();
+
+          if (choice !== 'continue') break;
+
+          turnMessage =
+            'Continue working on the task. Resume exactly where you left off and complete the remaining steps.';
+          spinner.start(chalk.gray('Continuing…'));
         }
-
-        console.log(chalk.gray(`[Iterations: ${response.iterations}]`));
-
-        if (response.tokenUsage) {
-          const k = (n: number) => n >= 1000 ? `${(n / 1000).toFixed(1)}k` : String(n);
-          const tu = response.tokenUsage;
-          console.log(chalk.gray(`[Tokens: ${k(tu.promptTokens)}p + ${k(tu.completionTokens)}c = ${k(tu.totalTokens)} total (this turn: ${k(tu.lastPromptTokens)}p prompt)]`));
-        }
-
-        console.log('');
       }
     } catch (error) {
       spinner.stop();

--- a/src/interfaces/cli/setup-wizard.ts
+++ b/src/interfaces/cli/setup-wizard.ts
@@ -39,7 +39,8 @@ const PROVIDERS: Record<ProviderKey, ProviderPreset> = {
     toolCallingModel: 'sarvam-105b',
     useHarmonyFormat: false,
     reasoningEffortStrategy: 'api_param',
-    defaultMaxTokens: 8192,
+    // Sarvam's API caps completion output at 4096 tokens; requesting more is rejected.
+    defaultMaxTokens: 4096,
     hasMultimodal: false,
     note: 'Sarvam does not offer a multimodal model. You will need to pick a separate provider for multimodal.',
   },

--- a/src/interfaces/http/index.ts
+++ b/src/interfaces/http/index.ts
@@ -19,6 +19,7 @@ import { createStorageProvider } from '../../storage/factory.js';
 import { setupHealthRoutes } from './routes/health.js';
 import { setupSessionRoutes } from './routes/session.js';
 import { setupChatRoutes } from './routes/chat.js';
+import { setupBenchmarkRoutes } from './routes/benchmark.js';
 import { setupWebSocketHandler } from './websocket-handler.js';
 import { authMiddleware } from './middleware/auth.js';
 
@@ -75,6 +76,7 @@ async function bootstrap(): Promise<{ app: Express; server: HttpServer; wss: Web
   app.use('/api', authMiddleware);
   setupSessionRoutes(app, sessionManager);
   setupChatRoutes(app, sessionManager);
+  setupBenchmarkRoutes(app);
 
   // WebSocket upgrade handler
   server.on('upgrade', (request, socket, head) => {

--- a/src/interfaces/http/routes/benchmark.ts
+++ b/src/interfaces/http/routes/benchmark.ts
@@ -1,0 +1,155 @@
+/**
+ * Benchmark routes — run the code-mode benchmark suite over HTTP.
+ *
+ * The suite runs in isolated temp workspaces (not session-bound), so these
+ * routes build their own ModelOrchestrator from the stored configuration,
+ * cached across requests. Long runs should prefer the streaming variant.
+ *
+ *   GET  /api/benchmark/tasks       → list available tasks (metadata only)
+ *   POST /api/benchmark/run         → run the suite, return the full SuiteResult
+ *   POST /api/benchmark/run/stream  → run the suite, stream per-task progress (SSE)
+ */
+
+import { Express, Request, Response } from 'express';
+import { configManager } from '../../../core/config.js';
+import { logger } from '../../../utils/logger.js';
+import {
+  createOrchestrator,
+  selectTasks,
+  runBenchmark,
+  listTaskMetadata,
+  listSuiteMetadata,
+  getSuite,
+  DEFAULT_SUITE_ID,
+} from '../../../code/benchmark/index.js';
+import type { ModelOrchestrator } from '../../../models/orchestrator.js';
+import type { RunnerOptions } from '../../../code/benchmark/index.js';
+
+let orchestratorPromise: Promise<{ orchestrator: ModelOrchestrator; modelLabel: string }> | null = null;
+
+/** Build (and cache) the orchestrator from stored config. */
+function getOrchestrator(): Promise<{ orchestrator: ModelOrchestrator; modelLabel: string }> {
+  if (!orchestratorPromise) {
+    orchestratorPromise = (async () => {
+      if (!configManager.isConfigured()) {
+        throw new Error('Jiva is not configured on this server');
+      }
+      configManager.validateConfig();
+      return createOrchestrator({
+        reasoning: configManager.getReasoningModel() as any,
+        multimodal: configManager.getMultimodalModel() as any,
+        toolCalling: configManager.getToolCallingModel() as any,
+        testConnectivity: true,
+        log: (m) => logger.info(`[benchmark] ${m}`),
+      });
+    })().catch((err) => {
+      orchestratorPromise = null; // allow retry on next request
+      throw err;
+    });
+  }
+  return orchestratorPromise;
+}
+
+/** Map a request body to RunnerOptions. */
+function parseRunOptions(body: any): { options: RunnerOptions; taskIds?: string[]; maxTier?: number; suiteId: string } {
+  return {
+    suiteId: typeof body?.suite === 'string' && body.suite ? body.suite : DEFAULT_SUITE_ID,
+    maxTier: typeof body?.maxTier === 'number' ? body.maxTier : undefined,
+    taskIds: Array.isArray(body?.tasks) ? body.tasks : undefined,
+    options: {
+      maxIterations: typeof body?.maxIterations === 'number' ? body.maxIterations : undefined,
+      timeoutMs: typeof body?.timeoutMs === 'number' ? body.timeoutMs : undefined,
+      lspEnabled: !!body?.lsp,
+      continuous: !!body?.continuous,
+    },
+  };
+}
+
+export function setupBenchmarkRoutes(app: Express): void {
+  app.get('/api/benchmark/suites', (_req: Request, res: Response) => {
+    res.status(200).json({ success: true, suites: listSuiteMetadata() });
+  });
+
+  app.get('/api/benchmark/tasks', (req: Request, res: Response) => {
+    const suiteId = (typeof req.query.suite === 'string' && req.query.suite) || DEFAULT_SUITE_ID;
+    const suite = getSuite(suiteId);
+    if (!suite) {
+      res.status(404).json({ error: `Unknown suite "${suiteId}"` });
+      return;
+    }
+    res.status(200).json({ success: true, suite: suite.id, tasks: listTaskMetadata(suite.tasks) });
+  });
+
+  app.post('/api/benchmark/run', async (req: Request, res: Response) => {
+    try {
+      const { options, taskIds, maxTier, suiteId } = parseRunOptions(req.body);
+      const suite = getSuite(suiteId);
+      if (!suite) {
+        res.status(404).json({ error: `Unknown suite "${suiteId}"` });
+        return;
+      }
+      const { orchestrator, modelLabel } = await getOrchestrator();
+      const tasks = selectTasks(suite.tasks, { maxTier, taskIds });
+      if (tasks.length === 0) {
+        res.status(400).json({ error: 'No benchmark tasks match the given filters' });
+        return;
+      }
+      const result = await runBenchmark(orchestrator, tasks, {
+        ...options,
+        model: modelLabel,
+        suiteId: suite.id,
+        suiteName: suite.name,
+        scoring: suite.scoring,
+      });
+      res.status(200).json({ success: true, suite: result });
+    } catch (error) {
+      logger.error('[API] Benchmark run error:', error);
+      res.status(500).json({ error: 'Benchmark failed', message: error instanceof Error ? error.message : 'Unknown error' });
+    }
+  });
+
+  app.post('/api/benchmark/run/stream', async (req: Request, res: Response) => {
+    res.setHeader('Content-Type', 'text/event-stream');
+    res.setHeader('Cache-Control', 'no-cache');
+    res.setHeader('Connection', 'keep-alive');
+    res.flushHeaders?.();
+
+    const sendEvent = (event: string, data: any) => {
+      res.write(`event: ${event}\n`);
+      res.write(`data: ${JSON.stringify(data)}\n\n`);
+    };
+
+    try {
+      const { options, taskIds, maxTier, suiteId } = parseRunOptions(req.body);
+      const suite = getSuite(suiteId);
+      if (!suite) {
+        sendEvent('error', { message: `Unknown suite "${suiteId}"` });
+        res.end();
+        return;
+      }
+      const { orchestrator, modelLabel } = await getOrchestrator();
+      const tasks = selectTasks(suite.tasks, { maxTier, taskIds });
+      if (tasks.length === 0) {
+        sendEvent('error', { message: 'No benchmark tasks match the given filters' });
+        res.end();
+        return;
+      }
+
+      const result = await runBenchmark(
+        orchestrator,
+        tasks,
+        { ...options, model: modelLabel, suiteId: suite.id, suiteName: suite.name, scoring: suite.scoring },
+        {
+          onTaskStart: (task, index, total) => sendEvent('task-start', { id: task.id, tier: task.tier, title: task.title, index, total }),
+          onTaskDone: (taskResult, index, total) => sendEvent('task-done', { result: taskResult, index, total }),
+        },
+      );
+
+      sendEvent('done', { suite: result });
+      res.end();
+    } catch (error) {
+      sendEvent('error', { message: error instanceof Error ? error.message : 'Unknown error' });
+      res.end();
+    }
+  });
+}

--- a/src/models/model-client.ts
+++ b/src/models/model-client.ts
@@ -97,7 +97,8 @@ export interface ModelClientConfig {
    * on their thinking chain before producing output. Without a sufficient budget
    * the model exhausts the default limit (~2048) reasoning and returns empty content.
    *
-   * Recommended: 8192 for Sarvam-105B, unset for Groq/Krutrim.
+   * Sarvam-105B caps completion output at 4096 tokens (requesting more is rejected),
+   * so use 4096 there. Leave unset for Groq/Krutrim.
    */
   defaultMaxTokens?: number;
 }


### PR DESCRIPTION
# Jiva v0.3.48 — Code-Mode Benchmark Suite

**Release Date:** June 29, 2026

---

## Summary

Jiva's `--code` mode works well with `gpt-oss-120b` but degrades with other models — Sarvam-105b (4096-token output cap) chokes on tasks that need larger writes/edits, and Krutrim struggles with longer, multi-step tasks. Until now there was **no objective way to measure** how a given model + config performs in code mode.

v0.3.48 adds a built-in, **TDD-style, deterministically-scored benchmark suite**. It drives `CodeAgent` through a sequence of coding tasks of increasing complexity in isolated throwaway workspaces, scoring each task with Node's built-in test runner (`node --test`) — no LLM judge, no network, no external test framework. The result is a per-task pass/fail plus diagnostic metrics (iterations, tokens, wall-time, and whether the iteration cap was hit) that surface exactly where a model breaks down.

The suite is invokable from both the **CLI** (`jiva benchmark`) and the **HTTP API** (`/api/benchmark/*`).

---

## The task suite

A single evolving Node library (`taskstore`) is the substrate. Each tier's workspace is scaffolded from the *canonical* solution of all prior tiers plus a new failing test, so the tiers genuinely build on one another while each is measured in isolation. The suite mixes building from scratch with improving/fixing existing code:

| Tier | Task | Capability exercised | Kind |
|------|------|----------------------|------|
| 1 | Create `createTask` | Write a new file | scratch |
| 2 | Add `addTask` / `removeTask` / `listTasks` | Read & extend a file | extend |
| 3 | Fix the `toggleTask` bug | Diagnose & fix a targeted bug | bugfix |
| 4 | Add task priorities | Multi-function feature | extend |
| 5 | Split into `model` / `query` modules | Multi-file refactor without regressions | refactor |
| 6 | Implement `sortTasks` with edge cases | Algorithmic reasoning (nulls, stability) | extend |
| 7 | Add JSON `serialize` / `deserialize` | New module + serialization | extend |
| 8 | Debug the id-collision integration bug | Long-horizon cross-module debugging | bugfix |

Later tiers (5/7/8) require larger outputs and more iterations — the regime where short-output and rate-limited models fail. Scoring is cumulative: tier N's workspace runs tests `1..N`, so a refactor that breaks an earlier tier is caught.

**Anti-gaming:** every test file is byte-hashed before the agent runs. If the agent edits a test to make it "pass", the task fails with reason `tests-modified`.

---

## CLI: `jiva benchmark`

```bash
# Run tiers 1–3 against the configured model
jiva benchmark --max-tier 3

# Run the whole suite and write a JSON report
jiva benchmark --output report.json

# Run specific tasks, machine-readable output
jiva benchmark --tasks t05-refactor-split,t08-debug-id-collision --json

# Carry the agent's own output forward between tiers (cascading, like a real session)
jiva benchmark --continuous
```

Options: `--config`, `--max-tier`, `--tasks`, `--max-iterations`, `--timeout`, `--lsp`, `--continuous`, `--output`, `--json`, `--keep-workspaces`. The process exits non-zero when any task fails, so it drops straight into CI.

The CLI prints a per-task table (status, iterations, tests passed, tokens, time), a summary line with the **highest tier passed** (a single capability-ceiling number), and the diagnostic notes for any failures.

---

## HTTP API

Registered under the existing `/api` auth middleware:

| Route | Purpose |
|-------|---------|
| `GET /api/benchmark/tasks` | List available tasks (metadata only) |
| `POST /api/benchmark/run` | Run the suite, return the full `SuiteResult` JSON |
| `POST /api/benchmark/run/stream` | Run the suite, stream per-task progress via SSE (`task-start`, `task-done`, `done`, `error`) |

Request body: `{ maxTier?, tasks?, maxIterations?, timeoutMs?, lsp?, continuous? }`. The orchestrator is built once from the stored config and cached across requests.

---

## Architecture

```
src/code/benchmark/
  types.ts                — BenchmarkTask, TaskResult, SuiteResult, RunnerOptions
  fixtures.ts             — canonical taskstore source (golden state per tier)
  tests.ts                — cumulative node:test files (the protected tests)
  tasks.ts                — the 8 ordered tiers + selection helpers
  verify.ts               — runNodeTests(): tamper check + `node --test` (scoped to the protected tests) + parse
  agent-factory.ts        — minimal CodeAgent per task (no MCP/persona/persistence)
  orchestrator-factory.ts — shared ModelOrchestrator builder (CLI + HTTP)
  runner.ts               — scaffolds workspaces, drives the agent, collects metrics
  report.ts               — CLI table + JSON serializer
  index.ts                — public entry point
```

Both interfaces converge on `runBenchmark(orchestrator, tasks, options, progress)`. The runner creates an isolated `mkdtemp` workspace per task (the user's repo is never touched), races `agent.chat()` against a wall-clock timeout, runs the verifier, then tears everything down.

A self-test (`scripts/bench-selftest.mjs`, run after `npm run build`) validates the fixtures and verifier without any model: for every tier it asserts the golden solution passes, the scaffold fails, and tampering is detected (24 checks).

---

## Benchmark suites (taskstore + micro-CRM)

The benchmark is now organised into **suites** with two scoring modes, laying the
groundwork for a tiered strategy (baseline → capability → frontier):

- **`taskstore` (baseline, gating).** The original 8-tier TDD suite. Binary pass/fail,
  tasks build on one another. Answers "does this model + config do code mode at all?"
- **`microcrm` (capability, scored).** A **building** suite that builds a CRM REST API
  using **only Node built-ins** — `node:http` + `node:sqlite` — graded by the **fraction of
  spec tests passed** (51 tests across 5 tasks). Tier 1 builds the base API from scratch
  (a genuine large-output test). Tiers 2-5 scaffold the working base and add one harder
  feature each: **atomic bulk insert** (transaction rollback), **advanced querying**
  (combined filters + sorting + `hasMore` pagination), **weighted pipeline analytics**, and
  **idempotency-key** dedup on create. Zero external dependencies, fully deterministic, real
  HTTP + real SQLite. The report shows the pass-rate and lists the exact spec tests missed.
  Requires Node ≥ 22.5.

**Output-length flag.** `CodeAgent` now counts output-token truncations per turn
(`AgentResponse.truncationEvents`), and the benchmark flags a failed task as
`[output-limited]` when it failed *after* hitting the model's output cap — distinguishing a
model that **can't emit a large enough response** (e.g. a hard 4096-token cap) from one that
got the **logic** wrong.

New scoring mode: `scored` suites report `Score: N/M tests (P%)` instead of all-or-nothing,
and the runner aggregates per-suite test totals. Verifier now also captures failing test
names. Run `jiva benchmark --list` to see all suites/tasks; `--suite <id>` to pick one.

HTTP gains `GET /api/benchmark/suites` and a `suite` field on the run routes.

## Code-mode compatibility fixes (surfaced by the benchmark)

The first benchmark runs immediately exposed two code-mode issues that hurt every model and broke weaker ones (Sarvam-105b, Krutrim) outright. Both are fixed in this release:

1. **`write_file` / `edit_file` now accept `path` as an alias for `file_path`.** Models frequently emit the common `path` argument; provider-side tool-call validation (Groq/Sarvam) then rejected the call with a 400 (`missing properties: 'file_path'`) *before* it reached the tool, wasting iterations and tokens. The schema now hard-requires only `content` (write) / `old_string`+`new_string` (edit), accepts either `path` or `file_path`, and `execute()` validates the path itself. `repairFailedToolCall` also normalizes `path`→`file_path` as a fallback.

2. **Schema/argument errors are no longer misdiagnosed as output-token truncation.** Groq codes both truncated and schema-invalid tool calls as `tool_use_failed`. The handler previously treated any such error on a file tool as "content too large" and told the model to "write in stages" — the wrong remedy. It now inspects `failed_generation`: a complete, parseable payload is treated as a schema error (with a targeted, tool-specific parameter correction), and only a genuinely cut-off payload routes to the write-in-stages path.

3. **Sarvam-105b output budget corrected to 4096.** The setup-wizard preset requested 8192 completion tokens, but Sarvam's API caps output at 4096 (requesting more is rejected). The preset now uses 4096.

4. **Graceful "continue?" prompt at the step limit.** When code mode hits its iteration limit before finishing, the agent now reports a `stopReason: 'max-iterations'`, and the interactive CLI offers the user a choice — **Continue working…** (resumes with full history) or **Stop for now** — instead of silently emitting `[Max iterations reached without a final response]`. (HTTP behaviour is unchanged.)

## Files Changed

| File | Change |
|------|--------|
| `src/code/benchmark/*` | **New** — the benchmark module (suites, runner, verifier, report) |
| `src/code/benchmark/suites.ts` | **New** — suite registry (taskstore + microcrm) |
| `src/code/benchmark/microcrm/*` | **New** — micro-CRM scored suite + `node:http`/`node:sqlite` test & reference assets |
| `scripts/copy-benchmark-assets.mjs` | **New** — copies benchmark `.mjs` assets into dist on build |
| `src/code/tools/write.ts` | Accept `path` alias; relax schema `required` to `content` |
| `src/code/tools/edit.ts` | Accept `path` alias; relax schema `required` to `old_string`/`new_string` |
| `src/code/agent.ts` | Distinguish truncation vs schema errors; targeted schema-arg correction; `path`→`file_path` repair; `truncationEvents` + `stopReason` on the response |
| `src/interfaces/cli/setup-wizard.ts` | Sarvam `defaultMaxTokens` 8192 → 4096 |
| `src/interfaces/cli/repl.ts` | Offer Continue/Stop when code mode hits its step limit |
| `src/core/agent-interface.ts` | `stopReason` on `AgentChatResponse` |
| `src/interfaces/cli/index.ts` | **New** `benchmark` command |
| `src/interfaces/http/routes/benchmark.ts` | **New** — benchmark HTTP routes |
| `src/interfaces/http/index.ts` | Register `setupBenchmarkRoutes` |
| `scripts/bench-selftest.mjs` | **New** — fixture/verifier self-test |
| `docs/guides/benchmark-suite.md` | **New** — usage & extension guide |
| `package.json` | Version `0.3.47` → `0.3.48` |

---

## Upgrade

```bash
npm install -g jiva-core@0.3.48
```

No config changes required. The benchmark reuses the model stack from your existing configuration.
