### PR TITLE
v0.3.50

### DIFF
--- a/docs/release_notes/v0.3.49.md
+++ b/docs/release_notes/v0.3.49.md
@@ -1,0 +1,122 @@
+# Jiva v0.3.49 — Bug Fix Release
+
+**Release Date:** July 6, 2026
+
+---
+
+## Summary
+
+Three bug fixes: a request-formatting crash on strict providers, a CodeAgent
+deadlock that made it give up well before `maxIterations` was reached, and
+support for reasoning/tool-calling models with native vision.
+
+---
+
+## Bug Fixes
+
+### 1. Manager double system-message crashes strict providers
+
+**Symptom:** `400 System message must be at the beginning` on providers that
+reject anything but a single leading system message (e.g. Krutrim's
+Qwen3.6), whenever a directive was configured.
+
+**Root cause:** `ManagerAgent.getSystemMessages()` (`src/core/manager-agent.ts`)
+appended the directive as a second `developer`-role message, which becomes a
+second `system` message after role conversion. Krutrim's `gpt-oss-120b`
+happened to tolerate two system messages; Qwen3.6 didn't.
+
+**Fix:** The directive is now merged into the single system message instead
+of appended separately. Safe for all providers — Manager never sends `tools`,
+so Harmony's developer-role tool-injection path never depended on the
+directive being a separate message.
+
+---
+
+### 2. CodeAgent gives up after 4 empty responses despite ample `maxIterations`
+
+**Symptom:** Code mode would stop with `[No response content]` after just
+~10 iterations even with `maxIterations` set to 100, following a run of
+`Empty response with no tool calls` warnings. Manually retrying the same
+request usually succeeded.
+
+**Root cause:** In-loop context compaction was gated on the response having
+tool calls. Once the model starts returning genuinely empty responses (no
+content, no tool calls), that gate can never be true again — so context can
+never shrink back down, and the same bloated prompt gets resent on every
+recovery-nudge retry, guaranteeing the same failure each time. The
+empty-response retry cap (4), not the iteration budget, was the real limiter.
+
+**Fix:**
+- Removed the tool-calls requirement from the in-loop compaction trigger
+  (`src/code/agent.ts`) — compaction now runs whenever prompt tokens exceed
+  the threshold, regardless of whether the last response had tool calls.
+- Added `finishReason` to `ModelResponse` (`src/models/base.ts`,
+  `src/models/model-client.ts`), captured from the API's own
+  `choices[0].finish_reason` (previously discarded). When an empty response
+  has `finishReason: 'length'`, that's direct evidence the model ran out of
+  completion-token budget mid-"thought" — CodeAgent now forces an immediate
+  compaction in that case (bypassing the normal token threshold) instead of
+  just adding another text nudge, which was only adding more prompt weight
+  and making the same budget problem worse on the next attempt.
+
+---
+
+## New Features
+
+### Vision-capable reasoning/tool-calling models
+
+Some providers (e.g. Groq's `llama-4-maverick`, some Krutrim models) offer a
+single model that handles both reasoning and vision, making a dedicated
+`multimodal` model configuration and its image-captioning detour unnecessary.
+
+A new `hasVision` flag on `ModelConfigSchema` / `ModelClientConfig` lets any
+model instance declare native vision support, regardless of its `type`:
+
+```json
+{
+  "models": {
+    "reasoning": {
+      "endpoint": "...",
+      "apiKey": "...",
+      "model": "llama-4-maverick",
+      "hasVision": true
+    }
+  }
+}
+```
+
+When set, `ModelOrchestrator` routes image content directly to that model
+instead of running it through the caption-then-forward pipeline. Priority
+when a request contains images: dedicated `multimodal` model (unchanged
+legacy behavior) → reasoning model with `hasVision` → tool-calling model
+with `hasVision` → legacy passthrough. Existing setups with a configured
+`multimodal` model are unaffected.
+
+DualAgent and CodeAgent needed no changes — both delegate all model calls
+through `ModelOrchestrator.chat()`/`chatWithFallback()`, which is the single
+place vision routing decisions are made.
+
+---
+
+## Files Changed
+
+| File | Change |
+|------|--------|
+| `src/core/manager-agent.ts` | Merge directive into single system message instead of appending a second one |
+| `src/code/agent.ts` | Compaction no longer gated on tool calls; forced compaction on `finishReason: 'length'` |
+| `src/models/base.ts` | Added `finishReason` and `hasVision`-supporting fields to `ModelResponse`/config types |
+| `src/models/model-client.ts` | Capture `finish_reason` from API response; `supportsVision()` honors `hasVision` |
+| `src/models/orchestrator.ts` | Image routing accounts for `hasVision` on reasoning/tool-calling models |
+| `src/core/config.ts` | `hasVision` field on `ModelConfigSchema` |
+| `src/interfaces/cli/index.ts` | Pass `hasVision` through when constructing model clients |
+| `src/interfaces/http/session-manager.ts` | Pass `hasVision` through for the reasoning model |
+
+---
+
+## Upgrade
+
+```bash
+npm install -g jiva-core@0.3.49
+```
+
+No breaking changes. All existing configs continue to work without modification.

--- a/docs/release_notes/v0.3.50.md
+++ b/docs/release_notes/v0.3.50.md
@@ -1,0 +1,114 @@
+# Jiva v0.3.50 — Sarvam First-Class Support, Code-Mode Task Metadata
+
+**Release Date:** July 6, 2026
+
+---
+
+## Summary
+
+Model-agnostic rate limiting and low-output-budget handling (motivated by
+Sarvam-105B's 40 req/min and 4096-token limits, but applicable to any
+similarly-constrained provider), a real bug fix where the CLI silently
+dropped `defaultMaxTokens`/`reasoningEffortStrategy` config, and richer
+metadata recorded on code-mode conversations.
+
+---
+
+## New Features
+
+### Model-agnostic proactive rate limiting
+
+`ModelClientConfig.maxRequestsPerMinute` — when set, `ModelClient` tracks its
+own request timestamps in a trailing 60s window and waits **before** sending
+a request that would exceed the limit, instead of only reacting to 429s
+after they happen. Set for any provider with a known hard rate ceiling; the
+Sarvam preset in the setup wizard now sets this to 40 automatically.
+
+429 handling also now checks the standard `Retry-After` HTTP header (RFC
+6585) first, falling back to parsing provider-specific wording out of the
+error body (Groq's "Please try again in 8.53s.") only when the header is
+absent.
+
+### Skeleton-first workflow for low-output-budget models
+
+When the reasoning model's `defaultMaxTokens` is ≤ 8192, code mode's system
+prompt now **mandates** (not just recommends for large files) scaffolding
+every new file as `### section-<name>` / `### endsection` blocks and filling
+them in one at a time — the model is told its exact token budget explicitly.
+
+`edit_file` gained a `use_regex` mode to make this reliable: `old_string` is
+compiled as a regex and matched against the file, so a whole section can be
+replaced by matching its markers without needing to reproduce the section's
+current (stub) content exactly.
+
+### Code-mode conversation metadata
+
+`ConversationMetadata` (unified into `storage/types.ts` — previously
+duplicated with a second, drifting copy in `conversation-manager.ts`) gains:
+
+```typescript
+{
+  mcpServers?: string[]   // MCP servers enabled for this code task
+  maxIterations?: number  // iteration budget configured for this task
+  harness?: string        // e.g. jiva-core's 'evaluator', or a UI feature
+                          // like Jivam's 'deep-run' — free-form, not a fixed enum
+}
+```
+
+`saveConversation()`/`autoSave()` take an optional `codeMeta` parameter;
+`CodeAgent` passes its own `mcpServerNames`/`maxIterations`/`harness`, and
+previously-saved values persist across subsequent auto-saves that don't
+repeat them. The workspace directory a code task ran in was already captured
+via the existing `workspace` field.
+
+---
+
+## Bug Fixes
+
+### CLI silently dropped `defaultMaxTokens` and `reasoningEffortStrategy`
+
+**Symptom:** A reasoning model configured with `defaultMaxTokens: 4096`
+(required for Sarvam-105B) had no effect when used via `jiva chat` — the
+request went out with no `max_tokens` cap at all, letting Sarvam apply its
+own internal default and risking the model exhausting its completion budget
+on its reasoning chain before producing visible output (the same failure
+shape as the empty-response bug fixed in v0.3.49, via a different path).
+
+**Root cause:** All four `createModelClient()` call sites in
+`src/interfaces/cli/index.ts` (reasoning ×2, tool-calling ×2) never passed
+`defaultMaxTokens` or `reasoningEffortStrategy` from the loaded config,
+despite both being present in the config schema and set by the setup
+wizard.
+
+**Fix:** Both fields now passed through at all four sites, along with the
+new `maxRequestsPerMinute`.
+
+---
+
+## Files Changed
+
+| File | Change |
+|------|--------|
+| `src/utils/errors.ts` | `ModelError.retryAfterMs` |
+| `src/models/model-client.ts` | Proactive rate limiter; `Retry-After` header parsing; `getDefaultMaxTokens()` |
+| `src/core/config.ts` | `maxRequestsPerMinute` field on `ModelConfigSchema` |
+| `src/interfaces/cli/setup-wizard.ts` | Sarvam preset sets `maxRequestsPerMinute: 40` |
+| `src/interfaces/cli/index.ts` | Fixed missing `defaultMaxTokens`/`reasoningEffortStrategy` passthrough (×4 sites); `harness` wiring for `--harness evaluator` |
+| `src/interfaces/http/session-manager.ts` | `maxRequestsPerMinute` passthrough |
+| `src/code/agent.ts` | Low-output-budget skeleton-first system prompt; `harness` config field; `codeMeta` on save calls |
+| `src/code/tools/edit.ts` | `use_regex` mode for `edit_file` |
+| `src/core/conversation-manager.ts` | `ConversationMetadata`/`CodeConversationMeta` now re-exported from `storage/types.ts` instead of duplicated |
+| `src/storage/types.ts` | Canonical `ConversationMetadata` gains `mcpServers`/`maxIterations`/`harness`; new `CodeConversationMeta` |
+
+---
+
+## Upgrade
+
+```bash
+npm install -g jiva-core@0.3.50
+```
+
+No breaking changes. All existing configs continue to work without
+modification. If you're on Sarvam and haven't re-run `jiva config` since
+before this release, doing so will pick up the new `maxRequestsPerMinute`
+default.

--- a/docs/release_notes/v0.3.50.md
+++ b/docs/release_notes/v0.3.50.md
@@ -85,6 +85,55 @@ new `maxRequestsPerMinute`.
 
 ---
 
+### Conversation titles always fell back to the first-message snippet
+
+**Symptom:** Conversation titles were never the LLM-generated 3–5 word
+summary they were supposed to be. Saved conversations in
+`~/.jiva/conversations/` showed one of two wrong shapes:
+- The fallback snippet — the first ~40 chars of the first user message
+  plus `...` (e.g. `make a beautiful looking game of tetris...`), or
+- Raw model "thinking" leaked into the title — e.g.
+  `\nOkay, the user wants a short title for their mess...`.
+
+**Root cause:** `ConversationManager.generateTitle()` (in
+`src/core/conversation-manager.ts`) asked the orchestrator for a title with
+`maxTokens: 20`. The orchestrator routes tool/image-less calls to the
+**reasoning** model, which (for models like `zai-org/GLM-5.2`) emits an
+inline `…</think>` chain *before* the answer. 20 tokens is barely
+enough for the thinking alone, so the model routinely exhausted its budget
+mid-thought — the response came back as `\nOkay, the user wants a
+short title for their mess…` with **no closing `</think>` and no actual
+title**.
+
+The cleanup pipeline then failed in two ways:
+1. `extractAssistantMessage()` (in `src/models/harmony.ts`) strips Harmony
+   control tokens (`<|call|>`, `<|channel|>`, …) but **not** ``
+   blocks, so the thinking text survived into `response.content`.
+2. `generateTitle()`'s own cleanup (trim, de-quote, de-punctuate, truncate
+   to 60 chars) didn't remove the thinking either, and its garbage guard
+   (`!title || length < 3 || includes('untitled')`) didn't catch 60-char
+   leaked thinking — so it was returned verbatim. When the API returned
+   the thinking out-of-band (in `reasoning_content`, leaving `content`
+   empty), the guard *did* trip and the method fell back to the first
+   40 chars — producing the snippet-shaped titles.
+
+**Fix:**
+- Added `stripThinkingContent()`, which removes both properly-closed
+  `…</think>` blocks and truncated/unclosed `<think…` runs (the
+  model ran out of budget before the closing tag). It's applied to
+  `response.content` before any other cleanup.
+- After stripping, the last non-empty line is taken as the title (the
+  model sometimes emits preamble before the actual title).
+- Raised `maxTokens` from 20 → 200 so a reasoning model has room to
+  finish its thinking chain *and* emit the title.
+- Set `reasoningEffort: 'low'` on the title call to minimise thinking for
+  what is a trivial classification task.
+
+The existing first-message fallback is retained as the last resort when
+the model still returns nothing usable.
+
+---
+
 ## Files Changed
 
 | File | Change |
@@ -97,7 +146,7 @@ new `maxRequestsPerMinute`.
 | `src/interfaces/http/session-manager.ts` | `maxRequestsPerMinute` passthrough |
 | `src/code/agent.ts` | Low-output-budget skeleton-first system prompt; `harness` config field; `codeMeta` on save calls |
 | `src/code/tools/edit.ts` | `use_regex` mode for `edit_file` |
-| `src/core/conversation-manager.ts` | `ConversationMetadata`/`CodeConversationMeta` now re-exported from `storage/types.ts` instead of duplicated |
+| `src/core/conversation-manager.ts` | `ConversationMetadata`/`CodeConversationMeta` now re-exported from `storage/types.ts` instead of duplicated; `generateTitle()` strips reasoning `` blocks, raises `maxTokens` 20→200, sets `reasoningEffort: 'low'`; new `stripThinkingContent()` helper |
 | `src/storage/types.ts` | Canonical `ConversationMetadata` gains `mcpServers`/`maxIterations`/`harness`; new `CodeConversationMeta` |
 
 ---

--- a/docs/release_notes/v0.3.50.md
+++ b/docs/release_notes/v0.3.50.md
@@ -1,6 +1,6 @@
-# Jiva v0.3.50 — Sarvam First-Class Support, Code-Mode Task Metadata
+# Jiva v0.3.50 — Unified Config, Vision Detection & Code-Mode Improvements
 
-**Release Date:** July 6, 2026
+**Release Date:** July 14, 2026
 
 ---
 
@@ -9,8 +9,9 @@
 Model-agnostic rate limiting and low-output-budget handling (motivated by
 Sarvam-105B's 40 req/min and 4096-token limits, but applicable to any
 similarly-constrained provider), a real bug fix where the CLI silently
-dropped `defaultMaxTokens`/`reasoningEffortStrategy` config, and richer
-metadata recorded on code-mode conversations.
+dropped `defaultMaxTokens`/`reasoningEffortStrategy` config, richer metadata
+recorded on code-mode conversations, unified config storage across CLI and
+HTTP interfaces, and auto-detection of vision-capable models during setup.
 
 ---
 
@@ -61,9 +62,122 @@ previously-saved values persist across subsequent auto-saves that don't
 repeat them. The workspace directory a code task ran in was already captured
 via the existing `workspace` field.
 
+### Unified config storage across all interfaces
+
+Jiva's CLI config previously lived at a platform-specific location via the
+`conf` package's default resolution (`~/Library/Preferences/jiva-nodejs` on
+macOS, `%APPDATA%/jiva-nodejs/Config` on Windows, `~/.config/jiva-nodejs` on
+Linux) — a different file entirely from what the local (non-cloud) HTTP
+interface's `LocalStorageProvider` already used for config
+(`~/.jiva/config.json`, alongside conversations and logs that already lived
+there). This meant CLI and local-HTTP-mode configuration were silently out of
+sync with each other.
+
+`ConfigManager` now pins `conf`'s storage to `~/.jiva` via the `cwd` option,
+so both interfaces read/write the exact same file.
+
+`migrateLegacyConfigIfNeeded()` runs once, the first time `ConfigManager` is
+constructed (both interfaces trigger this on startup): if `~/.jiva/config.json`
+doesn't exist yet but a legacy platform-specific config does, it's copied over.
+If something unexpectedly already exists at the new path by the time of the
+write (a race, or a stray file), it's backed up to `config-backup.json` first
+rather than clobbered. Once `~/.jiva/config.json` exists, it's treated as
+authoritative and migration is skipped on all subsequent runs. The CLI prints
+the migration result on the next `jiva` invocation; the HTTP interface logs it
+via `logger.warn` on startup.
+
+### Auto-detect vision capability during setup
+
+v0.3.49 added `hasVision` support for reasoning/tool-calling models, but the
+CLI setup wizard never asked for it — the flag could only be set by hand-
+editing `config.json`.
+
+`src/utils/vision-detection.ts` matches a model name against known vision-
+capable model families (Llama 4 Maverick/Scout, Qwen, Kimi, GLM, Claude,
+GPT-4+/GPT-5/o-series, Gemini, Pixtral, Grok, Phi multimodal) and returns a
+short reason when matched. This only drives the **default** answer to a y/n
+prompt — never authoritative, always overridable.
+
+`setup-wizard.ts` now asks "Does this model support vision (image input)?"
+right after the model name is entered, for both the reasoning and tool-calling
+model setup flows, defaulting to the detection result and showing the matched
+reason (e.g. "Llama 4 Maverick supports vision"). A `Vision: Yes/No` line is
+also shown in `jiva config --show`.
+
+### Vision-capable reasoning/tool-calling models (no separate multimodal model needed)
+
+Some providers (e.g. Groq's `llama-4-maverick`, Krutrim's vision-enabled
+models) offer a single model that handles both reasoning and vision, making
+the separate dedicated `multimodal` model configuration and its image-captioning
+detour unnecessary and wasteful for those setups.
+
+A new `hasVision` config flag (`ModelConfigSchema` + `ModelClientConfig`) lets
+any model instance declare native vision support regardless of its `type`. When
+set:
+
+- `ModelClient.supportsVision()` reports `true`
+- `ModelOrchestrator` routes image content directly to that model instead of
+  running it through the dedicated multimodal model's caption-then-forward
+  pipeline
+- `hasMultimodalSupport()` / `getMultimodalModel()` account for it too
+
+Priority order when a request contains images: dedicated multimodal model
+(unchanged legacy behavior) > reasoning model with `hasVision` > tool-calling
+model with `hasVision` > legacy passthrough. Existing setups with a configured
+`multimodal` model are unaffected.
+
+`DualAgent` and `CodeAgent` need no changes — both delegate all model calls
+through `ModelOrchestrator.chat()`/`chatWithFallback()`, so fixing routing at
+the orchestrator is sufficient for both to pick up native vision support.
+
 ---
 
 ## Bug Fixes
+
+### Manager double system-message crashes strict providers
+
+**Symptom:** `400 System message must be at the beginning` on providers that
+reject anything but a single leading system message (e.g. Krutrim's Qwen3.6),
+whenever a directive was configured.
+
+**Root cause:** `ManagerAgent.getSystemMessages()` (`src/core/manager-agent.ts`)
+appended the directive as a second `developer`-role message, which becomes a
+second `system` message after role conversion. Krutrim's `gpt-oss-120b`
+happened to tolerate two system messages; Qwen3.6 didn't.
+
+**Fix:** The directive is now merged into the single system message instead
+of appended separately. Safe for all providers — Manager never sends `tools`,
+so Harmony's developer-role tool-injection path never depended on the
+directive being a separate message.
+
+---
+
+### CodeAgent gives up after 4 empty responses despite ample `maxIterations`
+
+**Symptom:** Code mode would stop with `[No response content]` after just
+~10 iterations even with `maxIterations` set to 100, following a run of
+`Empty response with no tool calls` warnings. Manually retrying the same
+request usually succeeded.
+
+**Root cause:** In-loop context compaction was gated on the response having
+tool calls. Once the model starts returning genuinely empty responses (no
+content, no tool calls), that gate can never be true again — so context can
+never shrink back down, and the same bloated prompt gets resent on every
+recovery-nudge retry, guaranteeing the same failure each time. The
+empty-response retry cap (4), not the iteration budget, was the real limiter.
+
+**Fix:**
+- Removed the tool-calls requirement from the in-loop compaction trigger
+  (`src/code/agent.ts`) — compaction now runs whenever prompt tokens exceed
+  the threshold, regardless of whether the last response had tool calls.
+- Added `finishReason` to `ModelResponse` (`src/models/base.ts`,
+  `src/models/model-client.ts`), captured from the API's own
+  `choices[0].finish_reason` (previously discarded). When an empty response
+  has `finishReason: 'length'`, that's direct evidence the model ran out of
+  completion-token budget mid-"thought" — CodeAgent now forces an immediate
+  compaction in that case (bypassing the normal token threshold) instead of
+  just adding another text nudge, which was only adding more prompt weight
+  and making the same budget problem worse on the next attempt.
 
 ### CLI silently dropped `defaultMaxTokens` and `reasoningEffortStrategy`
 
@@ -139,13 +253,18 @@ the model still returns nothing usable.
 | File | Change |
 |------|--------|
 | `src/utils/errors.ts` | `ModelError.retryAfterMs` |
-| `src/models/model-client.ts` | Proactive rate limiter; `Retry-After` header parsing; `getDefaultMaxTokens()` |
-| `src/core/config.ts` | `maxRequestsPerMinute` field on `ModelConfigSchema` |
-| `src/interfaces/cli/setup-wizard.ts` | Sarvam preset sets `maxRequestsPerMinute: 40` |
-| `src/interfaces/cli/index.ts` | Fixed missing `defaultMaxTokens`/`reasoningEffortStrategy` passthrough (×4 sites); `harness` wiring for `--harness evaluator` |
+| `src/utils/vision-detection.ts` | **New** — `detectVisionCapability()` matches model names against known vision-capable families |
+| `src/models/model-client.ts` | Proactive rate limiter; `Retry-After` header parsing; `getDefaultMaxTokens()`; `supportsVision()` honors `hasVision` |
+| `src/models/base.ts` | Added `finishReason` to `ModelResponse` (captured from API's `choices[0].finish_reason`) |
+| `src/models/orchestrator.ts` | Image routing accounts for `hasVision` on reasoning/tool-calling models |
+| `src/core/config.ts` | `maxRequestsPerMinute` field on `ModelConfigSchema`; `migrateLegacyConfigIfNeeded()`; config storage unified to `~/.jiva` |
+| `src/interfaces/cli/setup-wizard.ts` | Sarvam preset sets `maxRequestsPerMinute: 40`; vision capability prompt after model name entry |
+| `src/interfaces/cli/index.ts` | Fixed missing `defaultMaxTokens`/`reasoningEffortStrategy` passthrough (×4 sites); `harness` wiring for `--harness evaluator`; vision prompt wiring |
+| `src/interfaces/http/index.ts` | Register config migration on startup; register benchmark routes |
 | `src/interfaces/http/session-manager.ts` | `maxRequestsPerMinute` passthrough |
 | `src/code/agent.ts` | Low-output-budget skeleton-first system prompt; `harness` config field; `codeMeta` on save calls |
 | `src/code/tools/edit.ts` | `use_regex` mode for `edit_file` |
+| `src/core/manager-agent.ts` | Merged directive into single system message instead of appending a second one |
 | `src/core/conversation-manager.ts` | `ConversationMetadata`/`CodeConversationMeta` now re-exported from `storage/types.ts` instead of duplicated; `generateTitle()` strips reasoning `` blocks, raises `maxTokens` 20→200, sets `reasoningEffort: 'low'`; new `stripThinkingContent()` helper |
 | `src/storage/types.ts` | Canonical `ConversationMetadata` gains `mcpServers`/`maxIterations`/`harness`; new `CodeConversationMeta` |
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "jiva-core",
-  "version": "0.3.48",
+  "version": "0.3.49",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "jiva-core",
-      "version": "0.3.48",
+      "version": "0.3.49",
       "license": "MIT",
       "dependencies": {
         "@google-cloud/storage": "^7.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "jiva-core",
-  "version": "0.3.49",
+  "version": "0.3.50",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "jiva-core",
-      "version": "0.3.49",
+      "version": "0.3.50",
       "license": "MIT",
       "dependencies": {
         "@google-cloud/storage": "^7.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jiva-core",
-  "version": "0.3.48",
+  "version": "0.3.49",
   "description": "Versatile autonomous AI agent with three-agent architecture (Manager, Worker, Client) powered by gpt-oss-120b. Adaptive validation, full MCP support, and intelligent quality control.",
   "main": "dist/index.js",
   "bin": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jiva-core",
-  "version": "0.3.49",
+  "version": "0.3.50",
   "description": "Versatile autonomous AI agent with three-agent architecture (Manager, Worker, Client) powered by gpt-oss-120b. Adaptive validation, full MCP support, and intelligent quality control.",
   "main": "dist/index.js",
   "bin": {

--- a/src/code/agent.ts
+++ b/src/code/agent.ts
@@ -807,15 +807,24 @@ ${directive ? `\n${directive}` : ''}`;
       // ── In-loop context compaction ──────────────────────────────────────────
       // Check if we're approaching the context window limit and compact if needed.
       // Triggered once per turn (compactedThisTurn flag) to avoid thrashing.
-      // Only runs when: threshold > 0, orchestrator available, not already compacted,
-      // and the response carried token usage data.
+      // Only runs when: threshold > 0, orchestrator available, not already compacted.
+      //
+      // Deliberately NOT gated on the response having tool calls: a model that's
+      // starved for completion-token budget by a bloated prompt (spending its
+      // whole budget "thinking" before it can emit a tool call, or even any
+      // visible text) is EXACTLY the scenario compaction needs to rescue —
+      // gating on tool calls here created a deadlock where a large context
+      // would push the model into empty responses, and because empty responses
+      // never carry tool calls, compaction could never fire to shrink the
+      // context back down. The model would then just keep re-hitting the same
+      // starved budget on every recovery-nudge retry and give up after
+      // MAX_EMPTY_RESPONSES, even with abundant maxIterations remaining.
       const promptTokens = response.usage?.promptTokens ?? 0;
       if (
         this.compactionThreshold > 0 &&
         promptTokens > this.compactionThreshold &&
         !compactedThisTurn &&
-        this.conversationManager &&
-        response.toolCalls && response.toolCalls.length > 0
+        this.conversationManager
       ) {
         logger.warn(
           `[CodeAgent] Context at ${promptTokens} tokens (threshold: ${this.compactionThreshold}) — compacting in-loop history`,
@@ -870,7 +879,34 @@ ${directive ? `\n${directive}` : ''}`;
         }
 
         if (!response.content && emptyResponseCount < MAX_EMPTY_RESPONSES) {
-          // Model returned empty content with no tool calls — it got stuck or confused.
+          // Model returned empty content with no tool calls.
+          //
+          // Two distinct causes look identical here but need different fixes:
+          //   1. finishReason === 'length' — the model hit its max_tokens ceiling
+          //      while still "thinking" and never got to emit a tool call or text.
+          //      This is a completion-token-budget problem, not confusion — nudging
+          //      with MORE instructions only adds prompt weight and makes the next
+          //      attempt hit the same wall (or worse). The real fix is to shrink the
+          //      context so more of the budget is left for actual output, so we force
+          //      an immediate compaction here regardless of the normal token threshold.
+          //   2. Anything else — the model is genuinely stuck/confused; a nudge is the
+          //      right tool.
+          const isLengthStarved = response.finishReason === 'length';
+          if (isLengthStarved && !compactedThisTurn && this.conversationManager) {
+            logger.warn(
+              '[CodeAgent] Empty response with finishReason=length — model ran out of completion budget ' +
+              'while thinking. Forcing context compaction instead of a text nudge.',
+            );
+            compactedThisTurn = true;
+            try {
+              const compacted = await this.compactInLoopMessages(messages, systemPrompt);
+              messages.splice(0, messages.length, ...compacted);
+              logger.info(`[CodeAgent] Forced compaction complete: ${messages.length} messages after compaction`);
+            } catch (compactErr) {
+              logger.error('[CodeAgent] Forced compaction failed, falling back to a recovery nudge', compactErr);
+            }
+          }
+
           // Inject an escalating recovery nudge and let it try again.
           emptyResponseCount++;
           logger.warn(
@@ -879,7 +915,14 @@ ${directive ? `\n${directive}` : ''}`;
 
           // Escalate urgency with each retry so the model doesn't keep ignoring it
           let nudgeContent: string;
-          if (emptyResponseCount <= 2) {
+          if (isLengthStarved) {
+            nudgeContent =
+              'Your last response ran out of space before producing any output — the context has now been ' +
+              'compacted to free up room. Continue the task with a SHORT, direct next step:\n' +
+              '- If you need to CREATE a file → call write_file now.\n' +
+              '- If you need to EDIT a file → call edit_file directly (skip re-reading files you already read).\n' +
+              '- If the task is already complete → provide a brief one-paragraph summary.';
+          } else if (emptyResponseCount <= 2) {
             nudgeContent =
               'Your last response was empty. Please continue working on the task.\n\n' +
               '- If you need to CREATE a file → call write_file now.\n' +

--- a/src/code/agent.ts
+++ b/src/code/agent.ts
@@ -129,6 +129,13 @@ export interface CodeAgentConfig {
    * Sourced from servers with `codeMode: true` in config and/or the --mcp CLI flag.
    */
   mcpServerNames?: string[];
+  /**
+   * Free-form harness/mode label recorded on saved conversations — e.g.
+   * jiva-core's own 'evaluator' harness (see --harness evaluator), or a
+   * UI-level feature like Jivam's 'deep-run'. Purely descriptive metadata;
+   * does not change CodeAgent's own behavior.
+   */
+  harness?: string;
 }
 
 const DEFAULT_MAX_ITERATIONS = 50;
@@ -139,8 +146,66 @@ const CODE_MODE_INDICATOR = '[CODE MODE]';
 // Default token threshold for in-loop compaction (90K leaves ~38K headroom in a 128K model)
 const DEFAULT_COMPACTION_THRESHOLD = 90_000;
 
+/**
+ * Below this output-token budget, the skeleton-first workflow becomes
+ * mandatory for EVERY new file (not just files over ~80 lines) — a low
+ * budget means even a moderately-sized file's content can get cut off
+ * mid-generation. Sarvam-105B (capped at 4096 by the provider) is the
+ * motivating case, but this applies to any model configured with a
+ * similarly small defaultMaxTokens.
+ */
+const LOW_OUTPUT_BUDGET_THRESHOLD = 8192;
+
 /** System prompt for code mode — focused on precision and persistence (ported from opencode beast.txt) */
-const _getSystemPromptBase = (workspaceDir: string, directive?: string, skillsBlock?: string, mcpToolNames?: string[]): string => {
+const _getSystemPromptBase = (
+  workspaceDir: string,
+  directive?: string,
+  skillsBlock?: string,
+  mcpToolNames?: string[],
+  outputTokenBudget?: number,
+): string => {
+  const isLowOutputBudget = !!outputTokenBudget && outputTokenBudget <= LOW_OUTPUT_BUDGET_THRESHOLD;
+
+  const largeFileGuidance = isLowOutputBudget
+    ? `8. OUTPUT BUDGET IS LIMITED — you can only write approximately ${outputTokenBudget} tokens per response.
+   This makes the skeleton-first approach MANDATORY for every new file, not just large ones —
+   even a moderately-sized file can get cut off mid-generation and silently corrupted at this budget.
+   MANDATORY WORKFLOW for creating any new file:
+   - Stage 1 — write_file: create the file as a SKELETON of marked sections, each wrapped like this:
+       ### section-<name>
+       <stub content — e.g. a single TODO comment, or empty body>
+       ### endsection
+     Use one section per logical unit (one function, one class, one config block). Keep each
+     section's stub to 1-3 lines. The whole skeleton for a typical file should fit comfortably
+     under your output budget.
+   - Stage 2+ — edit_file with use_regex: true: fill in ONE section per call, matching
+       old_string: "### section-<name>[\\s\\S]*?### endsection"
+     and passing the complete implementation (still wrapped in the same markers) as new_string.
+     This replaces the whole section in one shot without needing to reproduce its current
+     (stub) content exactly — far more reliable than exact-string matching when your own
+     stub output might not come back byte-for-byte identical.
+   - Never attempt to write more than one section's worth of real implementation in a single
+     tool call. If a section itself would exceed your output budget, split it into
+     ### section-<name>-part1 / ### section-<name>-part2 etc. and fill each separately.
+   EDITING an existing file — same idea: prefer edit_file with use_regex: true against a
+   ### section marker when the file already uses them; otherwise keep each edit_file call's
+   new_string small enough to comfortably fit your output budget.`
+    : `8. LARGE FILES — ALWAYS WORK IN SMALL CHUNKS (applies to ALL file types: TS, Python, HTML, CSS, JSON…):
+   "Large" means any file or edit whose total new content exceeds ~80 lines.
+   BEFORE writing or editing: mentally estimate the line count. If > 80 lines, apply the rules below.
+   EDITING large files:
+   - Break every edit into chunks of 50–80 lines maximum.
+   - Never pass a new_string longer than ~80 lines to edit_file.
+   - Split large edits into multiple sequential edit_file calls, one section at a time.
+   CREATING new large files (skeleton-first approach — mandatory for any file > 80 lines):
+   - Stage 1: write_file with a skeleton/scaffold only — class/function stubs, empty bodies,
+     placeholder comments like "// TODO: implement X". Keep the skeleton under 60 lines.
+   - Stage 2+: edit_file to replace each placeholder/stub with the real implementation,
+     50–80 lines per call. Never implement more than one function or section per call.
+     Consider wrapping stubs in ### section-<name> / ### endsection markers and using
+     edit_file's use_regex: true mode to replace a whole section reliably.
+   - Reason: model output longer than ~100 lines gets truncated mid-JSON, silently corrupting the file.`;
+
   const base = `You are a precise, highly capable coding assistant operating in code mode.
 You have direct access to code tools — use them to explore, understand, and modify code.
 
@@ -160,7 +225,7 @@ PERSISTENCE AND COMPLETION:
 
 TOOLS AVAILABLE:
 - read_file: Read an existing file or list a directory. Only needed before editing an existing file.
-- edit_file: Replace a specific string in an existing file (old_string → new_string). For partial changes.
+- edit_file: Replace a specific string (or regex pattern, with use_regex: true) in an existing file. For partial changes.
 - write_file: Create a new file or fully overwrite an existing one. Use this to create files from scratch.
 - glob: Find files matching a pattern (e.g. "**/*.ts"). Only when you need to locate existing files.
 - grep: Search existing file contents with regex. Only when you need to find something in existing code.
@@ -175,19 +240,7 @@ CODING PRINCIPLES — READ CAREFULLY:
 5. After editing, check LSP errors in the tool result and fix them.
 6. Verify your changes work by running tests or the build when appropriate.
 7. Use bash only for shell commands (tests, builds, git) — NOT for reading files.
-8. LARGE FILES — ALWAYS WORK IN SMALL CHUNKS (applies to ALL file types: TS, Python, HTML, CSS, JSON…):
-   "Large" means any file or edit whose total new content exceeds ~80 lines.
-   BEFORE writing or editing: mentally estimate the line count. If > 80 lines, apply the rules below.
-   EDITING large files:
-   - Break every edit into chunks of 50–80 lines maximum.
-   - Never pass a new_string longer than ~80 lines to edit_file.
-   - Split large edits into multiple sequential edit_file calls, one section at a time.
-   CREATING new large files (skeleton-first approach — mandatory for any file > 80 lines):
-   - Stage 1: write_file with a skeleton/scaffold only — class/function stubs, empty bodies,
-     placeholder comments like "// TODO: implement X". Keep the skeleton under 60 lines.
-   - Stage 2+: edit_file to replace each placeholder/stub with the real implementation,
-     50–80 lines per call. Never implement more than one function or section per call.
-   - Reason: model output longer than ~100 lines gets truncated mid-JSON, silently corrupting the file.
+${largeFileGuidance}
 
 TOOL SELECTION RULES (follow exactly):
 - To CREATE a new file → write_file immediately (no reads needed first)
@@ -269,6 +322,7 @@ export class CodeAgent {
   private tools: ICodeTool[];
   private _mcpManager?: MCPServerManager;
   private _mcpServerNames: string[] = [];
+  private _harness?: string;
   private _stopped = false;
 
   constructor(config: CodeAgentConfig) {
@@ -288,6 +342,7 @@ export class CodeAgent {
 
     this._mcpManager = config.mcpManager;
     this._mcpServerNames = config.mcpServerNames ?? [];
+    this._harness = config.harness;
 
     this.tools = [
       ReadFileTool,
@@ -434,7 +489,8 @@ ${directive ? `\n${directive}` : ''}`;
     const mcpToolNames = this._mcpManager
       ? this.tools.filter((t) => t.name.includes('__')).map((t) => t.name)
       : undefined;
-    const systemPrompt = _getSystemPromptBase(this.workspace.getWorkspaceDir(), directive || undefined, skillsBlock, mcpToolNames);
+    const outputTokenBudget = this.orchestrator.getReasoningModel().getDefaultMaxTokens();
+    const systemPrompt = _getSystemPromptBase(this.workspace.getWorkspaceDir(), directive || undefined, skillsBlock, mcpToolNames, outputTokenBudget);
 
     // Build message history: system + history + new user message
     const messages: Message[] = [
@@ -1078,6 +1134,11 @@ ${directive ? `\n${directive}` : ''}`;
         this.orchestrator,
         'code',
         this.orchestrator.getTokenUsage(),
+        {
+          mcpServers: this._mcpServerNames,
+          maxIterations: this.maxIterations,
+          harness: this._harness,
+        },
       );
     }
 
@@ -1277,6 +1338,12 @@ Keep the summary concise but complete. Focus on what would help continue the wor
       undefined,
       this.orchestrator,
       'code',
+      undefined,
+      {
+        mcpServers: this._mcpServerNames,
+        maxIterations: this.maxIterations,
+        harness: this._harness,
+      },
     );
   }
 

--- a/src/code/tools/edit.ts
+++ b/src/code/tools/edit.ts
@@ -15,11 +15,11 @@ const MAX_DIAGNOSTICS = 20;
 
 export const EditFileTool: ICodeTool = {
   name: 'edit_file',
-  description: `Replace an exact string in a file with a new string.
+  description: `Replace an exact string (or, with use_regex, a regex pattern match) in a file with a new string.
 
 REQUIRED PARAMETERS — ALL THREE are mandatory, never omit any:
   • file_path  — absolute path to the file to edit
-  • old_string — the EXACT text to find (must match the file exactly)
+  • old_string — the EXACT text to find (must match the file exactly), or a regex pattern if use_regex is true
   • new_string — the REPLACEMENT text (what replaces old_string)
 
 IMPORTANT: You MUST provide BOTH old_string AND new_string in every call.
@@ -36,6 +36,17 @@ Rules:
 - Prefer small, targeted edits over rewriting large sections.
 - LSP errors (if any) are reported after the edit so you can fix them immediately.
 
+REGEX MODE (use_regex: true):
+- old_string is compiled as a JavaScript regex (dot matches newlines). new_string may
+  reference capture groups with $1, $2, etc.
+- Best used for replacing a whole marked SECTION without needing to reproduce its exact
+  current content — e.g. old_string: "### section-parser[\\s\\S]*?### endsection",
+  new_string containing the new section body wrapped in the same markers.
+  This is the recommended way to fill in a section of a skeleton file written earlier
+  in stages (see write_file's skeleton-first guidance for large files).
+- Fails the same way as normal mode if the pattern matches zero times, or more than
+  once when replace_all is false.
+
 Returns a diff of the changes made, plus any LSP errors detected.`,
 
   parameters: {
@@ -51,15 +62,19 @@ Returns a diff of the changes made, plus any LSP errors detected.`,
       },
       old_string: {
         type: 'string',
-        description: 'The exact text to replace (empty string to create a new file)',
+        description: 'The exact text to replace (empty string to create a new file), or a regex pattern when use_regex is true',
       },
       new_string: {
         type: 'string',
-        description: 'The replacement text',
+        description: 'The replacement text (may reference regex capture groups like $1 when use_regex is true)',
       },
       replace_all: {
         type: 'boolean',
         description: 'Replace all occurrences of old_string (default: false)',
+      },
+      use_regex: {
+        type: 'boolean',
+        description: 'Treat old_string as a regex pattern instead of an exact/fuzzy string match (default: false). Recommended for replacing a whole ### section-name ... ### endsection block.',
       },
     },
     // file_path is intentionally not in `required` so the `path` alias is accepted by
@@ -76,6 +91,7 @@ Returns a diff of the changes made, plus any LSP errors detected.`,
     const oldString = args.old_string as string;
     const newString = args.new_string as string;
     const replaceAll = (args.replace_all as boolean) ?? false;
+    const useRegex = (args.use_regex as boolean) ?? false;
 
     if (oldString === newString) {
       return 'Error: old_string and new_string are identical — no change made.';
@@ -110,7 +126,9 @@ Returns a diff of the changes made, plus any LSP errors detected.`,
 
         let result: string;
         try {
-          result = replace(contentBefore, normalizedOld, normalizedNew, replaceAll);
+          result = useRegex
+            ? regexReplace(contentBefore, oldString, newString, replaceAll)
+            : replace(contentBefore, normalizedOld, normalizedNew, replaceAll);
         } catch (e) {
           return `Error: ${e instanceof Error ? e.message : String(e)}`;
         }
@@ -427,6 +445,42 @@ export function replace(content: string, oldString: string, newString: string, r
     );
   }
   throw new Error('Found multiple matches for old_string. Provide more surrounding context to make it unique.');
+}
+
+/**
+ * Regex-based replacement — used when the model passes use_regex: true.
+ * Primarily intended for replacing a whole marked section (e.g.
+ * `### section-name\n...\n### endsection`) without needing to reproduce its
+ * exact current body, which matters most for models with a small output
+ * token budget filling in a skeleton file written in an earlier turn.
+ */
+function regexReplace(content: string, pattern: string, replacement: string, replaceAll = false): string {
+  let regex: RegExp;
+  try {
+    // 's' (dotAll) so '.' spans newlines — section bodies are multi-line.
+    regex = new RegExp(pattern, replaceAll ? 'gs' : 's');
+  } catch (e) {
+    throw new Error(`Invalid regex pattern: ${e instanceof Error ? e.message : String(e)}`);
+  }
+
+  if (replaceAll) {
+    const matchCount = (content.match(regex) ?? []).length;
+    if (matchCount === 0) {
+      throw new Error('Regex pattern did not match anything in the file.');
+    }
+    return content.replace(regex, replacement);
+  }
+
+  const matches = content.match(new RegExp(pattern, 'gs'));
+  if (!matches || matches.length === 0) {
+    throw new Error('Regex pattern did not match anything in the file.');
+  }
+  if (matches.length > 1) {
+    throw new Error(
+      `Regex pattern matched ${matches.length} times — make it more specific, or pass replace_all: true to replace every match.`,
+    );
+  }
+  return content.replace(regex, replacement);
 }
 
 // ─── Utilities ────────────────────────────────────────────────────────────────

--- a/src/core/config.ts
+++ b/src/core/config.ts
@@ -1,7 +1,74 @@
 import Conf from 'conf';
 import { z } from 'zod';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
 import { ConfigurationError } from '../utils/errors.js';
 import { getDefaultFilesystemAllowedPath } from '../utils/platform.js';
+
+/**
+ * Jiva's per-user data directory. Conversations and logs already live here
+ * (see LocalStorageProvider); config.json now lives here too, unifying the
+ * CLI's config storage with what the local (non-cloud) HTTP interface's
+ * LocalStorageProvider was already using.
+ */
+const JIVA_HOME = path.join(os.homedir(), '.jiva');
+
+/**
+ * Where `conf` (via `projectName: 'jiva'`) used to store config.json, before
+ * the move to JIVA_HOME. Same platform-specific resolution `conf` itself
+ * used internally — kept here only to detect and migrate a pre-existing
+ * config on first run after upgrading.
+ */
+function getLegacyConfigPath(): string {
+  switch (process.platform) {
+    case 'win32': {
+      const appData = process.env.APPDATA ?? path.join(os.homedir(), 'AppData', 'Roaming');
+      return path.join(appData, 'jiva-nodejs', 'Config', 'config.json');
+    }
+    case 'darwin':
+      return path.join(os.homedir(), 'Library', 'Preferences', 'jiva-nodejs', 'config.json');
+    default:
+      return path.join(
+        process.env.XDG_CONFIG_HOME ?? path.join(os.homedir(), '.config'),
+        'jiva-nodejs', 'config.json',
+      );
+  }
+}
+
+/**
+ * One-time migration: if a config already exists at the new location
+ * (JIVA_HOME/config.json), it's authoritative — leave it alone. Otherwise,
+ * if a legacy config exists at the old platform-specific path, copy it to
+ * the new location so existing users don't lose their configuration.
+ *
+ * Defensive: if something already exists at the new path by the time we go
+ * to write (a race, or a stray file created between the check above and
+ * now), it is backed up to config-backup.json first rather than clobbered.
+ *
+ * Returns a short message describing what happened, or null if nothing
+ * needed to happen — callers (CLI, HTTP) print this so the migration is
+ * visible rather than silent.
+ */
+export function migrateLegacyConfigIfNeeded(): string | null {
+  const newPath = path.join(JIVA_HOME, 'config.json');
+  if (fs.existsSync(newPath)) return null; // already using the new location
+
+  const legacyPath = getLegacyConfigPath();
+  if (!fs.existsSync(legacyPath)) return null; // fresh install, nothing to migrate
+
+  fs.mkdirSync(JIVA_HOME, { recursive: true });
+
+  let backupMessage = '';
+  if (fs.existsSync(newPath)) {
+    const backupPath = path.join(JIVA_HOME, 'config-backup.json');
+    fs.copyFileSync(newPath, backupPath);
+    backupMessage = ` (existing file at the new location backed up to ${backupPath})`;
+  }
+
+  fs.copyFileSync(legacyPath, newPath);
+  return `Migrated config from ${legacyPath} to ${newPath}${backupMessage}`;
+}
 
 // Zod schemas for validation
 // Support both stdio-based and HTTP/SSE-based MCP servers
@@ -87,10 +154,23 @@ export type JivaConfig = z.infer<typeof JivaConfigSchema>;
 export class ConfigManager {
   private store: Conf<JivaConfig>;
   private static instance: ConfigManager;
+  /**
+   * Set once, the first time the singleton is constructed, if a legacy
+   * config was migrated to the new ~/.jiva/config.json location. CLI and
+   * HTTP entry points should check this right after the first
+   * `getInstance()` call and surface it (console/log) so the migration is
+   * visible rather than silent.
+   */
+  static lastMigrationMessage: string | null = null;
 
   private constructor() {
+    ConfigManager.lastMigrationMessage = migrateLegacyConfigIfNeeded();
     this.store = new Conf<JivaConfig>({
+      // cwd takes priority over projectName for path resolution — this is
+      // what actually pins storage to ~/.jiva/config.json. projectName is
+      // still required by Conf's types even when cwd is set.
       projectName: 'jiva',
+      cwd: JIVA_HOME,
     });
   }
 

--- a/src/core/config.ts
+++ b/src/core/config.ts
@@ -114,6 +114,12 @@ const ModelConfigSchema = z.object({
   /** Default max tokens — required for reasoning models like Sarvam-105B */
   defaultMaxTokens: z.number().optional(),
   /**
+   * Client-side proactive rate limit — max requests this model instance will
+   * send per trailing 60s window (e.g. Sarvam's standard plan: 40 req/min).
+   * Model-agnostic: set for any provider with a known hard rate ceiling.
+   */
+  maxRequestsPerMinute: z.number().optional(),
+  /**
    * Use Google Application Default Credentials instead of a static apiKey.
    * Required for Vertex AI MaaS endpoints (aiplatform.googleapis.com).
    * On Cloud Run the service account token is fetched automatically;

--- a/src/core/config.ts
+++ b/src/core/config.ts
@@ -35,6 +35,13 @@ const ModelConfigSchema = z.object({
   model: z.string().optional(),
   defaultModel: z.string().optional(),
   useHarmonyFormat: z.boolean().optional(),
+  /**
+   * True when this model instance itself has native vision/multimodal
+   * capability, regardless of `type`. Lets a `reasoning`- (or `tool-calling`-)
+   * typed model accept image content directly, without needing a separate
+   * dedicated `multimodal` model configured for image captioning.
+   */
+  hasVision: z.boolean().optional(),
   /** How to send reasoning effort: 'api_param' | 'system_prompt' | 'both' */
   reasoningEffortStrategy: z.enum(['api_param', 'system_prompt', 'both']).optional(),
   /** Default max tokens — required for reasoning models like Sarvam-105B */

--- a/src/core/conversation-manager.ts
+++ b/src/core/conversation-manager.ts
@@ -342,11 +342,20 @@ Keep the summary focused and complete — include file paths, function names, an
       const response = await orchestrator.chat({
         messages: [{ role: 'user', content: titlePrompt }],
         temperature: 0.1, // Low temperature for deterministic title generation
-        maxTokens: 20,
+        // Reasoning models (e.g. GLM-5.2) spend tokens on a thinking chain
+        // before emitting the title; 20 tokens was barely enough for the
+        // thinking alone, leaving nothing for the actual title.
+        maxTokens: 200,
+        reasoningEffort: 'low', // Minimize thinking for this simple task
       });
 
-      // Clean up the title
-      let title = response.content.trim();
+      // Clean up the title. Reasoning models (e.g. GLM-5.2, DeepSeek) emit
+      // inline thinking blocks; stripThinkingContent() removes those, then
+      // take the last non-empty line (the model sometimes emits preamble
+      // before the actual title).
+      let title = this.stripThinkingContent(response.content).trim();
+      const lines = title.split('\n').map(l => l.trim()).filter(Boolean);
+      title = lines.length > 0 ? lines[lines.length - 1] : '';
       // Remove quotes if present
       title = title.replace(/^["']|["']$/g, '');
       // Remove trailing punctuation
@@ -377,45 +386,25 @@ Keep the summary focused and complete — include file paths, function names, an
   }
 
   /**
+   * Remove reasoning/thinking blocks that some models (e.g. GLM-5.2,
+   * DeepSeek-R1) emit inline in the response content. Handles both
+   * properly-closed blocks and truncated/unclosed ones (where the model
+   * ran out of token budget mid-thought and never emitted the closing tag).
+   * \x3c is the '<' character, used here so the literal tag markers don't
+   * appear in the regex source.
+   */
+  private stripThinkingContent(content: string): string {
+    return content
+      .replace(/\x3cthink[\s\S]*?\x3c\/think>/g, '') // closed thinking blocks
+      .replace(/\x3cthink[\s\S]*$/g, ''); // unclosed (truncated) thinking
+  }
+
+  /**
    * Capitalize first letter of string
    */
   private capitalizeFirst(str: string): string {
     if (!str) return str;
     return str.charAt(0).toUpperCase() + str.slice(1);
-  }
-
-  /**
-   * Generate a summary for a conversation (for metadata)
-   */
-  async generateSummary(
-    messages: Message[],
-    orchestrator: ModelOrchestrator
-  ): Promise<string> {
-    try {
-      // Get user messages to understand the conversation topic
-      const userMessages = messages
-        .filter(msg => msg.role === 'user')
-        .map(msg => msg.content)
-        .slice(0, 5) // First 5 user messages
-        .join('\n');
-
-      const summaryPrompt = `Generate a brief 1-2 sentence summary of this conversation topic:
-
-${userMessages}
-
-Summary:`;
-
-      const response = await orchestrator.chat({
-        messages: [{ role: 'user', content: summaryPrompt }],
-        temperature: 0.1, // Low temperature for deterministic summary generation
-        maxTokens: 100,
-      });
-
-      return response.content.trim();
-    } catch (error) {
-      logger.error('Failed to generate summary', error);
-      return 'Conversation';
-    }
   }
 
   /**

--- a/src/core/conversation-manager.ts
+++ b/src/core/conversation-manager.ts
@@ -12,19 +12,12 @@ import { ModelOrchestrator } from '../models/orchestrator.js';
 import { StorageProvider } from '../storage/provider.js';
 import { SavedConversation } from '../storage/types.js';
 
-export interface ConversationMetadata {
-  id: string;
-  title?: string; // Human-readable title
-  created: string;
-  updated: string;
-  messageCount: number;
-  workspace?: string;
-  summary?: string;
-  type?: 'chat' | 'code';
-  totalPromptTokens?: number;
-  totalCompletionTokens?: number;
-  totalTokens?: number;
-}
+// Re-exported for backward compatibility — the canonical definitions now
+// live in storage/types.ts (SavedConversation.metadata is typed against
+// them, so keeping a second, separately-maintained copy here risked exactly
+// the kind of drift that motivated unifying them).
+export type { ConversationMetadata, CodeConversationMeta } from '../storage/types.js';
+import type { ConversationMetadata, CodeConversationMeta } from '../storage/types.js';
 
 export class ConversationManager {
   private storageProvider: StorageProvider;
@@ -53,7 +46,8 @@ export class ConversationManager {
     conversationId?: string,
     orchestrator?: ModelOrchestrator,
     type?: 'chat' | 'code',
-    tokenUsage?: { promptTokens: number; completionTokens: number; totalTokens: number }
+    tokenUsage?: { promptTokens: number; completionTokens: number; totalTokens: number },
+    codeMeta?: CodeConversationMeta
   ): Promise<string> {
     const finalId = conversationId || this.currentConversationId || this.generateConversationId();
 
@@ -100,6 +94,9 @@ export class ConversationManager {
       totalPromptTokens: (existingData?.metadata?.totalPromptTokens ?? 0) + (tokenUsage?.promptTokens ?? 0),
       totalCompletionTokens: (existingData?.metadata?.totalCompletionTokens ?? 0) + (tokenUsage?.completionTokens ?? 0),
       totalTokens: (existingData?.metadata?.totalTokens ?? 0) + (tokenUsage?.totalTokens ?? 0),
+      mcpServers: codeMeta?.mcpServers ?? existingData?.metadata?.mcpServers,
+      maxIterations: codeMeta?.maxIterations ?? existingData?.metadata?.maxIterations,
+      harness: codeMeta?.harness ?? existingData?.metadata?.harness,
     };
 
     const conversation: SavedConversation = {
@@ -429,10 +426,11 @@ Summary:`;
     workspace?: string,
     orchestrator?: ModelOrchestrator,
     type?: 'chat' | 'code',
-    tokenUsage?: { promptTokens: number; completionTokens: number; totalTokens: number }
+    tokenUsage?: { promptTokens: number; completionTokens: number; totalTokens: number },
+    codeMeta?: CodeConversationMeta
   ): Promise<void> {
     try {
-      await this.saveConversation(messages, workspace, this.currentConversationId || undefined, orchestrator, type, tokenUsage);
+      await this.saveConversation(messages, workspace, this.currentConversationId || undefined, orchestrator, type, tokenUsage, codeMeta);
     } catch (error) {
       logger.error('Auto-save failed', error);
     }

--- a/src/core/manager-agent.ts
+++ b/src/core/manager-agent.ts
@@ -112,6 +112,11 @@ IMPORTANT:
   /**
    * Get system messages with fresh directive + optional AgentContext.
    * Follows the per-call directive injection pattern from JivaAgent.getSystemMessages().
+   *
+   * The directive is merged into the single system message rather than appended as a
+   * separate message. Manager never sends `tools`, so Harmony's developer-role tool
+   * injection never applies here — appending a second message only risked providers
+   * (e.g. Krutrim's Qwen3.6) that reject anything but a single leading system message.
    */
   private getSystemMessages(agentContext?: AgentContext): Message[] {
     const systemMessage = this.conversationHistory[0];
@@ -119,20 +124,14 @@ IMPORTANT:
     // Inject fresh directive per-call
     const freshDirective = agentContext?.directive || this.workspace.getDirectivePrompt() || '';
 
-    const parts: string[] = [];
-    if (freshDirective) {
-      parts.push(freshDirective);
-    }
-
-    if (parts.length === 0) {
+    if (!freshDirective) {
       return [systemMessage];
     }
 
     return [
-      systemMessage,
       {
-        role: 'developer' as any,
-        content: parts.join('\n'),
+        ...systemMessage,
+        content: `${systemMessage.content}\n${freshDirective}`,
       },
     ];
   }

--- a/src/interfaces/cli/index.ts
+++ b/src/interfaces/cli/index.ts
@@ -6,7 +6,7 @@
 
 import { Command } from 'commander';
 import chalk from 'chalk';
-import { configManager } from '../../core/config.js';
+import { configManager, ConfigManager } from '../../core/config.js';
 import { createModelClient } from '../../models/model-client.js';
 import { ModelOrchestrator } from '../../models/orchestrator.js';
 import { MCPServerManager } from '../../mcp/server-manager.js';
@@ -31,6 +31,14 @@ const __dirname = dirname(__filename);
 const packageJson = JSON.parse(
   readFileSync(join(__dirname, '../../../package.json'), 'utf-8')
 );
+
+// Surface a one-time config migration (old ~/Library/Preferences/jiva-nodejs
+// or platform-equivalent config.json → ~/.jiva/config.json), if one just
+// happened. configManager's construction above already ran the migration;
+// this only prints the result.
+if (ConfigManager.lastMigrationMessage) {
+  console.log(chalk.yellow(`\n⚠  ${ConfigManager.lastMigrationMessage}\n`));
+}
 
 const program = new Command();
 program
@@ -73,20 +81,22 @@ program
           console.log(chalk.gray('  Endpoint:'), config.models.reasoning.endpoint);
           console.log(chalk.gray('  Model:'), config.models.reasoning.defaultModel);
           console.log(chalk.gray('  Harmony Format:'), config.models.reasoning.useHarmonyFormat ? 'Yes' : 'No');
+          console.log(chalk.gray('  Vision:'), config.models.reasoning.hasVision ? 'Yes' : 'No');
           console.log();
         }
-        
+
         if (config.models?.multimodal) {
           console.log(chalk.bold('Multimodal Model:'));
           console.log(chalk.gray('  Endpoint:'), config.models.multimodal.endpoint);
           console.log(chalk.gray('  Model:'), config.models.multimodal.defaultModel);
           console.log();
         }
-        
+
         if (config.models?.toolCalling) {
           console.log(chalk.bold('Tool-Calling Model:'), chalk.green('(primary for tool calls)'));
           console.log(chalk.gray('  Endpoint:'), config.models.toolCalling.endpoint);
           console.log(chalk.gray('  Model:'), config.models.toolCalling.defaultModel);
+          console.log(chalk.gray('  Vision:'), config.models.toolCalling.hasVision ? 'Yes' : 'No');
           console.log();
         }
         

--- a/src/interfaces/cli/index.ts
+++ b/src/interfaces/cli/index.ts
@@ -180,6 +180,7 @@ program
         model: reasoningModelConfig.defaultModel,
         type: 'reasoning',
         useHarmonyFormat: reasoningModelConfig.useHarmonyFormat,
+        hasVision: reasoningModelConfig.hasVision,
         defaultReasoningEffort: reasoningModelConfig.defaultReasoningEffort ?? undefined,
       });
 
@@ -206,6 +207,7 @@ program
           model: toolCallingModelConfig.defaultModel,
           type: 'tool-calling',
           useHarmonyFormat: toolCallingModelConfig.useHarmonyFormat,
+          hasVision: toolCallingModelConfig.hasVision,
           defaultReasoningEffort: 'medium',
         });
       }
@@ -690,6 +692,7 @@ program
         model: reasoningModelConfig.defaultModel,
         type: 'reasoning',
         useHarmonyFormat: reasoningModelConfig.useHarmonyFormat,
+        hasVision: reasoningModelConfig.hasVision,
         defaultReasoningEffort: reasoningModelConfig.defaultReasoningEffort ?? undefined,
       });
 
@@ -715,6 +718,7 @@ program
           model: toolCallingModelCfg.model || toolCallingModelCfg.defaultModel || '',
           type: 'tool-calling',
           useHarmonyFormat: toolCallingModelCfg.useHarmonyFormat,
+          hasVision: toolCallingModelCfg.hasVision,
           defaultReasoningEffort: 'medium',
         });
       }

--- a/src/interfaces/cli/index.ts
+++ b/src/interfaces/cli/index.ts
@@ -192,6 +192,9 @@ program
         useHarmonyFormat: reasoningModelConfig.useHarmonyFormat,
         hasVision: reasoningModelConfig.hasVision,
         defaultReasoningEffort: reasoningModelConfig.defaultReasoningEffort ?? undefined,
+        reasoningEffortStrategy: reasoningModelConfig.reasoningEffortStrategy,
+        defaultMaxTokens: reasoningModelConfig.defaultMaxTokens,
+        maxRequestsPerMinute: reasoningModelConfig.maxRequestsPerMinute,
       });
 
       let multimodalModel;
@@ -219,6 +222,8 @@ program
           useHarmonyFormat: toolCallingModelConfig.useHarmonyFormat,
           hasVision: toolCallingModelConfig.hasVision,
           defaultReasoningEffort: 'medium',
+          defaultMaxTokens: toolCallingModelConfig.defaultMaxTokens,
+          maxRequestsPerMinute: toolCallingModelConfig.maxRequestsPerMinute,
         });
       }
 
@@ -377,6 +382,7 @@ program
           lspEnabled,
           mcpManager: codeMcpServerNames.length > 0 ? mcpManager : undefined,
           mcpServerNames: codeMcpServerNames,
+          harness: options.harness === 'evaluator' ? 'evaluator' : undefined,
         });
 
         const mcpNote = codeMcpServerNames.length > 0 ? ` | MCP: ${codeMcpServerNames.join(', ')}` : '';
@@ -704,6 +710,9 @@ program
         useHarmonyFormat: reasoningModelConfig.useHarmonyFormat,
         hasVision: reasoningModelConfig.hasVision,
         defaultReasoningEffort: reasoningModelConfig.defaultReasoningEffort ?? undefined,
+        reasoningEffortStrategy: reasoningModelConfig.reasoningEffortStrategy,
+        defaultMaxTokens: reasoningModelConfig.defaultMaxTokens,
+        maxRequestsPerMinute: reasoningModelConfig.maxRequestsPerMinute,
       });
 
       let multimodalModel;
@@ -730,6 +739,8 @@ program
           useHarmonyFormat: toolCallingModelCfg.useHarmonyFormat,
           hasVision: toolCallingModelCfg.hasVision,
           defaultReasoningEffort: 'medium',
+          defaultMaxTokens: toolCallingModelCfg.defaultMaxTokens,
+          maxRequestsPerMinute: toolCallingModelCfg.maxRequestsPerMinute,
         });
       }
 

--- a/src/interfaces/cli/setup-wizard.ts
+++ b/src/interfaces/cli/setup-wizard.ts
@@ -27,6 +27,8 @@ interface ProviderPreset {
   useHarmonyFormat: boolean;
   reasoningEffortStrategy: 'api_param' | 'system_prompt' | 'both';
   defaultMaxTokens?: number;
+  /** Client-side proactive throttle — see ModelClientConfig.maxRequestsPerMinute. */
+  maxRequestsPerMinute?: number;
   hasMultimodal: boolean;
   note?: string; // shown during setup
 }
@@ -42,6 +44,8 @@ const PROVIDERS: Record<ProviderKey, ProviderPreset> = {
     reasoningEffortStrategy: 'api_param',
     // Sarvam's API caps completion output at 4096 tokens; requesting more is rejected.
     defaultMaxTokens: 4096,
+    // Sarvam's standard (non-enterprise) plan caps requests at 40/min.
+    maxRequestsPerMinute: 40,
     hasMultimodal: false,
     note: 'Sarvam does not offer a multimodal model. You will need to pick a separate provider for multimodal.',
   },
@@ -198,6 +202,7 @@ async function setupReasoningModel(collectedKeys: Map<ProviderKey, string>): Pro
     useHarmonyFormat: preset.useHarmonyFormat,
     reasoningEffortStrategy: preset.reasoningEffortStrategy,
     ...(preset.defaultMaxTokens ? { defaultMaxTokens: preset.defaultMaxTokens } : {}),
+    ...(preset.maxRequestsPerMinute ? { maxRequestsPerMinute: preset.maxRequestsPerMinute } : {}),
     ...(hasVision ? { hasVision: true } : {}),
   };
 
@@ -332,6 +337,8 @@ async function setupToolCallingModel(
     type: 'tool-calling',
     defaultModel: model,
     useHarmonyFormat: false, // always standard format for tool-calling models
+    ...(preset.defaultMaxTokens ? { defaultMaxTokens: preset.defaultMaxTokens } : {}),
+    ...(preset.maxRequestsPerMinute ? { maxRequestsPerMinute: preset.maxRequestsPerMinute } : {}),
     ...(hasVision ? { hasVision: true } : {}),
   };
 }

--- a/src/interfaces/cli/setup-wizard.ts
+++ b/src/interfaces/cli/setup-wizard.ts
@@ -10,6 +10,7 @@
 import inquirer from 'inquirer';
 import { configManager } from '../../core/config.js';
 import { logger } from '../../utils/logger.js';
+import { detectVisionCapability } from '../../utils/vision-detection.js';
 import chalk from 'chalk';
 import type { ModelConfig } from '../../core/config.js';
 
@@ -123,6 +124,27 @@ async function askEndpointAndKey(collectedKeys: Map<ProviderKey, string>): Promi
   return answers;
 }
 
+// ── Vision capability prompt ────────────────────────────────────────────────
+
+async function askHasVision(modelName: string): Promise<boolean> {
+  const detection = detectVisionCapability(modelName);
+
+  if (detection.supported) {
+    console.log(chalk.gray(`  ${detection.reason}.`));
+  }
+
+  const { hasVision } = await inquirer.prompt([
+    {
+      type: 'confirm',
+      name: 'hasVision',
+      message: 'Does this model support vision (image input)?',
+      default: detection.supported,
+    },
+  ]);
+
+  return hasVision;
+}
+
 // ── Reasoning model setup ──────────────────────────────────────────────────
 
 async function setupReasoningModel(collectedKeys: Map<ProviderKey, string>): Promise<{ config: ModelConfig; provider: ProviderKey }> {
@@ -165,6 +187,8 @@ async function setupReasoningModel(collectedKeys: Map<ProviderKey, string>): Pro
     },
   ]);
 
+  const hasVision = await askHasVision(model);
+
   const config: ModelConfig = {
     name: 'reasoning',
     endpoint,
@@ -174,6 +198,7 @@ async function setupReasoningModel(collectedKeys: Map<ProviderKey, string>): Pro
     useHarmonyFormat: preset.useHarmonyFormat,
     reasoningEffortStrategy: preset.reasoningEffortStrategy,
     ...(preset.defaultMaxTokens ? { defaultMaxTokens: preset.defaultMaxTokens } : {}),
+    ...(hasVision ? { hasVision: true } : {}),
   };
 
   return { config, provider: provider as ProviderKey };
@@ -298,6 +323,8 @@ async function setupToolCallingModel(
     },
   ]);
 
+  const hasVision = await askHasVision(model);
+
   return {
     name: 'tool-calling',
     endpoint,
@@ -305,6 +332,7 @@ async function setupToolCallingModel(
     type: 'tool-calling',
     defaultModel: model,
     useHarmonyFormat: false, // always standard format for tool-calling models
+    ...(hasVision ? { hasVision: true } : {}),
   };
 }
 

--- a/src/interfaces/http/index.ts
+++ b/src/interfaces/http/index.ts
@@ -14,6 +14,7 @@ import express, { Express } from 'express';
 import { createServer, Server as HttpServer } from 'http';
 import { WebSocketServer } from 'ws';
 import { logger, LogLevel } from '../../utils/logger.js';
+import { migrateLegacyConfigIfNeeded } from '../../core/config.js';
 import { SessionManager } from './session-manager.js';
 import { createStorageProvider } from '../../storage/factory.js';
 import { setupHealthRoutes } from './routes/health.js';
@@ -111,6 +112,17 @@ async function bootstrap(): Promise<{ app: Express; server: HttpServer; wss: Web
 async function start(): Promise<void> {
   try {
     logger.info('[HTTP] Starting Jiva HTTP/WebSocket server...');
+
+    // One-time config migration (old ~/Library/Preferences/jiva-nodejs or
+    // platform-equivalent config.json → ~/.jiva/config.json). Only matters
+    // when running with LocalStorageProvider (basePath ~/.jiva by default) —
+    // a no-op otherwise, since a GCS-backed deployment wouldn't have a
+    // legacy local config path to find anyway.
+    const migrationMessage = migrateLegacyConfigIfNeeded();
+    if (migrationMessage) {
+      logger.warn(`[HTTP] ${migrationMessage}`);
+    }
+
     logger.info(`[HTTP] Environment: ${process.env.NODE_ENV || 'development'}`);
     logger.info(`[HTTP] Storage: ${process.env.JIVA_STORAGE_PROVIDER || 'auto-detect'}`);
     logger.info(`[HTTP] Max sessions: ${MAX_CONCURRENT_SESSIONS}`);

--- a/src/interfaces/http/session-manager.ts
+++ b/src/interfaces/http/session-manager.ts
@@ -208,6 +208,7 @@ export class SessionManager extends EventEmitter {
         reasoningEffortStrategy: rm.reasoningEffortStrategy,
         defaultReasoningEffort: 'high',
         defaultMaxTokens: rm.defaultMaxTokens,
+        maxRequestsPerMinute: rm.maxRequestsPerMinute,
       });
 
       // Tool-calling model: when configured, serves as the PRIMARY model for tool-call

--- a/src/interfaces/http/session-manager.ts
+++ b/src/interfaces/http/session-manager.ts
@@ -204,6 +204,7 @@ export class SessionManager extends EventEmitter {
         type: 'reasoning',
         useHarmonyFormat: rm.useHarmonyFormat ?? false,
         useGoogleADC: rm.useGoogleADC ?? false,
+        hasVision: rm.hasVision ?? false,
         reasoningEffortStrategy: rm.reasoningEffortStrategy,
         defaultReasoningEffort: 'high',
         defaultMaxTokens: rm.defaultMaxTokens,

--- a/src/models/base.ts
+++ b/src/models/base.ts
@@ -40,6 +40,14 @@ export interface ModelResponse {
     completionTokens: number;
     totalTokens: number;
   };
+  /**
+   * The API's own reason the completion stopped, e.g. 'stop' | 'length' | 'tool_calls'.
+   * 'length' means the completion hit its max_tokens ceiling — if content and toolCalls
+   * are both empty with finishReason 'length', the model ran out of budget while still
+   * "thinking" and never got to emit anything, which looks identical to a genuine empty
+   * response but needs a different fix (more budget / less context), not just a nudge.
+   */
+  finishReason?: string;
   raw?: any;
 }
 

--- a/src/models/model-client.ts
+++ b/src/models/model-client.ts
@@ -101,6 +101,15 @@ export interface ModelClientConfig {
    * so use 4096 there. Leave unset for Groq/Krutrim.
    */
   defaultMaxTokens?: number;
+
+  /**
+   * True when this model instance itself has native vision/multimodal
+   * capability, regardless of `type`. Lets a `reasoning`- (or `tool-calling`-)
+   * typed model accept image content directly (see `supportsVision()`),
+   * without needing a separate dedicated `multimodal` model configured.
+   * Default: false
+   */
+  hasVision?: boolean;
 }
 
 export class ModelClient implements IModel {
@@ -111,7 +120,7 @@ export class ModelClient implements IModel {
   }
 
   supportsVision(): boolean {
-    return this.config.type === 'multimodal';
+    return this.config.type === 'multimodal' || !!this.config.hasVision;
   }
 
   supportsToolCalling(): boolean {

--- a/src/models/model-client.ts
+++ b/src/models/model-client.ts
@@ -103,6 +103,16 @@ export interface ModelClientConfig {
   defaultMaxTokens?: number;
 
   /**
+   * Client-side proactive rate limit — max requests this model instance will
+   * send in any trailing 60s window. When set, `chat()` waits BEFORE sending
+   * a request that would exceed the limit, rather than only reacting to 429s
+   * after the fact. Model-agnostic: set this for any provider with a known
+   * hard rate ceiling (e.g. Sarvam's free tier: 40 req/min).
+   * Default: unset (no proactive throttling, only reactive 429 retry).
+   */
+  maxRequestsPerMinute?: number;
+
+  /**
    * True when this model instance itself has native vision/multimodal
    * capability, regardless of `type`. Lets a `reasoning`- (or `tool-calling`-)
    * typed model accept image content directly (see `supportsVision()`),
@@ -114,6 +124,8 @@ export interface ModelClientConfig {
 
 export class ModelClient implements IModel {
   private config: ModelClientConfig;
+  /** Timestamps (ms) of requests sent in the trailing rate-limit window. */
+  private requestTimestamps: number[] = [];
 
   constructor(config: ModelClientConfig) {
     this.config = config;
@@ -126,6 +138,40 @@ export class ModelClient implements IModel {
   supportsToolCalling(): boolean {
     // Both the reasoning model and dedicated tool-calling model support tool calling
     return this.config.type === 'reasoning' || this.config.type === 'tool-calling';
+  }
+
+  /** The configured max output tokens for this model instance, if any. */
+  getDefaultMaxTokens(): number | undefined {
+    return this.config.defaultMaxTokens;
+  }
+
+  /**
+   * Proactively wait if sending a request right now would exceed
+   * `maxRequestsPerMinute`. No-op when the config doesn't set a limit.
+   * Called before every attempt (including retries) so a burst of calls in
+   * quick succession — tool-result turns, title generation, compaction
+   * summaries — can never collectively exceed the ceiling.
+   */
+  private async throttleIfNeeded(): Promise<void> {
+    const limit = this.config.maxRequestsPerMinute;
+    if (!limit || limit <= 0) return;
+
+    const windowMs = 60_000;
+    const now = Date.now();
+    this.requestTimestamps = this.requestTimestamps.filter(t => now - t < windowMs);
+
+    if (this.requestTimestamps.length >= limit) {
+      const oldest = this.requestTimestamps[0];
+      const waitMs = windowMs - (now - oldest) + 100; // small buffer past the window edge
+      logger.warn(
+        `[RateLimiter] ${this.config.model}: at the ${limit} req/min limit, waiting ${(waitMs / 1000).toFixed(1)}s`,
+      );
+      await new Promise(resolve => setTimeout(resolve, waitMs));
+      const afterWait = Date.now();
+      this.requestTimestamps = this.requestTimestamps.filter(t => afterWait - t < windowMs);
+    }
+
+    this.requestTimestamps.push(Date.now());
   }
 
   async chat(options: ChatCompletionOptions): Promise<ModelResponse> {
@@ -142,6 +188,7 @@ export class ModelClient implements IModel {
       }
 
       try {
+        await this.throttleIfNeeded();
         return await this.attemptChat(options, isReasoningModel);
       } catch (error) {
         lastError = error as Error;
@@ -170,11 +217,16 @@ export class ModelClient implements IModel {
           else if (error.message.includes('(503)')) errorType = '503 Service Unavailable';
           else if (error.message.includes('(504)')) errorType = '504 Gateway Timeout';
 
-          // For 429s, parse the actual retry-after time from the error message.
-          // Groq returns: "Please try again in 8.53s."
+          // For 429s, prefer the standard Retry-After header (captured on the
+          // error as retryAfterMs — provider-agnostic, RFC 6585) over parsing
+          // provider-specific wording out of the message body. Groq returns
+          // "Please try again in 8.53s." in the body; other providers (e.g.
+          // Sarvam) may only set the header with no matching text, so the
+          // header must be checked first rather than only as a fallback.
           if (is429) {
-            const match = error.message.match(/try again in (\d+(?:\.\d+)?)\s*s/i);
-            const retryAfterMs = match ? Math.ceil(parseFloat(match[1]) * 1000) + 500 : null;
+            const textMatch = error.message.match(/try again in (\d+(?:\.\d+)?)\s*s/i);
+            const textParsedMs = textMatch ? Math.ceil(parseFloat(textMatch[1]) * 1000) + 500 : null;
+            const retryAfterMs = error.retryAfterMs ?? textParsedMs;
             // Use parsed time, falling back to capped exponential backoff
             const exponential = Math.min(Math.pow(2, attempt) * 1000, 30_000);
             this._lastRetryWait = retryAfterMs ?? exponential;
@@ -324,9 +376,30 @@ export class ModelClient implements IModel {
           }
         }
 
+        // Standard RFC 6585 header — either delay-seconds ("30") or an HTTP-date.
+        // Captured here (not just parsed out of the message text later) so the
+        // retry logic works uniformly across providers regardless of whether
+        // they also include human-readable wording in the error body.
+        let retryAfterMs: number | undefined;
+        if (response.status === 429) {
+          const retryAfterHeader = response.headers.get('retry-after');
+          if (retryAfterHeader) {
+            const asSeconds = Number(retryAfterHeader);
+            if (!Number.isNaN(asSeconds)) {
+              retryAfterMs = asSeconds * 1000;
+            } else {
+              const asDate = Date.parse(retryAfterHeader);
+              if (!Number.isNaN(asDate)) {
+                retryAfterMs = Math.max(0, asDate - Date.now());
+              }
+            }
+          }
+        }
+
         throw new ModelError(
           `API error (${response.status}): ${errorText}`,
-          this.config.model
+          this.config.model,
+          retryAfterMs,
         );
       }
 

--- a/src/models/model-client.ts
+++ b/src/models/model-client.ts
@@ -380,6 +380,7 @@ export class ModelClient implements IModel {
             completionTokens: data.usage.completion_tokens || 0,
             totalTokens: data.usage.total_tokens || 0,
           } : undefined,
+          finishReason: choice.finish_reason,
           raw: {
             ...data,
             parsedHarmony: parsed,
@@ -428,6 +429,7 @@ export class ModelClient implements IModel {
             completionTokens: data.usage.completion_tokens || 0,
             totalTokens: data.usage.total_tokens || 0,
           } : undefined,
+          finishReason: choice.finish_reason,
           raw: data,
         };
       }

--- a/src/models/orchestrator.ts
+++ b/src/models/orchestrator.ts
@@ -47,7 +47,17 @@ export class ModelOrchestrator {
    * Process a chat completion, selecting the model based on `useFallback`.
    *   useFallback=true  → use tool-calling model (primary when configured)
    *   useFallback=false → use reasoning model (primary when no tool-calling model configured)
-   * Images are always pre-processed by the multimodal model prior to routing.
+   *
+   * Image routing priority when the request contains images:
+   *   1. A dedicated `multimodalModel` is configured → caption images via it,
+   *      then forward text-only to the primary/fallback model (unchanged
+   *      legacy behaviour).
+   *   2. No dedicated multimodal model, but the model that would otherwise
+   *      handle this call has native vision (`hasVision` config flag) →
+   *      pass the images straight through to it, no captioning needed.
+   *   3. Neither is available → images are forwarded as-is to a text-only
+   *      model (unchanged legacy behaviour — the model will likely ignore
+   *      or choke on them, same as before this feature existed).
    */
   async chatWithFallback(options: ChatCompletionOptions, useFallback: boolean): Promise<ModelResponse> {
     // Check if request contains images
@@ -58,6 +68,12 @@ export class ModelOrchestrator {
     if (hasImages && this.multimodalModel) {
       // Use multimodal model to process images first, then primary/fallback model
       response = await this.handleMultimodalRequest(options, useFallback);
+    } else if (hasImages && useFallback && this.toolCallingModel?.supportsVision()) {
+      logger.info('  [Orchestrator] Tool-calling model has native vision — passing images directly');
+      response = await this.toolCallingModel.chat(options);
+    } else if (hasImages && this.reasoningModel.supportsVision()) {
+      logger.info('  [Orchestrator] Reasoning model has native vision — passing images directly');
+      response = await this.reasoningModel.chat(options);
     } else if (useFallback && this.toolCallingModel) {
       logger.info('  [Orchestrator] Using tool-calling model');
       response = await this.toolCallingModel.chat(options);
@@ -222,10 +238,15 @@ export class ModelOrchestrator {
   }
 
   /**
-   * Get multimodal model instance if configured
+   * Get a vision-capable model instance if one is available: a dedicated
+   * multimodal model if configured, otherwise the reasoning or tool-calling
+   * model if it has native vision (`hasVision` config flag).
    */
   getMultimodalModel(): ModelClient | undefined {
-    return this.multimodalModel;
+    if (this.multimodalModel) return this.multimodalModel;
+    if (this.reasoningModel.supportsVision()) return this.reasoningModel;
+    if (this.toolCallingModel?.supportsVision()) return this.toolCallingModel;
+    return undefined;
   }
 
   /**
@@ -236,9 +257,10 @@ export class ModelOrchestrator {
   }
 
   /**
-   * Check if multimodal support is available
+   * Check if multimodal support is available — either a dedicated
+   * multimodal model, or a reasoning/tool-calling model with native vision.
    */
   hasMultimodalSupport(): boolean {
-    return !!this.multimodalModel;
+    return !!this.multimodalModel || this.reasoningModel.supportsVision() || !!this.toolCallingModel?.supportsVision();
   }
 }

--- a/src/storage/types.ts
+++ b/src/storage/types.ts
@@ -15,6 +15,25 @@ export interface StorageContext {
 }
 
 /**
+ * Extra context captured for code-mode conversations only — lets a UI (e.g.
+ * Jivam) reconstruct exactly how a code task was configured when resuming
+ * or reviewing it later.
+ */
+export interface CodeConversationMeta {
+  /** Names of MCP servers that were enabled for this code task. */
+  mcpServers?: string[];
+  /** Iteration budget configured for this task. */
+  maxIterations?: number;
+  /**
+   * Free-form harness/mode label, if any — e.g. jiva-core's own 'evaluator'
+   * harness, or a UI-level feature like Jivam's 'deep-run'. Not validated
+   * against a fixed enum since callers outside jiva-core (like Jivam) may
+   * set their own values here.
+   */
+  harness?: string;
+}
+
+/**
  * Conversation metadata (lightweight, for listing)
  */
 export interface ConversationMetadata {
@@ -32,6 +51,10 @@ export interface ConversationMetadata {
   totalCompletionTokens?: number;
   /** totalPromptTokens + totalCompletionTokens */
   totalTokens?: number;
+  /** Code-mode specific context — see CodeConversationMeta. Only meaningful when type === 'code'. */
+  mcpServers?: string[];
+  maxIterations?: number;
+  harness?: string;
 }
 
 /**

--- a/src/utils/errors.ts
+++ b/src/utils/errors.ts
@@ -13,7 +13,17 @@ export class ConfigurationError extends JivaError {
 }
 
 export class ModelError extends JivaError {
-  constructor(message: string, public modelName?: string) {
+  constructor(
+    message: string,
+    public modelName?: string,
+    /**
+     * Milliseconds to wait before retrying, parsed from the API response's
+     * standard `Retry-After` header (RFC 6585) when the error was a 429.
+     * Preferred over parsing provider-specific wording out of the error
+     * message body, which only some providers (e.g. Groq) include.
+     */
+    public retryAfterMs?: number,
+  ) {
     super(message, 'MODEL_ERROR');
     this.name = 'ModelError';
   }

--- a/src/utils/vision-detection.ts
+++ b/src/utils/vision-detection.ts
@@ -1,0 +1,67 @@
+/**
+ * Best-effort detection of whether a model name belongs to a family known to
+ * support native vision (image) input alongside reasoning/tool-calling.
+ *
+ * This only drives the DEFAULT answer to a y/n prompt during setup — it is
+ * never authoritative. Users can always override it. Matching is
+ * intentionally broad (family-name-level, not exact-model-level) since a
+ * false positive just means the user answers "n" once, while a false
+ * negative silently withholds a useful default.
+ */
+
+export interface VisionDetectionResult {
+  supported: boolean;
+  reason?: string;
+}
+
+const VISION_PATTERNS: Array<[RegExp, string]> = [
+  // Llama 4 herd is natively multimodal; Maverick/Scout are the vision-capable variants.
+  [/maverick/i, 'Llama 4 Maverick supports vision'],
+  [/scout/i, 'Llama 4 Scout supports vision'],
+  [/llama-?4/i, 'Llama 4 models support vision'],
+  [/llama.*vision/i, 'Llama vision variants support vision'],
+
+  // Qwen (VL variants and newer flagship models)
+  [/qwen/i, 'Qwen models support vision'],
+
+  // Moonshot AI's Kimi
+  [/kimi/i, 'Kimi models support vision'],
+
+  // Zhipu AI's GLM
+  [/glm/i, 'GLM models support vision'],
+
+  // Anthropic Claude — all Claude 3+ models support vision, no modern text-only variant
+  [/claude/i, 'Claude models support vision'],
+
+  // OpenAI GPT-4o/4.x/5.x and o-series reasoning models support vision.
+  // gpt-oss is deliberately excluded — it's a text-only open-weight reasoning
+  // model (see the Krutrim preset in setup-wizard.ts, which pairs it with a
+  // separate Llama-4-Maverick multimodal model for exactly this reason).
+  [/gpt-4/i, 'GPT-4 models support vision'],
+  [/gpt-5/i, 'GPT-5 models support vision'],
+  [/\bo[134]\b/i, 'OpenAI o-series reasoning models support vision'],
+
+  // Google Gemini — all modern Gemini models are natively multimodal
+  [/gemini/i, 'Gemini models support vision'],
+
+  // Mistral's vision-specialised model
+  [/pixtral/i, 'Pixtral supports vision'],
+
+  // xAI Grok — modern Grok models support vision
+  [/grok/i, 'Grok models support vision'],
+
+  // Microsoft Phi multimodal variants
+  [/phi.*(vision|multimodal)/i, 'Phi multimodal variants support vision'],
+];
+
+export function detectVisionCapability(modelName: string): VisionDetectionResult {
+  if (!modelName) return { supported: false };
+
+  for (const [pattern, reason] of VISION_PATTERNS) {
+    if (pattern.test(modelName)) {
+      return { supported: true, reason };
+    }
+  }
+
+  return { supported: false };
+}


### PR DESCRIPTION
# Jiva v0.3.50 — Unified Config, Vision Detection & Code-Mode Improvements

**Release Date:** July 14, 2026

---

## Summary

Model-agnostic rate limiting and low-output-budget handling (motivated by
Sarvam-105B's 40 req/min and 4096-token limits, but applicable to any
similarly-constrained provider), a real bug fix where the CLI silently
dropped `defaultMaxTokens`/`reasoningEffortStrategy` config, richer metadata
recorded on code-mode conversations, unified config storage across CLI and
HTTP interfaces, and auto-detection of vision-capable models during setup.

---

## New Features

### Model-agnostic proactive rate limiting

`ModelClientConfig.maxRequestsPerMinute` — when set, `ModelClient` tracks its
own request timestamps in a trailing 60s window and waits **before** sending
a request that would exceed the limit, instead of only reacting to 429s
after they happen. Set for any provider with a known hard rate ceiling; the
Sarvam preset in the setup wizard now sets this to 40 automatically.

429 handling also now checks the standard `Retry-After` HTTP header (RFC
6585) first, falling back to parsing provider-specific wording out of the
error body (Groq's "Please try again in 8.53s.") only when the header is
absent.

### Skeleton-first workflow for low-output-budget models

When the reasoning model's `defaultMaxTokens` is ≤ 8192, code mode's system
prompt now **mandates** (not just recommends for large files) scaffolding
every new file as `### section-<name>` / `### endsection` blocks and filling
them in one at a time — the model is told its exact token budget explicitly.

`edit_file` gained a `use_regex` mode to make this reliable: `old_string` is
compiled as a regex and matched against the file, so a whole section can be
replaced by matching its markers without needing to reproduce the section's
current (stub) content exactly.

### Code-mode conversation metadata

`ConversationMetadata` (unified into `storage/types.ts` — previously
duplicated with a second, drifting copy in `conversation-manager.ts`) gains:

```typescript
{
  mcpServers?: string[]   // MCP servers enabled for this code task
  maxIterations?: number  // iteration budget configured for this task
  harness?: string        // e.g. jiva-core's 'evaluator', or a UI feature
                          // like Jivam's 'deep-run' — free-form, not a fixed enum
}
```

`saveConversation()`/`autoSave()` take an optional `codeMeta` parameter;
`CodeAgent` passes its own `mcpServerNames`/`maxIterations`/`harness`, and
previously-saved values persist across subsequent auto-saves that don't
repeat them. The workspace directory a code task ran in was already captured
via the existing `workspace` field.

### Unified config storage across all interfaces

Jiva's CLI config previously lived at a platform-specific location via the
`conf` package's default resolution (`~/Library/Preferences/jiva-nodejs` on
macOS, `%APPDATA%/jiva-nodejs/Config` on Windows, `~/.config/jiva-nodejs` on
Linux) — a different file entirely from what the local (non-cloud) HTTP
interface's `LocalStorageProvider` already used for config
(`~/.jiva/config.json`, alongside conversations and logs that already lived
there). This meant CLI and local-HTTP-mode configuration were silently out of
sync with each other.

`ConfigManager` now pins `conf`'s storage to `~/.jiva` via the `cwd` option,
so both interfaces read/write the exact same file.

`migrateLegacyConfigIfNeeded()` runs once, the first time `ConfigManager` is
constructed (both interfaces trigger this on startup): if `~/.jiva/config.json`
doesn't exist yet but a legacy platform-specific config does, it's copied over.
If something unexpectedly already exists at the new path by the time of the
write (a race, or a stray file), it's backed up to `config-backup.json` first
rather than clobbered. Once `~/.jiva/config.json` exists, it's treated as
authoritative and migration is skipped on all subsequent runs. The CLI prints
the migration result on the next `jiva` invocation; the HTTP interface logs it
via `logger.warn` on startup.

### Auto-detect vision capability during setup

v0.3.49 added `hasVision` support for reasoning/tool-calling models, but the
CLI setup wizard never asked for it — the flag could only be set by hand-
editing `config.json`.

`src/utils/vision-detection.ts` matches a model name against known vision-
capable model families (Llama 4 Maverick/Scout, Qwen, Kimi, GLM, Claude,
GPT-4+/GPT-5/o-series, Gemini, Pixtral, Grok, Phi multimodal) and returns a
short reason when matched. This only drives the **default** answer to a y/n
prompt — never authoritative, always overridable.

`setup-wizard.ts` now asks "Does this model support vision (image input)?"
right after the model name is entered, for both the reasoning and tool-calling
model setup flows, defaulting to the detection result and showing the matched
reason (e.g. "Llama 4 Maverick supports vision"). A `Vision: Yes/No` line is
also shown in `jiva config --show`.

### Vision-capable reasoning/tool-calling models (no separate multimodal model needed)

Some providers (e.g. Groq's `llama-4-maverick`, Krutrim's vision-enabled
models) offer a single model that handles both reasoning and vision, making
the separate dedicated `multimodal` model configuration and its image-captioning
detour unnecessary and wasteful for those setups.

A new `hasVision` config flag (`ModelConfigSchema` + `ModelClientConfig`) lets
any model instance declare native vision support regardless of its `type`. When
set:

- `ModelClient.supportsVision()` reports `true`
- `ModelOrchestrator` routes image content directly to that model instead of
  running it through the dedicated multimodal model's caption-then-forward
  pipeline
- `hasMultimodalSupport()` / `getMultimodalModel()` account for it too

Priority order when a request contains images: dedicated multimodal model
(unchanged legacy behavior) > reasoning model with `hasVision` > tool-calling
model with `hasVision` > legacy passthrough. Existing setups with a configured
`multimodal` model are unaffected.

`DualAgent` and `CodeAgent` need no changes — both delegate all model calls
through `ModelOrchestrator.chat()`/`chatWithFallback()`, so fixing routing at
the orchestrator is sufficient for both to pick up native vision support.

---

## Bug Fixes

### Manager double system-message crashes strict providers

**Symptom:** `400 System message must be at the beginning` on providers that
reject anything but a single leading system message (e.g. Krutrim's Qwen3.6),
whenever a directive was configured.

**Root cause:** `ManagerAgent.getSystemMessages()` (`src/core/manager-agent.ts`)
appended the directive as a second `developer`-role message, which becomes a
second `system` message after role conversion. Krutrim's `gpt-oss-120b`
happened to tolerate two system messages; Qwen3.6 didn't.

**Fix:** The directive is now merged into the single system message instead
of appended separately. Safe for all providers — Manager never sends `tools`,
so Harmony's developer-role tool-injection path never depended on the
directive being a separate message.

---

### CodeAgent gives up after 4 empty responses despite ample `maxIterations`

**Symptom:** Code mode would stop with `[No response content]` after just
~10 iterations even with `maxIterations` set to 100, following a run of
`Empty response with no tool calls` warnings. Manually retrying the same
request usually succeeded.

**Root cause:** In-loop context compaction was gated on the response having
tool calls. Once the model starts returning genuinely empty responses (no
content, no tool calls), that gate can never be true again — so context can
never shrink back down, and the same bloated prompt gets resent on every
recovery-nudge retry, guaranteeing the same failure each time. The
empty-response retry cap (4), not the iteration budget, was the real limiter.

**Fix:**
- Removed the tool-calls requirement from the in-loop compaction trigger
  (`src/code/agent.ts`) — compaction now runs whenever prompt tokens exceed
  the threshold, regardless of whether the last response had tool calls.
- Added `finishReason` to `ModelResponse` (`src/models/base.ts`,
  `src/models/model-client.ts`), captured from the API's own
  `choices[0].finish_reason` (previously discarded). When an empty response
  has `finishReason: 'length'`, that's direct evidence the model ran out of
  completion-token budget mid-"thought" — CodeAgent now forces an immediate
  compaction in that case (bypassing the normal token threshold) instead of
  just adding another text nudge, which was only adding more prompt weight
  and making the same budget problem worse on the next attempt.

### CLI silently dropped `defaultMaxTokens` and `reasoningEffortStrategy`

**Symptom:** A reasoning model configured with `defaultMaxTokens: 4096`
(required for Sarvam-105B) had no effect when used via `jiva chat` — the
request went out with no `max_tokens` cap at all, letting Sarvam apply its
own internal default and risking the model exhausting its completion budget
on its reasoning chain before producing visible output (the same failure
shape as the empty-response bug fixed in v0.3.49, via a different path).

**Root cause:** All four `createModelClient()` call sites in
`src/interfaces/cli/index.ts` (reasoning ×2, tool-calling ×2) never passed
`defaultMaxTokens` or `reasoningEffortStrategy` from the loaded config,
despite both being present in the config schema and set by the setup
wizard.

**Fix:** Both fields now passed through at all four sites, along with the
new `maxRequestsPerMinute`.

---

### Conversation titles always fell back to the first-message snippet

**Symptom:** Conversation titles were never the LLM-generated 3–5 word
summary they were supposed to be. Saved conversations in
`~/.jiva/conversations/` showed one of two wrong shapes:
- The fallback snippet — the first ~40 chars of the first user message
  plus `...` (e.g. `make a beautiful looking game of tetris...`), or
- Raw model "thinking" leaked into the title — e.g.
  `\nOkay, the user wants a short title for their mess...`.

**Root cause:** `ConversationManager.generateTitle()` (in
`src/core/conversation-manager.ts`) asked the orchestrator for a title with
`maxTokens: 20`. The orchestrator routes tool/image-less calls to the
**reasoning** model, which (for models like `zai-org/GLM-5.2`) emits an
inline `…</think>` chain *before* the answer. 20 tokens is barely
enough for the thinking alone, so the model routinely exhausted its budget
mid-thought — the response came back as `\nOkay, the user wants a
short title for their mess…` with **no closing `</think>` and no actual
title**.

The cleanup pipeline then failed in two ways:
1. `extractAssistantMessage()` (in `src/models/harmony.ts`) strips Harmony
   control tokens (`<|call|>`, `<|channel|>`, …) but **not** ``
   blocks, so the thinking text survived into `response.content`.
2. `generateTitle()`'s own cleanup (trim, de-quote, de-punctuate, truncate
   to 60 chars) didn't remove the thinking either, and its garbage guard
   (`!title || length < 3 || includes('untitled')`) didn't catch 60-char
   leaked thinking — so it was returned verbatim. When the API returned
   the thinking out-of-band (in `reasoning_content`, leaving `content`
   empty), the guard *did* trip and the method fell back to the first
   40 chars — producing the snippet-shaped titles.

**Fix:**
- Added `stripThinkingContent()`, which removes both properly-closed
  `…</think>` blocks and truncated/unclosed `<think…` runs (the
  model ran out of budget before the closing tag). It's applied to
  `response.content` before any other cleanup.
- After stripping, the last non-empty line is taken as the title (the
  model sometimes emits preamble before the actual title).
- Raised `maxTokens` from 20 → 200 so a reasoning model has room to
  finish its thinking chain *and* emit the title.
- Set `reasoningEffort: 'low'` on the title call to minimise thinking for
  what is a trivial classification task.

The existing first-message fallback is retained as the last resort when
the model still returns nothing usable.

---

## Files Changed

| File | Change |
|------|--------|
| `src/utils/errors.ts` | `ModelError.retryAfterMs` |
| `src/utils/vision-detection.ts` | **New** — `detectVisionCapability()` matches model names against known vision-capable families |
| `src/models/model-client.ts` | Proactive rate limiter; `Retry-After` header parsing; `getDefaultMaxTokens()`; `supportsVision()` honors `hasVision` |
| `src/models/base.ts` | Added `finishReason` to `ModelResponse` (captured from API's `choices[0].finish_reason`) |
| `src/models/orchestrator.ts` | Image routing accounts for `hasVision` on reasoning/tool-calling models |
| `src/core/config.ts` | `maxRequestsPerMinute` field on `ModelConfigSchema`; `migrateLegacyConfigIfNeeded()`; config storage unified to `~/.jiva` |
| `src/interfaces/cli/setup-wizard.ts` | Sarvam preset sets `maxRequestsPerMinute: 40`; vision capability prompt after model name entry |
| `src/interfaces/cli/index.ts` | Fixed missing `defaultMaxTokens`/`reasoningEffortStrategy` passthrough (×4 sites); `harness` wiring for `--harness evaluator`; vision prompt wiring |
| `src/interfaces/http/index.ts` | Register config migration on startup; register benchmark routes |
| `src/interfaces/http/session-manager.ts` | `maxRequestsPerMinute` passthrough |
| `src/code/agent.ts` | Low-output-budget skeleton-first system prompt; `harness` config field; `codeMeta` on save calls |
| `src/code/tools/edit.ts` | `use_regex` mode for `edit_file` |
| `src/core/manager-agent.ts` | Merged directive into single system message instead of appending a second one |
| `src/core/conversation-manager.ts` | `ConversationMetadata`/`CodeConversationMeta` now re-exported from `storage/types.ts` instead of duplicated; `generateTitle()` strips reasoning `` blocks, raises `maxTokens` 20→200, sets `reasoningEffort: 'low'`; new `stripThinkingContent()` helper |
| `src/storage/types.ts` | Canonical `ConversationMetadata` gains `mcpServers`/`maxIterations`/`harness`; new `CodeConversationMeta` |

---

## Upgrade

```bash
npm install -g jiva-core@0.3.50
```

No breaking changes. All existing configs continue to work without
modification. If you're on Sarvam and haven't re-run `jiva config` since
before this release, doing so will pick up the new `maxRequestsPerMinute`
default.
