### PR TITLE
v0.3.51: detailed tool-call argument logging in Code mode

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "jiva-core",
-  "version": "0.3.50",
+  "version": "0.3.51",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "jiva-core",
-      "version": "0.3.50",
+      "version": "0.3.51",
       "license": "MIT",
       "dependencies": {
         "@google-cloud/storage": "^7.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jiva-core",
-  "version": "0.3.50",
+  "version": "0.3.51",
   "description": "Versatile autonomous AI agent with three-agent architecture (Manager, Worker, Client) powered by gpt-oss-120b. Adaptive validation, full MCP support, and intelligent quality control.",
   "main": "dist/index.js",
   "bin": {

--- a/src/code/agent.ts
+++ b/src/code/agent.ts
@@ -10,7 +10,7 @@ import { WorkspaceManager } from '../core/workspace.js';
 import { ConversationManager } from '../core/conversation-manager.js';
 import { formatToolResult } from '../models/harmony.js';
 import type { Message, Tool } from '../models/base.js';
-import { logger } from '../utils/logger.js';
+import { logger, formatToolCallArgs } from '../utils/logger.js';
 import type { PersonaManager } from '../personas/persona-manager.js';
 import type { MCPServerManager } from '../mcp/server-manager.js';
 import { LspManager } from './lsp/manager.js';
@@ -483,6 +483,14 @@ ${directive ? `\n${directive}` : ''}`;
    * Runs the model → tools → model loop until no more tool calls or max iterations.
    */
   async chat(userMessage: string, onChunk?: (text: string) => void): Promise<AgentResponse> {
+    // Code mode has no persona concept, but `logger`'s persona context is a
+    // process-wide singleton that Chat mode sets and never resets — an
+    // embedding app running both modes in the same long-lived process (e.g.
+    // Jivam's persistent background service) can leak a stale
+    // `[PersonaName]` prefix onto every one of this agent's log lines,
+    // corrupting any log-line parser downstream that expects `[CodeAgent]`
+    // to lead the message.
+    logger.setPersonaContext(null);
     const toolsUsed: string[] = [];
     const directive = this.workspace.getDirectivePrompt();
     const skillsBlock = this.personaManager?.getSystemPromptAddition() || undefined;
@@ -1034,7 +1042,7 @@ ${directive ? `\n${directive}` : ''}`;
           break;
         }
 
-        logger.info(`[CodeAgent] Tool: ${toolName}`);
+        logger.info(`[CodeAgent] Tool: ${toolName} ${formatToolCallArgs(toolArgs)}`);
         toolsUsed.push(toolName);
 
         const tool = this.tools.find((t) => t.name === toolName);

--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -139,3 +139,37 @@ class Logger {
 }
 
 export const logger = Logger.getInstance();
+
+const MAX_STRING_VALUE_LEN = 500;
+const MAX_TOTAL_LEN = 2000;
+
+/**
+ * Renders tool-call arguments for a log line — a single-line JSON blob,
+ * safe to append after a "Tool: <name>" message. Per-string-value
+ * truncation (500 chars) is deliberately more generous than the 200-char
+ * precedent used elsewhere for token-budget-constrained summaries (see
+ * code/agent.ts) since this is a human-inspects-on-demand view, not a
+ * context-compaction one. An overall-length cap is a second safety net for
+ * future tools with deeply nested schemas (today's built-in tools are all
+ * flat/top-level).
+ */
+export function formatToolCallArgs(args: Record<string, unknown>): string {
+  const shortened: Record<string, unknown> = {};
+  for (const [key, value] of Object.entries(args)) {
+    if (typeof value === 'string' && value.length > MAX_STRING_VALUE_LEN) {
+      shortened[key] = `${value.slice(0, MAX_STRING_VALUE_LEN)}...(${value.length - MAX_STRING_VALUE_LEN} more chars)`;
+    } else {
+      shortened[key] = value;
+    }
+  }
+  let json: string;
+  try {
+    json = JSON.stringify(shortened);
+  } catch {
+    return '{}';
+  }
+  if (json.length > MAX_TOTAL_LEN) {
+    json = `${json.slice(0, MAX_TOTAL_LEN)}..."}`;
+  }
+  return json;
+}


### PR DESCRIPTION
## Summary
- CodeAgent's tool-call log line now includes actual call arguments (e.g. `Tool: read_file {"path":"...","offset":0}`), truncated per-value at 500 chars for oversized content like file writes
- Fixes a persona-context leak bug: Chat mode's active persona was never reset, so a long-running process serving both Chat and Code mode could leak a stale `[PersonaName]` prefix onto Code mode's log lines

## Test plan
- [x] Verified via real CLI runs (`jiva run --code`) that log lines now show structured args, single-line, correctly truncated for long values
- [x] Verified the persona-leak fix directly against the built logger
- [x] `tsc --noEmit` and `npm run build` clean