### PR TITLE
v0.3.52

### DIFF
--- a/docs/release_notes/v0.3.51.md
+++ b/docs/release_notes/v0.3.51.md
@@ -1,0 +1,78 @@
+# Jiva v0.3.51 — Code-Mode Tool-Call Argument Logging
+
+**Release Date:** July 20, 2026
+
+---
+
+## Summary
+
+CodeAgent's tool-call log lines now include the actual call arguments, not
+just the tool name, so the CLI, HTTP interface logs, and any embedding
+consumer (e.g. Jivam) can see what a tool call actually did. Also fixes an
+independent bug found while tracing this: Chat mode's persona context could
+leak a stale log-line prefix onto Code mode.
+
+---
+
+## New Features
+
+### Detailed tool-call argument logging in Code mode
+
+**Before:** `CodeAgent`'s per-tool-call log line was just
+`[CodeAgent] Tool: edit_file` — no indication of which file, what command,
+or any other argument the model passed.
+
+**After:** The same log line now reads
+`[CodeAgent] Tool: edit_file {"path":"src/foo.ts","old_string":"...","new_string":"..."}`.
+
+`src/utils/logger.ts` gains `formatToolCallArgs()`, which renders a tool
+call's argument object as a single-line JSON blob safe to append to a log
+message: any string value over 500 characters is truncated with a
+`...(N more chars)` suffix, and the overall serialized output is capped at
+2000 characters as a second safety net. `src/code/agent.ts`'s tool-call log
+line now calls it: `` `[CodeAgent] Tool: ${toolName} ${formatToolCallArgs(toolArgs)}` ``.
+
+The 500-char per-value truncation is deliberately more generous than the
+200-char precedent used elsewhere for token-budget-constrained summaries —
+this is a human-inspects-on-demand log view, not a context-compaction path.
+
+---
+
+## Bug Fixes
+
+### Chat mode's persona prefix could leak onto Code mode's log lines
+
+**Symptom:** In an embedding app that runs Chat mode and Code mode in the
+same long-lived process (e.g. Jivam's persistent background service), Code
+mode's log lines could show a stale `[PersonaName]` prefix instead of the
+expected `[CodeAgent]` tag, breaking any downstream log-line parser that
+assumes `[CodeAgent]` leads the message.
+
+**Root cause:** `logger`'s persona context is a process-wide singleton that
+Chat mode sets (to prefix its own log lines with the active persona's name)
+but never resets. Code mode has no persona concept, so if a Chat-mode
+conversation had run earlier in the same process, its persona context stuck
+around and bled into Code mode's log output.
+
+**Fix:** `CodeAgent.chat()` now calls `logger.setPersonaContext(null)` at
+the start of every run, clearing any stale persona context before Code
+mode's own log lines are written.
+
+---
+
+## Files Changed
+
+| File | Change |
+|------|--------|
+| `src/utils/logger.ts` | New `formatToolCallArgs()` — renders tool-call args as a single-line JSON blob, truncating string values >500 chars and capping total output at 2000 chars |
+| `src/code/agent.ts` | Tool-call log line now includes `formatToolCallArgs(toolArgs)`; `chat()` resets persona context (`logger.setPersonaContext(null)`) at the start of every run |
+
+---
+
+## Upgrade
+
+```bash
+npm install -g jiva-core@0.3.51
+```
+
+No breaking changes. No config or schema changes.

--- a/docs/release_notes/v0.3.52.md
+++ b/docs/release_notes/v0.3.52.md
@@ -15,7 +15,10 @@ generically. Also replaces the argument truncator with a recursive version
 so nested MCP tool schemas can't produce invalid JSON in the log. Also
 fixes a real, longstanding bug (present since v0.3.41) where a batch of
 parallel tool calls could get left half-answered, causing frequent, hard
-API failures mid-run in both Code and Chat mode.
+API failures mid-run in both Code and Chat mode. A second, separate source
+of the same API failure — in-loop context compaction splitting a tool call
+away from its result — is also fixed, alongside a higher, now-configurable
+compaction threshold.
 
 ---
 
@@ -46,6 +49,33 @@ answered before the next request goes out.
 
 ---
 
+### Context compaction could orphan a tool_call from its result
+
+**Symptom:** A separate cause of the same `invalid_tool_messages` family of
+API failures above — `"tool message tool_call_id 'X' does not match any
+tool call in the preceding assistant messages"` — surfaced in Code mode
+specifically on wide parallel tool-call batches.
+
+**Root cause:** `CodeAgent`'s in-loop compaction (`compactInLoopMessages`)
+kept the last 10 *messages* verbatim and summarised everything before that
+away — a raw positional cut with no awareness of where a tool-call/
+tool-result boundary fell. A parallel batch wider than 10 messages could
+straddle that cut: the assistant message declaring the calls got
+summarised away while some of its own trailing tool-result messages
+survived in the kept tail, orphaning them.
+
+**Fix:** Compaction now groups messages into "rounds" (an assistant/user
+message plus the tool-result messages immediately following it,
+`src/code/rounds.ts`) and always cuts on round boundaries, never mid-round
+— works the same whether or not the assistant message carries a
+structured `tool_calls` array (i.e. also correct for Harmony-mode
+history). As a second line of defence, a new `ensureToolResultPairing()`
+(`src/models/harmony.ts`) runs immediately before every model call in both
+CodeAgent and WorkerAgent, silently repairing (and logging) any orphaned
+or unanswered tool call that slips through regardless of cause.
+
+---
+
 ## New Features
 
 ### Chat mode tool-call argument logging
@@ -63,6 +93,25 @@ available). No per-tool-name special-casing was needed — because Chat mode
 routes every tool call, including filesystem operations, through
 `mcpManager.getClient()`, this single change covers every MCP server's
 tools.
+
+### Configurable compaction threshold, raised default
+
+`CodeAgent`'s in-loop compaction fired once the prompt exceeded a fixed
+90,000-token threshold, and — separately — could only ever fire once per
+`chat()` turn, no matter how many iterations followed. That once-per-turn
+cap meant the threshold needed generous headroom to survive whatever a
+long tool-heavy turn (up to `maxIterations`, default 50) might add
+afterwards with no further compaction possible.
+
+Compaction can now re-trigger later in the same turn once growth crosses
+the threshold again (`compactedThisIteration`, reset every iteration
+instead of once per turn). With that safety net in place, the default is
+raised to 100,000 tokens (~78% of a 128K context window, matching
+`DualAgent`'s existing equivalent default). It's also now overridable —
+via `codeMode.compactionThreshold` in jiva config for the CLI, or
+`JIVA_CODE_COMPACTION_THRESHOLD` for the HTTP interface — for models with
+a larger context window. Set to `0` to disable in-loop compaction
+entirely.
 
 ### Recursive argument truncation
 
@@ -89,8 +138,13 @@ before serialization instead of by slicing the serialized string.
 
 | File | Change |
 |------|--------|
-| `src/core/worker-agent.ts` | Tool-call log line now includes `formatToolCallArgs(args)`; log call moved after argument parsing. Tool-call loop now indexed and stubs tool-result responses for calls abandoned by the doom-loop break |
-| `src/code/agent.ts` | Tool-call loop now indexed and stubs tool-result responses for calls abandoned by the doom-loop or excessive-reads-nudge break |
+| `src/core/worker-agent.ts` | Tool-call log line now includes `formatToolCallArgs(args)`; log call moved after argument parsing. Tool-call loop now indexed and stubs tool-result responses for calls abandoned by the doom-loop break; `ensureToolResultPairing()` runs before every model call |
+| `src/code/agent.ts` | Tool-call loop now indexed and stubs tool-result responses for calls abandoned by the doom-loop or excessive-reads-nudge break; `ensureToolResultPairing()` runs before every model call; compaction rewritten to cut on round boundaries (`compactInLoopMessages`); compaction can re-trigger per iteration (`compactedThisIteration`); default threshold raised 90,000 → 100,000, overridable via `compactionThreshold` |
+| `src/code/rounds.ts` | **New** — `groupMessagesIntoRounds()` / `splitRoundsForCompaction()`, the round-boundary grouping logic that `compactInLoopMessages` now cuts on |
+| `src/models/harmony.ts` | New `ensureToolResultPairing()` — repairs orphaned/unanswered tool calls in message history, logging when it does |
+| `src/core/config.ts` | New optional `codeMode.compactionThreshold` field |
+| `src/interfaces/cli/index.ts` | Passes `codeModeConfig.compactionThreshold` through to `CodeAgent` |
+| `src/interfaces/http/session-manager.ts` | New `JIVA_CODE_COMPACTION_THRESHOLD` env var passed through to `CodeAgent` |
 | `src/utils/logger.ts` | New recursive `truncateValue()` (depth-aware string/array/object truncation) replaces the old top-level-only truncation + fixed-length JSON-string cut; `formatToolCallArgs()` now truncates before serializing instead of after |
 
 ---
@@ -101,4 +155,7 @@ before serialization instead of by slicing the serialized string.
 npm install -g jiva-core@0.3.52
 ```
 
-No breaking changes. No config or schema changes.
+No breaking changes. One new optional config field: `codeMode.compactionThreshold`
+(jiva config) / `JIVA_CODE_COMPACTION_THRESHOLD` (HTTP interface env var) —
+existing configs are unaffected and pick up the new 100,000-token default
+automatically.

--- a/docs/release_notes/v0.3.52.md
+++ b/docs/release_notes/v0.3.52.md
@@ -12,7 +12,37 @@ never got carried over to Chat mode. Since Chat mode has no "built-in vs
 MCP" distinction (every tool, including filesystem ops, goes through
 `mcpManager.getClient()`), this one fix covers every MCP server's tools
 generically. Also replaces the argument truncator with a recursive version
-so nested MCP tool schemas can't produce invalid JSON in the log.
+so nested MCP tool schemas can't produce invalid JSON in the log. Also
+fixes a real, longstanding bug (present since v0.3.41) where a batch of
+parallel tool calls could get left half-answered, causing frequent, hard
+API failures mid-run in both Code and Chat mode.
+
+---
+
+## Bug Fixes
+
+### Incomplete parallel tool-call groups causing hard API failures
+
+**Before:** `CodeAgent` and `WorkerAgent`'s tool-execution loops iterate
+`response.toolCalls`, which can hold several calls the model issued
+together as one parallel batch. Both had `break` statements (doom-loop
+detection in both; CodeAgent's "15 consecutive read_file calls" nudge) that
+exited the loop early without ever sending a tool-result message for the
+call that triggered the break, or for any calls still queued later in the
+same batch. The next API call then sent a conversation history with a
+partially-answered `tool_calls` array, which providers that validate
+parallel tool-calling strictly reject outright with `invalid_tool_messages:
+incomplete parallel tool-call group: tool call 'X' has no tool response`
+— and every retry hit the identical error, since the retry logic re-sent
+the same malformed history without fixing the actual gap. In practice this
+surfaced as a Deep Run that worked fine for a while, then collapsed with
+repeated `API error (400)` and produced nothing.
+
+**After:** Both loops now push a stub `tool`-role response (via the
+existing `formatToolResult()` helper) for the triggering call and every
+call still queued after it in the batch before pushing the nudge/stop
+message and breaking — every `tool_call_id` the model issues is always
+answered before the next request goes out.
 
 ---
 
@@ -59,7 +89,8 @@ before serialization instead of by slicing the serialized string.
 
 | File | Change |
 |------|--------|
-| `src/core/worker-agent.ts` | Tool-call log line now includes `formatToolCallArgs(args)`; log call moved after argument parsing |
+| `src/core/worker-agent.ts` | Tool-call log line now includes `formatToolCallArgs(args)`; log call moved after argument parsing. Tool-call loop now indexed and stubs tool-result responses for calls abandoned by the doom-loop break |
+| `src/code/agent.ts` | Tool-call loop now indexed and stubs tool-result responses for calls abandoned by the doom-loop or excessive-reads-nudge break |
 | `src/utils/logger.ts` | New recursive `truncateValue()` (depth-aware string/array/object truncation) replaces the old top-level-only truncation + fixed-length JSON-string cut; `formatToolCallArgs()` now truncates before serializing instead of after |
 
 ---

--- a/docs/release_notes/v0.3.52.md
+++ b/docs/release_notes/v0.3.52.md
@@ -1,0 +1,73 @@
+# Jiva v0.3.52 — Chat-Mode Tool-Call Logging & Recursive Argument Truncation
+
+**Release Date:** July 29, 2026
+
+---
+
+## Summary
+
+Chat mode's `WorkerAgent` now logs tool-call arguments the same way Code
+mode's `CodeAgent` has since v0.3.51 — closing a gap where the v0.3.51 fix
+never got carried over to Chat mode. Since Chat mode has no "built-in vs
+MCP" distinction (every tool, including filesystem ops, goes through
+`mcpManager.getClient()`), this one fix covers every MCP server's tools
+generically. Also replaces the argument truncator with a recursive version
+so nested MCP tool schemas can't produce invalid JSON in the log.
+
+---
+
+## New Features
+
+### Chat mode tool-call argument logging
+
+**Before:** `WorkerAgent`'s per-tool-call log line was a bare
+`  [Worker] Tool: <name>` with no arguments at all, unlike `CodeAgent`,
+which has logged full args since v0.3.51.
+
+**After:** `src/core/worker-agent.ts`'s log line now matches CodeAgent's
+shape: `` `  [Worker] Tool: ${toolName} ${formatToolCallArgs(args)}` ``,
+using the same `formatToolCallArgs()` helper from `src/utils/logger.ts`.
+The log call was also moved to after `toolCall.function.arguments` is
+parsed (it previously ran before parsing, when `args` wasn't yet
+available). No per-tool-name special-casing was needed — because Chat mode
+routes every tool call, including filesystem operations, through
+`mcpManager.getClient()`, this single change covers every MCP server's
+tools.
+
+### Recursive argument truncation
+
+**Before:** `formatToolCallArgs()` only truncated string values at the
+top level of the arguments object, then hard-cut the final serialized JSON
+string at a fixed 2000-character length as a fallback. That was safe for
+today's flat, top-level built-in tool arguments, but a deeply nested MCP
+tool schema could have its structure cut off mid-token by the length-based
+fallback, producing invalid JSON in the log.
+
+**After:** `src/utils/logger.ts` replaces the shallow truncation with a new
+recursive `truncateValue()` that walks objects and arrays at any nesting
+depth, truncating string leaves wherever they occur (still 500 chars per
+value), capping arrays at 20 entries and objects at 50 keys (each with a
+`...(N more items/keys)` marker), and bailing out at depth 10 with
+`'[max depth exceeded]'`. `formatToolCallArgs()` now simply returns
+`JSON.stringify(truncateValue(args))` — the result is always valid JSON
+regardless of how deeply nested the input is, since truncation happens
+before serialization instead of by slicing the serialized string.
+
+---
+
+## Files Changed
+
+| File | Change |
+|------|--------|
+| `src/core/worker-agent.ts` | Tool-call log line now includes `formatToolCallArgs(args)`; log call moved after argument parsing |
+| `src/utils/logger.ts` | New recursive `truncateValue()` (depth-aware string/array/object truncation) replaces the old top-level-only truncation + fixed-length JSON-string cut; `formatToolCallArgs()` now truncates before serializing instead of after |
+
+---
+
+## Upgrade
+
+```bash
+npm install -g jiva-core@0.3.52
+```
+
+No breaking changes. No config or schema changes.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "jiva-core",
-  "version": "0.3.51",
+  "version": "0.3.52",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "jiva-core",
-      "version": "0.3.51",
+      "version": "0.3.52",
       "license": "MIT",
       "dependencies": {
         "@google-cloud/storage": "^7.0.0",

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
   },
   "type": "module",
   "scripts": {
+    "test": "tsx --test src/**/*.test.ts",
     "test:web": "playwright test",
     "build": "tsc && node scripts/copy-benchmark-assets.mjs",
     "dev": "tsx src/interfaces/cli/index.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jiva-core",
-  "version": "0.3.51",
+  "version": "0.3.52",
   "description": "Versatile autonomous AI agent with three-agent architecture (Manager, Worker, Client) powered by gpt-oss-120b. Adaptive validation, full MCP support, and intelligent quality control.",
   "main": "dist/index.js",
   "bin": {

--- a/src/code/agent.ts
+++ b/src/code/agent.ts
@@ -1008,8 +1008,21 @@ ${directive ? `\n${directive}` : ''}`;
         break;
       }
 
-      // Execute tool calls
-      for (const toolCall of response.toolCalls) {
+      // Execute tool calls. Indexed, not for...of — the doom-loop and
+      // excessive-reads branches below need to know which tool calls in
+      // this batch (response.toolCalls can hold several, issued as one
+      // parallel group) still haven't been answered when they decide to
+      // bail out early, so every one of them can still get a stub tool
+      // result before we stop. Skipping that was a real bug: providers that
+      // validate parallel tool-calling strictly reject the *next* request
+      // outright with "incomplete parallel tool-call group: tool call 'X'
+      // has no tool response" the moment any tool_call_id from an assistant
+      // turn is missing its matching tool message — which silently broke
+      // every session that happened to hit a doom-loop or 15-consecutive-
+      // reads nudge in the middle of a multi-call batch, not just at the
+      // end of one.
+      for (let toolCallIndex = 0; toolCallIndex < response.toolCalls.length; toolCallIndex++) {
+        const toolCall = response.toolCalls[toolCallIndex];
         const toolName = toolCall.function.name;
         let toolArgs: Record<string, unknown> = {};
         try {
@@ -1035,6 +1048,13 @@ ${directive ? `\n${directive}` : ''}`;
           recentCalls.every((c) => c === recentCalls[0])
         ) {
           logger.warn(`[CodeAgent] Doom loop detected for tool: ${toolName}`);
+          // This call (and anything still queued after it in the same
+          // batch) never gets executed — but every tool_call_id the model
+          // issued still needs a tool-role response before the next
+          // non-tool message, or the request becomes malformed.
+          for (const skipped of response.toolCalls.slice(toolCallIndex)) {
+            messages.push(formatToolResult(skipped.id, skipped.function.name, 'Skipped — doom loop detected, see the instruction that follows.'));
+          }
           messages.push({
             role: 'user',
             content: `STOP: You are calling \`${toolName}\` with the same arguments repeatedly. This action is not making progress. Stop and reassess your approach — try a different strategy or report what is blocking you.`,
@@ -1098,6 +1118,13 @@ ${directive ? `\n${directive}` : ''}`;
         if (consecutiveReadCount >= MAX_CONSECUTIVE_READS) {
           logger.warn(`[CodeAgent] ${consecutiveReadCount} consecutive read_file calls without edits — nudging model to act`);
           consecutiveReadCount = 0;
+          // This tool call already got its real result above — but any
+          // calls still queued after it in the same batch won't run, and
+          // still need a stub tool response for the same reason as the
+          // doom-loop case above.
+          for (const skipped of response.toolCalls.slice(toolCallIndex + 1)) {
+            messages.push(formatToolResult(skipped.id, skipped.function.name, 'Skipped — see the instruction that follows.'));
+          }
           messages.push({
             role: 'user',
             content:

--- a/src/code/agent.ts
+++ b/src/code/agent.ts
@@ -8,9 +8,10 @@
 import { ModelOrchestrator } from '../models/orchestrator.js';
 import { WorkspaceManager } from '../core/workspace.js';
 import { ConversationManager } from '../core/conversation-manager.js';
-import { formatToolResult } from '../models/harmony.js';
+import { formatToolResult, ensureToolResultPairing } from '../models/harmony.js';
 import type { Message, Tool } from '../models/base.js';
 import { logger, formatToolCallArgs } from '../utils/logger.js';
+import { splitRoundsForCompaction } from './rounds.js';
 import type { PersonaManager } from '../personas/persona-manager.js';
 import type { MCPServerManager } from '../mcp/server-manager.js';
 import { LspManager } from './lsp/manager.js';
@@ -115,7 +116,12 @@ export interface CodeAgentConfig {
    * Token count at which in-loop context compaction is triggered.
    * When promptTokens in a response exceeds this threshold, the message history
    * is condensed to free up context window space.
-   * Default: 90000 (safe for a 128K context model, leaving ~38K for output).
+   * Default: 100000 (≈78% of a 128K context model, matching DualAgent's
+   * equivalent default — see `DEFAULT_COMPACTION_THRESHOLD` below for the full
+   * reasoning). Override for models with a larger context window: sourced from
+   * `codeMode.compactionThreshold` in jiva config, one absolute token count per
+   * installation today (no per-model context-window field exists yet to compute
+   * this automatically).
    * Set to 0 to disable in-loop compaction.
    */
   compactionThreshold?: number;
@@ -143,8 +149,22 @@ const DOOM_LOOP_THRESHOLD = 3;
 /** Max consecutive read_file calls before injecting an "act, don't just read" nudge. */
 const MAX_CONSECUTIVE_READS = 15;
 const CODE_MODE_INDICATOR = '[CODE MODE]';
-// Default token threshold for in-loop compaction (90K leaves ~38K headroom in a 128K model)
-const DEFAULT_COMPACTION_THRESHOLD = 90_000;
+// Default token threshold for in-loop compaction, assuming a 128K context model
+// (the same assumption DualAgent's equivalent default already makes elsewhere in
+// this codebase — see `src/core/dual-agent.ts`). Previously 90_000 (~70%, ~38K
+// headroom); raised to match DualAgent's 100_000 (~78%, ~28K headroom) now that
+// compaction can re-trigger later in the same turn (see `compactedThisIteration`
+// above) instead of firing only once per chat() call. That was the main reason
+// the extra headroom existed: after the single compaction, a long tool-heavy
+// turn (up to maxIterations, default 50) could keep growing the context
+// unchecked for the rest of the turn, so a bigger safety margin was needed to
+// absorb that unbounded growth. With re-triggering, the required headroom is
+// just enough for one round's growth (the batch that pushed tokens over the
+// threshold, plus the compaction summary call's own overhead) before the next
+// check catches it again — 28K comfortably covers that in normal use.
+// Override via `codeMode.compactionThreshold` in jiva config for models with a
+// larger context window.
+const DEFAULT_COMPACTION_THRESHOLD = 100_000;
 
 /**
  * Below this output-token budget, the skeleton-first workflow becomes
@@ -429,6 +449,7 @@ ${directive ? `\n${directive}` : ''}`;
 
       let response;
       try {
+        messages.splice(0, messages.length, ...ensureToolResultPairing(messages));
         response = await this.orchestrator.chatWithFallback({
           messages,
           tools: isLast ? [] : readOnlyDefs,
@@ -544,9 +565,6 @@ ${directive ? `\n${directive}` : ''}`;
     let continueInjected = false;
     let wrapUpInjected = false;
 
-    // In-loop compaction flag — only compact once per chat() turn to avoid thrashing
-    let compactedThisTurn = false;
-
     // Reset stop flag at the start of each chat() so the agent is immediately reusable
     this._stopped = false;
 
@@ -558,6 +576,16 @@ ${directive ? `\n${directive}` : ''}`;
         stopReason = 'stopped';
         break;
       }
+
+      // In-loop compaction flag — guards against compacting twice for the SAME
+      // response (the normal threshold check below and the forced length-starved
+      // check further down are structurally reachable from the same iteration).
+      // Reset every iteration (not once per chat() turn) so compaction can fire
+      // again later in a long-running turn once growth re-crosses the threshold —
+      // a turn can run up to maxIterations (default 50), and tool-heavy work can
+      // easily rebuild a large context after a single earlier compaction.
+      let compactedThisIteration = false;
+
       iterations = i + 1;
       logger.debug(`[CodeAgent] Iteration ${iterations}/${this.maxIterations}`);
 
@@ -598,6 +626,7 @@ ${directive ? `\n${directive}` : ''}`;
 
       let response;
       try {
+        messages.splice(0, messages.length, ...ensureToolResultPairing(messages));
         response = await this.orchestrator.chatWithFallback({
           messages,
           // Strip tools in the final phase so the model is forced to produce a text response
@@ -870,8 +899,10 @@ ${directive ? `\n${directive}` : ''}`;
 
       // ── In-loop context compaction ──────────────────────────────────────────
       // Check if we're approaching the context window limit and compact if needed.
-      // Triggered once per turn (compactedThisTurn flag) to avoid thrashing.
-      // Only runs when: threshold > 0, orchestrator available, not already compacted.
+      // Triggered at most once per iteration (compactedThisIteration flag), but can
+      // fire again on a later iteration once growth re-crosses the threshold.
+      // Only runs when: threshold > 0, orchestrator available, not already compacted
+      // this iteration.
       //
       // Deliberately NOT gated on the response having tool calls: a model that's
       // starved for completion-token budget by a bloated prompt (spending its
@@ -887,13 +918,13 @@ ${directive ? `\n${directive}` : ''}`;
       if (
         this.compactionThreshold > 0 &&
         promptTokens > this.compactionThreshold &&
-        !compactedThisTurn &&
+        !compactedThisIteration &&
         this.conversationManager
       ) {
         logger.warn(
           `[CodeAgent] Context at ${promptTokens} tokens (threshold: ${this.compactionThreshold}) — compacting in-loop history`,
         );
-        compactedThisTurn = true;
+        compactedThisIteration = true;
         try {
           const compacted = await this.compactInLoopMessages(messages, systemPrompt);
           // Replace messages in-place, preserving the system prompt at index 0
@@ -956,12 +987,12 @@ ${directive ? `\n${directive}` : ''}`;
           //   2. Anything else — the model is genuinely stuck/confused; a nudge is the
           //      right tool.
           const isLengthStarved = response.finishReason === 'length';
-          if (isLengthStarved && !compactedThisTurn && this.conversationManager) {
+          if (isLengthStarved && !compactedThisIteration && this.conversationManager) {
             logger.warn(
               '[CodeAgent] Empty response with finishReason=length — model ran out of completion budget ' +
               'while thinking. Forcing context compaction instead of a text nudge.',
             );
-            compactedThisTurn = true;
+            compactedThisIteration = true;
             try {
               const compacted = await this.compactInLoopMessages(messages, systemPrompt);
               messages.splice(0, messages.length, ...compacted);
@@ -1185,28 +1216,39 @@ ${directive ? `\n${directive}` : ''}`;
    *
    * Strategy (mirrors opencode's compaction approach):
    * 1. Keep the system/developer prompt (index 0).
-   * 2. Identify tool-call + tool-result pairs in the middle of the conversation.
+   * 2. Group the rest into rounds (a non-tool message + its immediately-following
+   *    run of tool-result messages) via `splitRoundsForCompaction`, and cut strictly
+   *    on round boundaries — never mid-round — so a tool_call can never be summarized
+   *    away while the tool_result answering it survives in the kept tail, or vice
+   *    versa. This holds regardless of message shape (standard tool-calling or
+   *    Harmony mode) since the grouping only inspects `role`, not `tool_calls`.
    * 3. Replace bulky tool results with compact "[result summarised]" placeholders.
    * 4. If a ConversationManager is available, generate a structured summary of
    *    the condensed middle section and inject it as a single context message.
    *
-   * This runs in-loop (mid-turn) so we only compact once per chat() invocation
-   * to avoid thrashing (controlled by the `compactedThisTurn` flag in the caller).
+   * This runs in-loop (mid-turn); the caller (`compactedThisIteration`) only
+   * guards against compacting twice for the same response, not against
+   * compacting again on a later iteration once growth re-crosses the threshold.
    */
   private async compactInLoopMessages(messages: Message[], systemPrompt: string): Promise<Message[]> {
-    // Always keep: [0] system/developer prompt + last KEEP_RECENT messages
-    const KEEP_RECENT = 10;
+    // Always keep: [0] system/developer prompt + last KEEP_RECENT_ROUNDS rounds.
+    // A round count, not a raw message count — a single wide parallel tool-call
+    // batch can itself contain more messages than any small fixed budget, so
+    // counting rounds (not messages) is what keeps the cut round-boundary-safe
+    // without needing a backward-walk correction pass.
+    const KEEP_RECENT_ROUNDS = 5;
 
-    if (messages.length <= KEEP_RECENT + 1) {
+    const { recentMessages, middleMessages } = splitRoundsForCompaction(
+      messages.slice(1), // messages[0] is always the system/developer prompt
+      KEEP_RECENT_ROUNDS,
+    );
+
+    if (middleMessages.length === 0) {
       // Nothing meaningful to compact
       return messages;
     }
 
     const systemMsg: Message = { role: 'developer' as any, content: systemPrompt };
-    const recentMessages = messages.slice(-KEEP_RECENT);
-    const middleMessages = messages.slice(1, -KEEP_RECENT);
-
-    if (middleMessages.length === 0) return messages;
 
     // Build a structured compaction summary using the opencode template
     const conversationText = middleMessages

--- a/src/code/rounds.test.ts
+++ b/src/code/rounds.test.ts
@@ -1,0 +1,107 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import type { Message, ToolCall } from '../models/base.js';
+import { groupMessagesIntoRounds, splitRoundsForCompaction } from './rounds.js';
+
+function toolCall(id: string, name = 'grep'): ToolCall {
+  return { id, type: 'function', function: { name, arguments: '{}' } };
+}
+
+function toolResult(id: string, name = 'grep'): Message {
+  return { role: 'tool', name, tool_call_id: id, content: `result for ${id}` };
+}
+
+test('groupMessagesIntoRounds: reproduces the reported failure shape without splitting the round', () => {
+  // An assistant message issuing 6 parallel tool_calls (functions.grep:1..6),
+  // followed by their 6 tool-result messages — wide enough that the old
+  // KEEP_RECENT=10 raw-message slice would land mid-round.
+  const ids = Array.from({ length: 6 }, (_, i) => `functions.grep:${i + 1}`);
+  const messages: Message[] = [
+    { role: 'developer', content: 'system prompt' },
+    { role: 'user', content: 'find all usages of foo' },
+    { role: 'assistant', content: null, tool_calls: ids.map((id) => toolCall(id)) },
+    ...ids.map((id) => toolResult(id)),
+  ];
+
+  const rounds = groupMessagesIntoRounds(messages);
+
+  // developer, user, and the assistant+6-tool-results round are 3 distinct rounds.
+  assert.equal(rounds.length, 3);
+  const toolRound = rounds[2];
+  assert.equal(toolRound.length, 7); // 1 assistant + 6 tool results
+  assert.equal(toolRound[0].role, 'assistant');
+  assert.ok(toolRound.slice(1).every((m) => m.role === 'tool'));
+});
+
+test('groupMessagesIntoRounds: N alternating turns produce N rounds', () => {
+  const messages: Message[] = [];
+  for (let i = 0; i < 4; i++) {
+    messages.push({ role: 'user', content: `turn ${i}` });
+    messages.push({ role: 'assistant', content: null, tool_calls: [toolCall(`id-${i}`)] });
+    messages.push(toolResult(`id-${i}`));
+  }
+  const rounds = groupMessagesIntoRounds(messages);
+  // Each iteration pushes a user round (no trailing tool messages) and an
+  // assistant+tool-result round, so 4 iterations produce 8 rounds.
+  assert.equal(rounds.length, 8);
+});
+
+test('groupMessagesIntoRounds: Harmony-mode assistant message (no tool_calls field) still groups with its tool results', () => {
+  const messages: Message[] = [
+    { role: 'user', content: 'do something' },
+    { role: 'assistant', content: '<|call|>functions.bash<|call|>echo hi' }, // rawHarmony — no tool_calls field
+    toolResult('bash-1', 'bash'),
+    toolResult('bash-2', 'bash'),
+  ];
+  const rounds = groupMessagesIntoRounds(messages);
+  assert.equal(rounds.length, 2);
+  assert.equal(rounds[1].length, 3);
+  assert.equal(rounds[1][0].role, 'assistant');
+});
+
+test('groupMessagesIntoRounds: a round with zero trailing tool messages is still its own round', () => {
+  const messages: Message[] = [
+    { role: 'user', content: 'hello' },
+    { role: 'assistant', content: 'hi there' },
+  ];
+  const rounds = groupMessagesIntoRounds(messages);
+  assert.equal(rounds.length, 2);
+  assert.deepEqual(rounds, [[messages[0]], [messages[1]]]);
+});
+
+test('splitRoundsForCompaction: never lets recentMessages start with an orphaned tool message', () => {
+  const ids = Array.from({ length: 6 }, (_, i) => `functions.grep:${i + 1}`);
+  const messages: Message[] = [
+    { role: 'user', content: 'task 1' },
+    { role: 'assistant', content: 'ok 1' },
+    { role: 'user', content: 'task 2' },
+    { role: 'assistant', content: null, tool_calls: ids.map((id) => toolCall(id)) },
+    ...ids.map((id) => toolResult(id)),
+    { role: 'user', content: 'task 3' },
+    { role: 'assistant', content: 'ok 3' },
+  ];
+
+  const { recentMessages, middleMessages } = splitRoundsForCompaction(messages, 2);
+
+  // With keepRounds=2, only the last 2 rounds ("task 3" round pair) are kept;
+  // the wide tool-call round must be fully in the summarized-away middle,
+  // never split.
+  assert.ok(middleMessages.length > 0);
+  if (recentMessages.length > 0) {
+    assert.notEqual(recentMessages[0].role, 'tool');
+  }
+  // The 6-call round must appear entirely on one side.
+  const middleHasAnyToolMsg = middleMessages.some((m) => m.role === 'tool');
+  const recentHasAnyToolMsg = recentMessages.some((m) => m.role === 'tool');
+  assert.ok(!(middleHasAnyToolMsg && recentHasAnyToolMsg));
+});
+
+test('splitRoundsForCompaction: fewer rounds than keepRounds keeps everything, summarizes nothing', () => {
+  const messages: Message[] = [
+    { role: 'user', content: 'hi' },
+    { role: 'assistant', content: 'hello' },
+  ];
+  const { recentMessages, middleMessages } = splitRoundsForCompaction(messages, 5);
+  assert.equal(middleMessages.length, 0);
+  assert.equal(recentMessages.length, 2);
+});

--- a/src/code/rounds.ts
+++ b/src/code/rounds.ts
@@ -1,0 +1,47 @@
+/**
+ * Structural grouping of a conversation's message array into "rounds", used to
+ * keep context-compaction boundaries from splitting a tool_call away from the
+ * tool_result message(s) that answer it.
+ */
+
+import type { Message } from '../models/base.js';
+
+/**
+ * One "round" = a non-tool message plus the maximal contiguous run of
+ * role:'tool' messages immediately following it. Grouping is purely
+ * structural (role-adjacency), not id-based, so it works identically whether
+ * the assistant message carries a structured `tool_calls` array (standard
+ * tool-calling mode) or not (Harmony mode, where tool_calls exist only
+ * in-memory in the caller — see the `Message.tool_calls` doc comment).
+ */
+export function groupMessagesIntoRounds(messages: Message[]): Message[][] {
+  const rounds: Message[][] = [];
+  for (const msg of messages) {
+    if (msg.role === 'tool' && rounds.length > 0) {
+      rounds[rounds.length - 1].push(msg);
+    } else {
+      rounds.push([msg]);
+    }
+  }
+  return rounds;
+}
+
+/**
+ * Splits messages into a "keep verbatim" tail and a "summarize away" middle,
+ * cutting strictly on round boundaries so a tool_call/tool_result pair can
+ * never be split across the two halves — regardless of how wide a single
+ * round is (e.g. a large parallel tool-call batch), since the cut is chosen
+ * by round count, not by a fixed message-count budget.
+ */
+export function splitRoundsForCompaction(
+  messages: Message[],
+  keepRounds: number,
+): { recentMessages: Message[]; middleMessages: Message[] } {
+  const rounds = groupMessagesIntoRounds(messages);
+  if (rounds.length <= keepRounds) {
+    return { recentMessages: rounds.flat(), middleMessages: [] };
+  }
+  const recentRounds = rounds.slice(-keepRounds);
+  const middleRounds = rounds.slice(0, -keepRounds);
+  return { recentMessages: recentRounds.flat(), middleMessages: middleRounds.flat() };
+}

--- a/src/core/config.ts
+++ b/src/core/config.ts
@@ -135,6 +135,14 @@ const CodeModeConfigSchema = z.object({
   }).optional(),
   maxIterations: z.number().default(50),
   includeMcp: z.boolean().default(false),
+  /**
+   * Token count at which CodeAgent's in-loop context compaction is triggered.
+   * Defaults to 100000 (CodeAgent's own `DEFAULT_COMPACTION_THRESHOLD`, sized
+   * for a 128K context model). Raise this for models with a larger context
+   * window — e.g. a 200K-context model can comfortably use a higher value.
+   * Set to 0 to disable in-loop compaction entirely.
+   */
+  compactionThreshold: z.number().optional(),
 });
 
 const JivaConfigSchema = z.object({

--- a/src/core/worker-agent.ts
+++ b/src/core/worker-agent.ts
@@ -15,7 +15,7 @@ import { PersonaManager } from '../personas/persona-manager.js';
 import { AgentSpawner } from './agent-spawner.js';
 import { AgentContext } from './types/agent-context.js';
 import { Message, MessageContent, ModelResponse, Tool } from '../models/base.js';
-import { formatToolResult } from '../models/harmony.js';
+import { formatToolResult, ensureToolResultPairing } from '../models/harmony.js';
 import { logger, formatToolCallArgs } from '../utils/logger.js';
 import { OrchestrationLogger, orchestrationLogger } from '../utils/orchestration-logger.js';
 
@@ -363,6 +363,7 @@ Please complete this subtask and report your findings.`,
       let response: ModelResponse;
 
       try {
+        conversationHistory.splice(0, conversationHistory.length, ...ensureToolResultPairing(conversationHistory));
         response = await this.orchestrator.chatWithFallback({
           messages: conversationHistory,
           tools: tools.length > 0 ? tools : undefined,

--- a/src/core/worker-agent.ts
+++ b/src/core/worker-agent.ts
@@ -16,7 +16,7 @@ import { AgentSpawner } from './agent-spawner.js';
 import { AgentContext } from './types/agent-context.js';
 import { Message, MessageContent, ModelResponse, Tool } from '../models/base.js';
 import { formatToolResult } from '../models/harmony.js';
-import { logger } from '../utils/logger.js';
+import { logger, formatToolCallArgs } from '../utils/logger.js';
 import { OrchestrationLogger, orchestrationLogger } from '../utils/orchestration-logger.js';
 
 /** Max consecutive empty responses before breaking out */
@@ -658,12 +658,12 @@ Please complete this subtask and report your findings.`,
 
         for (const toolCall of response.toolCalls) {
           const toolName = toolCall.function.name;
-          logger.info(`  [Worker] Tool: ${toolName}`);
 
           // Parse args outside the try block so the catch block can reference
           // them for the failure signature (circuit breaker key).
           let args: Record<string, any> = {};
           try { args = JSON.parse(toolCall.function.arguments); } catch { /* use empty */ }
+          logger.info(`  [Worker] Tool: ${toolName} ${formatToolCallArgs(args)}`);
           const failureSig = `${toolName}:${JSON.stringify(args)}`;
 
           // Sliding-window doom-loop: only triggers on CONSECUTIVE identical calls

--- a/src/core/worker-agent.ts
+++ b/src/core/worker-agent.ts
@@ -656,7 +656,18 @@ Please complete this subtask and report your findings.`,
       if (response.toolCalls && response.toolCalls.length > 0) {
         logger.info(`  [Worker] Using ${response.toolCalls.length} tool(s)`);
 
-        for (const toolCall of response.toolCalls) {
+        // Indexed, not for...of — response.toolCalls can hold several calls
+        // issued together as one parallel group, and the doom-loop check
+        // below needs to know which of them are still unanswered when it
+        // decides to bail out early, so every one can still get a stub tool
+        // result before the loop stops. Without this, a provider that
+        // validates parallel tool-calling strictly rejects the *next*
+        // request outright with "incomplete parallel tool-call group: tool
+        // call 'X' has no tool response" the moment any tool_call_id from
+        // this turn is missing its matching tool message — the same bug
+        // (and fix) as CodeAgent's tool loop, see src/code/agent.ts.
+        for (let toolCallIndex = 0; toolCallIndex < response.toolCalls.length; toolCallIndex++) {
+          const toolCall = response.toolCalls[toolCallIndex];
           const toolName = toolCall.function.name;
 
           // Parse args outside the try block so the catch block can reference
@@ -675,6 +686,9 @@ Please complete this subtask and report your findings.`,
             recentCalls.every((c) => c === recentCalls[0])
           ) {
             logger.warn(`  [Worker] Doom loop detected for tool: ${toolName} — same call ${DOOM_LOOP_THRESHOLD} times in a row`);
+            for (const skipped of response.toolCalls.slice(toolCallIndex)) {
+              conversationHistory.push(formatToolResult(skipped.id, skipped.function.name, 'Skipped — doom loop detected, see the instruction that follows.'));
+            }
             conversationHistory.push({
               role: 'user',
               content: `STOP: You are calling \`${toolName}\` with the same arguments ${DOOM_LOOP_THRESHOLD} times in a row. This is not making progress. Try a different approach, different arguments, or a different tool to achieve the same goal.`,

--- a/src/interfaces/cli/index.ts
+++ b/src/interfaces/cli/index.ts
@@ -383,6 +383,7 @@ program
           mcpManager: codeMcpServerNames.length > 0 ? mcpManager : undefined,
           mcpServerNames: codeMcpServerNames,
           harness: options.harness === 'evaluator' ? 'evaluator' : undefined,
+          compactionThreshold: codeModeConfig?.compactionThreshold,
         });
 
         const mcpNote = codeMcpServerNames.length > 0 ? ` | MCP: ${codeMcpServerNames.join(', ')}` : '';
@@ -892,6 +893,7 @@ program
           lspEnabled: lspEnabledRun,
           mcpManager: codeMcpServerNamesRun.length > 0 ? mcpManager : undefined,
           mcpServerNames: codeMcpServerNamesRun,
+          compactionThreshold: codeModeConfigRun?.compactionThreshold,
         });
 
         const mcpNoteRun = codeMcpServerNamesRun.length > 0 ? ` | MCP: ${codeMcpServerNamesRun.join(', ')}` : '';

--- a/src/interfaces/http/session-manager.ts
+++ b/src/interfaces/http/session-manager.ts
@@ -324,12 +324,19 @@ export class SessionManager extends EventEmitter {
       if (codeModeEnabled) {
         const { CodeAgent } = await import('../../code/agent.js');
         const lspEnabled = process.env.JIVA_CODE_LSP !== 'false';
+        // Server-level override for models with a larger context window than the
+        // 128K CodeAgent's DEFAULT_COMPACTION_THRESHOLD assumes. Mirrors the
+        // `codeMode.compactionThreshold` jiva-config field the CLI reads, since
+        // this interface sources its per-tenant config from `storageProvider`
+        // rather than a local config.json.
+        const envCompactionThreshold = process.env.JIVA_CODE_COMPACTION_THRESHOLD;
         agent = new CodeAgent({
           orchestrator,
           workspace,
           conversationManager,
           maxIterations: 50,
           lspEnabled,
+          compactionThreshold: envCompactionThreshold ? Number(envCompactionThreshold) : undefined,
         });
         logger.info('[SessionManager] Using CodeAgent (code mode)');
       } else {

--- a/src/models/harmony.test.ts
+++ b/src/models/harmony.test.ts
@@ -1,0 +1,63 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import type { Message, ToolCall } from './base.js';
+import { ensureToolResultPairing, formatToolResult } from './harmony.js';
+
+function toolCall(id: string, name = 'grep'): ToolCall {
+  return { id, type: 'function', function: { name, arguments: '{}' } };
+}
+
+test('ensureToolResultPairing: inserts a stub for a declared call missing its result', () => {
+  const messages: Message[] = [
+    { role: 'user', content: 'task' },
+    { role: 'assistant', content: null, tool_calls: [toolCall('a'), toolCall('b')] },
+    formatToolResult('a', 'grep', 'result a'),
+    { role: 'user', content: 'next turn' },
+  ];
+
+  const repaired = ensureToolResultPairing(messages);
+
+  const toolMsgs = repaired.filter((m) => m.role === 'tool');
+  assert.equal(toolMsgs.length, 2);
+  assert.ok(toolMsgs.some((m) => m.tool_call_id === 'a' && m.content === 'result a'));
+  const stub = toolMsgs.find((m) => m.tool_call_id === 'b');
+  assert.ok(stub, 'expected a synthetic stub for the missing call b');
+  assert.match(String(stub!.content), /orphaned tool call/i);
+});
+
+test('ensureToolResultPairing: drops a tool message with no matching declared call', () => {
+  const messages: Message[] = [
+    { role: 'user', content: 'task' },
+    { role: 'assistant', content: null, tool_calls: [toolCall('a')] },
+    formatToolResult('a', 'grep', 'result a'),
+    formatToolResult('zzz', 'grep', 'orphan result'), // no declared call for this id
+    { role: 'user', content: 'next turn' },
+  ];
+
+  const repaired = ensureToolResultPairing(messages);
+  const toolMsgs = repaired.filter((m) => m.role === 'tool');
+  assert.equal(toolMsgs.length, 1);
+  assert.equal(toolMsgs[0].tool_call_id, 'a');
+});
+
+test('ensureToolResultPairing: Harmony-mode round (no tool_calls field) passes through unchanged', () => {
+  const messages: Message[] = [
+    { role: 'user', content: 'task' },
+    { role: 'assistant', content: '<|call|>functions.bash<|call|>echo hi' }, // rawHarmony, no tool_calls
+    formatToolResult('bash-1', 'bash', 'hi'),
+  ];
+
+  const repaired = ensureToolResultPairing(messages);
+  assert.deepEqual(repaired, messages);
+});
+
+test('ensureToolResultPairing: idempotent on already-valid input', () => {
+  const messages: Message[] = [
+    { role: 'user', content: 'task' },
+    { role: 'assistant', content: null, tool_calls: [toolCall('a')] },
+    formatToolResult('a', 'grep', 'result a'),
+  ];
+  const once = ensureToolResultPairing(messages);
+  const twice = ensureToolResultPairing(once);
+  assert.deepEqual(once, twice);
+});

--- a/src/models/harmony.ts
+++ b/src/models/harmony.ts
@@ -9,6 +9,7 @@
 
 import { logger } from '../utils/logger.js';
 import { ToolCallError } from '../utils/errors.js';
+import type { Message } from './base.js';
 
 export interface HarmonyMessage {
   role: 'system' | 'developer' | 'user' | 'assistant' | 'tool';
@@ -386,4 +387,74 @@ export function formatToolResult(
     tool_call_id: toolCallId,
     content: typeof result === 'string' ? result : JSON.stringify(result, null, 2),
   };
+}
+
+/**
+ * Defense-in-depth repair pass, run immediately before sending messages to the
+ * model. Ensures every tool_call declared by an assistant message has a
+ * matching tool result before the next non-tool message, and drops any tool
+ * result that matches no declared call. Never throws; repairs silently and
+ * logs a warning when it actually changes anything, so regressions stay
+ * observable.
+ *
+ * This is a pure safety net for whatever the primary round-aware compaction
+ * (see `code/rounds.ts`), or any other future history mutation, might still
+ * get wrong — it does not replace the semantically-specific stubs already
+ * added at known early-break sites (doom-loop / excessive-reads nudges),
+ * which produce a more informative placeholder than this generic one can.
+ *
+ * Harmony-mode assistant messages carry no structured `tool_calls` (see the
+ * `Message.tool_calls` doc comment), so per-id verification only applies in
+ * standard tool-calling mode; Harmony rounds are left untouched since there's
+ * no ground truth here to check them against.
+ */
+export function ensureToolResultPairing(messages: Message[]): Message[] {
+  const result: Message[] = [];
+  let repaired = false;
+  // Ids declared by the most recent assistant message's tool_calls that
+  // haven't yet been matched by a tool-result message.
+  let pendingCalls: Map<string, string> | null = null; // id -> tool name
+
+  const flushPending = () => {
+    if (!pendingCalls) return;
+    for (const [id, name] of pendingCalls) {
+      result.push(formatToolResult(id, name, '[No result recorded — orphaned tool call, auto-repaired]'));
+      repaired = true;
+    }
+    pendingCalls = null;
+  };
+
+  for (const msg of messages) {
+    if (msg.role === 'tool') {
+      const id = msg.tool_call_id;
+      if (pendingCalls && id && pendingCalls.has(id)) {
+        pendingCalls.delete(id);
+        result.push(msg);
+      } else if (pendingCalls) {
+        // Doesn't match any currently-open call — orphaned, drop it.
+        repaired = true;
+      } else {
+        // No structured tool_calls being tracked (e.g. a Harmony round) —
+        // can't verify, pass through unchanged.
+        result.push(msg);
+      }
+      continue;
+    }
+
+    // A non-tool message closes out the previous round: any calls still
+    // pending at this point never got answered.
+    flushPending();
+
+    result.push(msg);
+    if (msg.role === 'assistant' && msg.tool_calls && msg.tool_calls.length > 0) {
+      pendingCalls = new Map(msg.tool_calls.map((tc) => [tc.id, tc.function.name]));
+    }
+  }
+  flushPending();
+
+  if (repaired) {
+    logger.warn('[ensureToolResultPairing] Repaired mismatched tool_call/tool_result pairing in message history');
+  }
+
+  return result;
 }

--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -141,7 +141,43 @@ class Logger {
 export const logger = Logger.getInstance();
 
 const MAX_STRING_VALUE_LEN = 500;
-const MAX_TOTAL_LEN = 2000;
+const MAX_ARRAY_LEN = 20;
+const MAX_OBJECT_KEYS = 50;
+const MAX_DEPTH = 10;
+
+/**
+ * Truncates string leaves wherever they occur in a value — at any nesting
+ * depth, not just the top level — and caps array/object sizes, so the
+ * result always serializes to valid JSON. A shallow, top-level-only
+ * truncation followed by slicing the final JSON *string* (the original
+ * approach here) can cut a nested structure mid-token and produce
+ * unparseable output — harmless for today's flat built-in tools, but not
+ * safe once MCP tools (arbitrary, possibly deeply-nested JSON-Schema args)
+ * go through the same formatter.
+ */
+function truncateValue(value: unknown, depth = 0): unknown {
+  if (depth > MAX_DEPTH) return '[max depth exceeded]';
+  if (typeof value === 'string') {
+    return value.length > MAX_STRING_VALUE_LEN
+      ? `${value.slice(0, MAX_STRING_VALUE_LEN)}...(${value.length - MAX_STRING_VALUE_LEN} more chars)`
+      : value;
+  }
+  if (Array.isArray(value)) {
+    const truncated = value.slice(0, MAX_ARRAY_LEN).map((v) => truncateValue(v, depth + 1));
+    if (value.length > MAX_ARRAY_LEN) truncated.push(`...(${value.length - MAX_ARRAY_LEN} more items)`);
+    return truncated;
+  }
+  if (value !== null && typeof value === 'object') {
+    const entries = Object.entries(value as Record<string, unknown>);
+    const result: Record<string, unknown> = {};
+    for (const [k, v] of entries.slice(0, MAX_OBJECT_KEYS)) {
+      result[k] = truncateValue(v, depth + 1);
+    }
+    if (entries.length > MAX_OBJECT_KEYS) result['...'] = `(${entries.length - MAX_OBJECT_KEYS} more keys)`;
+    return result;
+  }
+  return value; // number, boolean, null, undefined
+}
 
 /**
  * Renders tool-call arguments for a log line — a single-line JSON blob,
@@ -149,27 +185,12 @@ const MAX_TOTAL_LEN = 2000;
  * truncation (500 chars) is deliberately more generous than the 200-char
  * precedent used elsewhere for token-budget-constrained summaries (see
  * code/agent.ts) since this is a human-inspects-on-demand view, not a
- * context-compaction one. An overall-length cap is a second safety net for
- * future tools with deeply nested schemas (today's built-in tools are all
- * flat/top-level).
+ * context-compaction one.
  */
 export function formatToolCallArgs(args: Record<string, unknown>): string {
-  const shortened: Record<string, unknown> = {};
-  for (const [key, value] of Object.entries(args)) {
-    if (typeof value === 'string' && value.length > MAX_STRING_VALUE_LEN) {
-      shortened[key] = `${value.slice(0, MAX_STRING_VALUE_LEN)}...(${value.length - MAX_STRING_VALUE_LEN} more chars)`;
-    } else {
-      shortened[key] = value;
-    }
-  }
-  let json: string;
   try {
-    json = JSON.stringify(shortened);
+    return JSON.stringify(truncateValue(args));
   } catch {
     return '{}';
   }
-  if (json.length > MAX_TOTAL_LEN) {
-    json = `${json.slice(0, MAX_TOTAL_LEN)}..."}`;
-  }
-  return json;
 }


### PR DESCRIPTION
# Jiva v0.3.52 — Chat-Mode Tool-Call Logging & Recursive Argument Truncation

**Release Date:** July 29, 2026

---

## Summary

Chat mode's `WorkerAgent` now logs tool-call arguments the same way Code
mode's `CodeAgent` has since v0.3.51 — closing a gap where the v0.3.51 fix
never got carried over to Chat mode. Since Chat mode has no "built-in vs
MCP" distinction (every tool, including filesystem ops, goes through
`mcpManager.getClient()`), this one fix covers every MCP server's tools
generically. Also replaces the argument truncator with a recursive version
so nested MCP tool schemas can't produce invalid JSON in the log. Also
fixes a real, longstanding bug (present since v0.3.41) where a batch of
parallel tool calls could get left half-answered, causing frequent, hard
API failures mid-run in both Code and Chat mode. A second, separate source
of the same API failure — in-loop context compaction splitting a tool call
away from its result — is also fixed, alongside a higher, now-configurable
compaction threshold.

---

## Bug Fixes

### Incomplete parallel tool-call groups causing hard API failures

**Before:** `CodeAgent` and `WorkerAgent`'s tool-execution loops iterate
`response.toolCalls`, which can hold several calls the model issued
together as one parallel batch. Both had `break` statements (doom-loop
detection in both; CodeAgent's "15 consecutive read_file calls" nudge) that
exited the loop early without ever sending a tool-result message for the
call that triggered the break, or for any calls still queued later in the
same batch. The next API call then sent a conversation history with a
partially-answered `tool_calls` array, which providers that validate
parallel tool-calling strictly reject outright with `invalid_tool_messages:
incomplete parallel tool-call group: tool call 'X' has no tool response`
— and every retry hit the identical error, since the retry logic re-sent
the same malformed history without fixing the actual gap. In practice this
surfaced as a Deep Run that worked fine for a while, then collapsed with
repeated `API error (400)` and produced nothing.

**After:** Both loops now push a stub `tool`-role response (via the
existing `formatToolResult()` helper) for the triggering call and every
call still queued after it in the batch before pushing the nudge/stop
message and breaking — every `tool_call_id` the model issues is always
answered before the next request goes out.

---

### Context compaction could orphan a tool_call from its result

**Symptom:** A separate cause of the same `invalid_tool_messages` family of
API failures above — `"tool message tool_call_id 'X' does not match any
tool call in the preceding assistant messages"` — surfaced in Code mode
specifically on wide parallel tool-call batches.

**Root cause:** `CodeAgent`'s in-loop compaction (`compactInLoopMessages`)
kept the last 10 *messages* verbatim and summarised everything before that
away — a raw positional cut with no awareness of where a tool-call/
tool-result boundary fell. A parallel batch wider than 10 messages could
straddle that cut: the assistant message declaring the calls got
summarised away while some of its own trailing tool-result messages
survived in the kept tail, orphaning them.

**Fix:** Compaction now groups messages into "rounds" (an assistant/user
message plus the tool-result messages immediately following it,
`src/code/rounds.ts`) and always cuts on round boundaries, never mid-round
— works the same whether or not the assistant message carries a
structured `tool_calls` array (i.e. also correct for Harmony-mode
history). As a second line of defence, a new `ensureToolResultPairing()`
(`src/models/harmony.ts`) runs immediately before every model call in both
CodeAgent and WorkerAgent, silently repairing (and logging) any orphaned
or unanswered tool call that slips through regardless of cause.

---

## New Features

### Chat mode tool-call argument logging

**Before:** `WorkerAgent`'s per-tool-call log line was a bare
`  [Worker] Tool: <name>` with no arguments at all, unlike `CodeAgent`,
which has logged full args since v0.3.51.

**After:** `src/core/worker-agent.ts`'s log line now matches CodeAgent's
shape: `` `  [Worker] Tool: ${toolName} ${formatToolCallArgs(args)}` ``,
using the same `formatToolCallArgs()` helper from `src/utils/logger.ts`.
The log call was also moved to after `toolCall.function.arguments` is
parsed (it previously ran before parsing, when `args` wasn't yet
available). No per-tool-name special-casing was needed — because Chat mode
routes every tool call, including filesystem operations, through
`mcpManager.getClient()`, this single change covers every MCP server's
tools.

### Configurable compaction threshold, raised default

`CodeAgent`'s in-loop compaction fired once the prompt exceeded a fixed
90,000-token threshold, and — separately — could only ever fire once per
`chat()` turn, no matter how many iterations followed. That once-per-turn
cap meant the threshold needed generous headroom to survive whatever a
long tool-heavy turn (up to `maxIterations`, default 50) might add
afterwards with no further compaction possible.

Compaction can now re-trigger later in the same turn once growth crosses
the threshold again (`compactedThisIteration`, reset every iteration
instead of once per turn). With that safety net in place, the default is
raised to 100,000 tokens (~78% of a 128K context window, matching
`DualAgent`'s existing equivalent default). It's also now overridable —
via `codeMode.compactionThreshold` in jiva config for the CLI, or
`JIVA_CODE_COMPACTION_THRESHOLD` for the HTTP interface — for models with
a larger context window. Set to `0` to disable in-loop compaction
entirely.

### Recursive argument truncation

**Before:** `formatToolCallArgs()` only truncated string values at the
top level of the arguments object, then hard-cut the final serialized JSON
string at a fixed 2000-character length as a fallback. That was safe for
today's flat, top-level built-in tool arguments, but a deeply nested MCP
tool schema could have its structure cut off mid-token by the length-based
fallback, producing invalid JSON in the log.

**After:** `src/utils/logger.ts` replaces the shallow truncation with a new
recursive `truncateValue()` that walks objects and arrays at any nesting
depth, truncating string leaves wherever they occur (still 500 chars per
value), capping arrays at 20 entries and objects at 50 keys (each with a
`...(N more items/keys)` marker), and bailing out at depth 10 with
`'[max depth exceeded]'`. `formatToolCallArgs()` now simply returns
`JSON.stringify(truncateValue(args))` — the result is always valid JSON
regardless of how deeply nested the input is, since truncation happens
before serialization instead of by slicing the serialized string.

---

## Files Changed

| File | Change |
|------|--------|
| `src/core/worker-agent.ts` | Tool-call log line now includes `formatToolCallArgs(args)`; log call moved after argument parsing. Tool-call loop now indexed and stubs tool-result responses for calls abandoned by the doom-loop break; `ensureToolResultPairing()` runs before every model call |
| `src/code/agent.ts` | Tool-call loop now indexed and stubs tool-result responses for calls abandoned by the doom-loop or excessive-reads-nudge break; `ensureToolResultPairing()` runs before every model call; compaction rewritten to cut on round boundaries (`compactInLoopMessages`); compaction can re-trigger per iteration (`compactedThisIteration`); default threshold raised 90,000 → 100,000, overridable via `compactionThreshold` |
| `src/code/rounds.ts` | **New** — `groupMessagesIntoRounds()` / `splitRoundsForCompaction()`, the round-boundary grouping logic that `compactInLoopMessages` now cuts on |
| `src/models/harmony.ts` | New `ensureToolResultPairing()` — repairs orphaned/unanswered tool calls in message history, logging when it does |
| `src/core/config.ts` | New optional `codeMode.compactionThreshold` field |
| `src/interfaces/cli/index.ts` | Passes `codeModeConfig.compactionThreshold` through to `CodeAgent` |
| `src/interfaces/http/session-manager.ts` | New `JIVA_CODE_COMPACTION_THRESHOLD` env var passed through to `CodeAgent` |
| `src/utils/logger.ts` | New recursive `truncateValue()` (depth-aware string/array/object truncation) replaces the old top-level-only truncation + fixed-length JSON-string cut; `formatToolCallArgs()` now truncates before serializing instead of after |

---

## Upgrade

```bash
npm install -g jiva-core@0.3.52
```

No breaking changes. One new optional config field: `codeMode.compactionThreshold`
(jiva config) / `JIVA_CODE_COMPACTION_THRESHOLD` (HTTP interface env var) —
existing configs are unaffected and pick up the new 100,000-token default
automatically.