### PR TITLE
v0.3.53

### DIFF
--- a/docs/release_notes/v0.3.53.md
+++ b/docs/release_notes/v0.3.53.md
@@ -6,7 +6,7 @@
 
 ## Summary
 
-Adds streaming support for streaming-only models (Together AI's `Qwen/Qwen3.7-Plus` and similar), introduces a per-session `agentConfig` that overrides model/tool-calling-model/MCP/LSP/max-iterations/workspace-dir without touching disk, exposes tool-call arguments in the `/api/chat` response, and adds a lightweight `GET /api/session/:sessionId/status` polling endpoint for live progress. All changes are additive and backward-compatible.
+Adds streaming support for streaming-only models (Together AI's `Qwen/Qwen3.7-Plus` and similar), introduces a per-session `agentConfig` that overrides model/tool-calling-model/MCP/LSP/max-iterations/workspace-dir without touching disk, exposes tool-call arguments in the `/api/chat` response, adds a lightweight `GET /api/session/:sessionId/status` polling endpoint for live progress, and fixes empty conversation titles when using reasoning models. All changes are additive and backward-compatible.
 
 ---
 
@@ -23,6 +23,12 @@ Adds streaming support for streaming-only models (Together AI's `Qwen/Qwen3.7-Pl
 **Before:** `createSession` always passed `defaultReasoningEffort: 'medium'` when building the tool-calling model client. Plain tool-calling models that don't support reasoning (e.g. Groq's `llama-3.3-70b-versatile`) rejected the request with `400`.
 
 **After:** The catalog entry's `defaultReasoningEffort` and `reasoningEffortStrategy` are passed through as-is (undefined if not set). Non-reasoning tool-calling models now send no `reasoning_effort`; reasoning-capable ones can still opt in explicitly.
+
+### Reasoning models produced empty conversation titles
+
+**Before:** The title-generation call in `conversation-manager.ts` used a hardcoded `maxTokens: 200`. Reasoning models (GLM-5.2, DeepSeek, Qwen3, gpt-oss, Sarvam) spend tokens on their internal thinking chain *before* emitting the actual title, so the 200-token budget could be entirely consumed by thinking — producing an empty title.
+
+**After:** A new optional `disableThinking` flag on `ChatCompletionOptions` lets a caller ask the model to skip its thinking chain for a given call. `ModelClient` injects `chat_template_kwargs` into the request body with **both** `thinking: false` (the flag GLM reads) and `enable_thinking: false` (the flag Qwen3 reads) — each model family reads only its own flag, and other providers ignore `chat_template_kwargs` entirely. The title generator now sets `disableThinking: true` (for models that *can* turn thinking off, e.g. GLM/Qwen3) alongside the existing `reasoningEffort: 'low'` (for models that *can't* disable thinking but can minimize it, e.g. gpt-oss/Sarvam), and removes the hardcoded `maxTokens: 200` so each model falls back to its configured `defaultMaxTokens`.
 
 ---
 
@@ -59,7 +65,9 @@ A new `toolCalls: {name, args}[]` field appears alongside the existing `toolsUse
 
 | File | Change |
 |------|--------|
-| `src/models/model-client.ts` | Auto-detect `streaming_required` 400, flip per-instance flag, retry with `stream: true` + `stream_options: { include_usage: true }`; new `parseSSEStream()` reassembles SSE into non-streaming response shape |
+| `src/models/model-client.ts` | Auto-detect `streaming_required` 400, flip per-instance flag, retry with `stream: true` + `stream_options: { include_usage: true }`; new `parseSSEStream()` reassembles SSE into non-streaming response shape; inject `chat_template_kwargs` with `thinking: false` + `enable_thinking: false` when `disableThinking` is set |
+| `src/models/base.ts` | New optional `disableThinking?: boolean` field on `ChatCompletionOptions` |
+| `src/core/conversation-manager.ts` | Title generation sets `disableThinking: true` + keeps `reasoningEffort: 'low'`; removes hardcoded `maxTokens: 200` in favor of the model's `defaultMaxTokens` |
 | `src/interfaces/http/agent-config.ts` | **New** — `AgentConfig` interface + `validateAgentConfig()` structural validator |
 | `src/interfaces/http/session-manager.ts` | `getOrCreateSession` / `createSession` accept optional `agentConfig`; per-session config overrides model/tool-calling-model/MCP/LSP/max-iterations/workspace-dir; tool-calling model no longer forces `defaultReasoningEffort`; new `getSessionStatus()` |
 | `src/interfaces/http/routes/session.ts` | `POST /api/session` validates `agentConfig` (400 on failure) before session/MCP creation; new `GET /api/session/:sessionId/status` route |

--- a/docs/release_notes/v0.3.53.md
+++ b/docs/release_notes/v0.3.53.md
@@ -88,3 +88,5 @@ npm install -g jiva-core@0.3.53
 ```
 
 No breaking changes. All new behavior is opt-in via the optional `agentConfig` request body field; sessions that omit it behave exactly as before. The streaming fix is transparent — non-streaming providers are unaffected, and streaming-only providers self-heal on first call.
+
+- `compactionThreshold` is now globally editable in `config.json` (via `jiva config --compaction-threshold`) and applies to both chat and code modes; CLI supports setting it with a hint (set to ~70-80% of model context length).

--- a/docs/release_notes/v0.3.53.md
+++ b/docs/release_notes/v0.3.53.md
@@ -1,0 +1,82 @@
+# Jiva v0.3.53 — Streaming-Only Model Support, Per-Session `agentConfig`, Tool-Call Arguments & Live Status
+
+**Release Date:** August 5, 2026
+
+---
+
+## Summary
+
+Adds streaming support for streaming-only models (Together AI's `Qwen/Qwen3.7-Plus` and similar), introduces a per-session `agentConfig` that overrides model/tool-calling-model/MCP/LSP/max-iterations/workspace-dir without touching disk, exposes tool-call arguments in the `/api/chat` response, and adds a lightweight `GET /api/session/:sessionId/status` polling endpoint for live progress. All changes are additive and backward-compatible.
+
+---
+
+## Bug Fixes
+
+### Streaming-only models rejected with `streaming_required`
+
+**Before:** `ModelClient.attemptChat()` always sent non-streaming requests. Providers like Together AI that only support streaming (e.g. `Qwen/Qwen3.7-Plus`) rejected every call with `400 streaming_required`, making those models unusable.
+
+**After:** `src/models/model-client.ts` detects the `streaming_required` 400, flips a per-instance flag, and retries with `stream: true` + `stream_options: { include_usage: true }`. A new `parseSSEStream()` reassembles the streamed response into the same shape as a non-streaming response, so Harmony format, tool-call extraction, and usage tracking work unchanged. Non-streaming providers are completely unaffected.
+
+### Tool-calling models forced a `reasoning_effort` they reject
+
+**Before:** `createSession` always passed `defaultReasoningEffort: 'medium'` when building the tool-calling model client. Plain tool-calling models that don't support reasoning (e.g. Groq's `llama-3.3-70b-versatile`) rejected the request with `400`.
+
+**After:** The catalog entry's `defaultReasoningEffort` and `reasoningEffortStrategy` are passed through as-is (undefined if not set). Non-reasoning tool-calling models now send no `reasoning_effort`; reasoning-capable ones can still opt in explicitly.
+
+---
+
+## New Features
+
+### Per-session `agentConfig` (HTTP interface)
+
+A new optional `agentConfig` object on `POST /api/session`, `POST /api/chat`, and `POST /api/chat/stream` overrides session-scoped settings without persisting anything to disk:
+
+- `model` / `toolCallingModel` — override the reasoning/tool-calling model names
+- `mcpServers` — replace the MCP server list for this session
+- `codeModeEnabled` / `codeLsp` — override code-mode and LSP flags
+- `maxIterations` — override the per-agent iteration cap
+- `workspaceDir` — session-scoped workspace (uses `WorkspaceManager`'s config-mode constructor instead of resolving to `process.cwd()`)
+- `systemPrompt` — accepted but reserved for future use
+
+A new `validateAgentConfig()` in `src/interfaces/http/agent-config.ts` returns a 400 with descriptive errors before any session or MCP subprocess is created. For `/api/chat/stream`, validation runs before SSE headers are sent, so a bad config returns a clean JSON 400 instead of an error mid-stream. If `agentConfig` is supplied for an already-cached or already-pending session, it's logged and ignored (the existing session's config wins). Per-session config is never written via `storageProvider.setConfig()` — secrets never touch disk/GCS.
+
+### Per-session skills directory
+
+`PersonaManager` now accepts an `additionalSkillsDirs: string[]` constructor argument. When `agentConfig.workspaceDir` is set, `${workspaceDir}/skills` is scanned alongside `~/.claude/skills`. Each directory is independently non-fatal — a missing per-session `skills/` folder just contributes nothing.
+
+### Tool-call arguments in `/api/chat` response
+
+A new `toolCalls: {name, args}[]` field appears alongside the existing `toolsUsed: string[]` in both `POST /api/chat` and `POST /api/chat/stream` JSON responses. Lets callers see *what* a tool ran (e.g. the actual SQL query), not just that it ran. Threaded from `WorkerAgent` → `DualAgent` → HTTP response. Code mode (`CodeAgent`) is not covered — no current agent type uses code mode with this feature. Deliberately additive — `toolsUsed`'s element type is unchanged.
+
+### Live session status endpoint
+
+`OrchestrationLogger` now retains a `currentStatus` string (e.g. `"Running SQL query…"`, `"Planning execution…"`, `"Synthesizing results…"`) derived in `writeEvent()` from the same structured events it already logs. A new `GET /api/session/:sessionId/status` route exposes it — returns `200 { status }` if the session exists, `404 { error: 'Session not found' }` otherwise (an expected poll outcome, not an error). Lets a caller poll real progress from a second concurrent HTTP request while `POST /api/chat` is still in flight, without needing full SSE/WebSocket plumbing.
+
+---
+
+## Files Changed
+
+| File | Change |
+|------|--------|
+| `src/models/model-client.ts` | Auto-detect `streaming_required` 400, flip per-instance flag, retry with `stream: true` + `stream_options: { include_usage: true }`; new `parseSSEStream()` reassembles SSE into non-streaming response shape |
+| `src/interfaces/http/agent-config.ts` | **New** — `AgentConfig` interface + `validateAgentConfig()` structural validator |
+| `src/interfaces/http/session-manager.ts` | `getOrCreateSession` / `createSession` accept optional `agentConfig`; per-session config overrides model/tool-calling-model/MCP/LSP/max-iterations/workspace-dir; tool-calling model no longer forces `defaultReasoningEffort`; new `getSessionStatus()` |
+| `src/interfaces/http/routes/session.ts` | `POST /api/session` validates `agentConfig` (400 on failure) before session/MCP creation; new `GET /api/session/:sessionId/status` route |
+| `src/interfaces/http/routes/chat.ts` | `POST /api/chat` and `POST /api/chat/stream` validate `agentConfig` (400 on failure) before SSE headers; responses include `toolCalls` alongside `toolsUsed` |
+| `src/core/worker-agent.ts` | New `toolCalls: {name, args}[]` field on `WorkerResult`, populated at every `toolsUsed.push` site |
+| `src/core/dual-agent.ts` | New `allToolCalls` aggregation in `DualAgentResponse`; exposed in both return paths |
+| `src/core/agent-interface.ts` | New optional `toolCalls` field on `AgentChatResponse` (undefined for `CodeAgent` → omitted from JSON) |
+| `src/personas/persona-manager.ts` | New `additionalSkillsDirs: string[]` constructor param; `initializeStandaloneSkills()` scans each dir independently non-fatal |
+| `src/utils/orchestration-logger.ts` | New `currentStatus` field + `getCurrentStatus()` getter; derived in `writeEvent()` from existing structured events |
+| `package.json` | Version bump `0.3.52` → `0.3.53` |
+
+---
+
+## Upgrade
+
+```bash
+npm install -g jiva-core@0.3.53
+```
+
+No breaking changes. All new behavior is opt-in via the optional `agentConfig` request body field; sessions that omit it behave exactly as before. The streaming fix is transparent — non-streaming providers are unaffected, and streaming-only providers self-heal on first call.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jiva-core",
-  "version": "0.3.52",
+  "version": "0.3.53",
   "description": "Versatile autonomous AI agent with three-agent architecture (Manager, Worker, Client) powered by gpt-oss-120b. Adaptive validation, full MCP support, and intelligent quality control.",
   "main": "dist/index.js",
   "bin": {

--- a/src/core/agent-interface.ts
+++ b/src/core/agent-interface.ts
@@ -9,10 +9,17 @@ import type { WorkspaceManager } from './workspace.js';
 import type { ConversationManager } from './conversation-manager.js';
 import type { Message } from '../models/base.js';
 import type { TokenUsageSnapshot } from '../models/token-tracker.js';
+import type { ToolCallRecord } from './worker-agent.js';
 
 export interface AgentChatResponse {
   content: string;
   toolsUsed: string[];
+  /**
+   * Parallel to `toolsUsed`: each tool call's name AND arguments.
+   * Present only for DualAgent (Chat-mode) responses; `undefined` for CodeAgent
+   * (code-mode) sessions, so it is omitted from JSON in that case.
+   */
+  toolCalls?: ToolCallRecord[];
   iterations: number;
   /**
    * Present only in DualAgent responses (contains the plan produced by the manager).

--- a/src/core/config.ts
+++ b/src/core/config.ts
@@ -287,6 +287,11 @@ export class ConfigManager {
     this.store.set('codeMode', { ...current, enabled });
   }
 
+  setCompactionThreshold(threshold: number) {
+    const current = this.store.get('codeMode') || {};
+    this.store.set('codeMode', { ...current, compactionThreshold: threshold });
+  }
+
   reset() {
     this.store.clear();
   }

--- a/src/core/conversation-manager.ts
+++ b/src/core/conversation-manager.ts
@@ -342,17 +342,16 @@ Keep the summary focused and complete — include file paths, function names, an
       const response = await orchestrator.chat({
         messages: [{ role: 'user', content: titlePrompt }],
         temperature: 0.1, // Low temperature for deterministic title generation
-        // Reasoning models (e.g. GLM-5.2) spend tokens on a thinking chain
-        // before emitting the title; 20 tokens was barely enough for the
-        // thinking alone, leaving nothing for the actual title.
-        maxTokens: 200,
-        reasoningEffort: 'low', // Minimize thinking for this simple task
+        // Reasoning models can exhaust max_tokens on thinking, returning empty
+        // content. disableThinking (GLM/Qwen3) + reasoningEffort:'low' (gpt-oss,
+        // Sarvam) prevent this; max_tokens is left unset so each model uses its
+        // configured defaultMaxTokens.
+        reasoningEffort: 'low',
+        disableThinking: true,
       });
 
-      // Clean up the title. Reasoning models (e.g. GLM-5.2, DeepSeek) emit
-      // inline thinking blocks; stripThinkingContent() removes those, then
-      // take the last non-empty line (the model sometimes emits preamble
-      // before the actual title).
+      // Clean up the title: strip inline thinking blocks (GLM-5.2, DeepSeek),
+      // then take the last non-empty line (models sometimes emit preamble first).
       let title = this.stripThinkingContent(response.content).trim();
       const lines = title.split('\n').map(l => l.trim()).filter(Boolean);
       title = lines.length > 0 ? lines[lines.length - 1] : '';

--- a/src/core/dual-agent.ts
+++ b/src/core/dual-agent.ts
@@ -19,6 +19,7 @@ import { serializeAgentContext } from './utils/serialize-agent-context.js';
 import { logger } from '../utils/logger.js';
 import { OrchestrationLogger, orchestrationLogger } from '../utils/orchestration-logger.js';
 import { Message } from '../models/base.js';
+import type { ToolCallRecord } from './worker-agent.js';
 
 export interface DualAgentConfig {
   orchestrator: ModelOrchestrator;
@@ -55,6 +56,8 @@ export interface DualAgentResponse {
   content: string;
   iterations: number;
   toolsUsed: string[];
+  /** Parallel to `toolsUsed`: each tool call's name AND arguments. */
+  toolCalls: ToolCallRecord[];
   plan?: {
     subtasks: string[];
     reasoning: string;
@@ -288,6 +291,9 @@ VALIDATION GUIDANCE:
     const agentContext = this.buildAgentContext();
 
     const allToolsUsed: string[] = [];
+    // Parallel to `allToolsUsed`: aggregates each worker's `toolCalls` so the
+    // HTTP layer can surface tool arguments to end users.
+    const allToolCalls: ToolCallRecord[] = [];
     let totalIterations = 0;
 
     // PHASE 1: Manager creates plan
@@ -332,6 +338,7 @@ VALIDATION GUIDANCE:
         content: directReply,
         iterations: 1,
         toolsUsed: [],
+        toolCalls: [],
         plan: { subtasks: [], reasoning: plan.reasoning },
         tokenUsage: this.orchestrator.getTokenUsage(),
       };
@@ -369,6 +376,9 @@ VALIDATION GUIDANCE:
 
       totalIterations += 1;
       allToolsUsed.push(...workerResult.toolsUsed);
+      if (workerResult.toolCalls) {
+        allToolCalls.push(...workerResult.toolCalls);
+      }
 
       // Manager reviews Worker's result — fast-path for common cases, LLM only for edge cases
       const review = await this.manager.reviewSubtaskResult(subtask, workerResult, userMessage);
@@ -440,6 +450,7 @@ VALIDATION GUIDANCE:
       content: finalResponse,
       iterations: totalIterations,
       toolsUsed: allToolsUsed,
+      toolCalls: allToolCalls,
       plan: {
         subtasks: plan.subtasks,
         reasoning: plan.reasoning,

--- a/src/core/worker-agent.ts
+++ b/src/core/worker-agent.ts
@@ -85,10 +85,18 @@ export interface ToolFailure {
   attempts: number;
 }
 
+/** A single tool invocation with its name and arguments (parallel to `toolsUsed`). */
+export interface ToolCallRecord {
+  name: string;
+  args: Record<string, any>;
+}
+
 export interface WorkerResult {
   success: boolean;
   result: string;
   toolsUsed: string[];
+  /** Parallel to `toolsUsed`: each entry records the tool name AND its arguments. */
+  toolCalls: ToolCallRecord[];
   failedTools: ToolFailure[];
   reasoning: string;
 }
@@ -153,6 +161,9 @@ export class WorkerAgent {
 
     const conversationHistory: Message[] = [];
     const toolsUsed: string[] = [];
+    // Parallel to `toolsUsed`: records each tool call's name AND arguments so
+    // callers can surface *what* a tool ran, not just that it ran.
+    const toolCalls: ToolCallRecord[] = [];
     // Tracks consecutive failures per (toolName:args) signature.
     // Drives the per-tool circuit breaker: warn at 2, hard-stop at 3.
     const toolFailureCounts = new Map<string, { count: number; lastError: string }>();
@@ -458,6 +469,7 @@ Please complete this subtask and report your findings.`,
             try {
               const repResult = await this.mcpManager.getClient().executeTool(repairedName, repairedArgs);
               toolsUsed.push(repairedName);
+              toolCalls.push({ name: repairedName, args: repairedArgs });
               const repText = typeof repResult === 'string' ? repResult : JSON.stringify(repResult);
               conversationHistory.push({ role: 'assistant', content: '' });
               conversationHistory.push({
@@ -715,6 +727,7 @@ Please complete this subtask and report your findings.`,
               });
 
               toolsUsed.push(toolName);
+              toolCalls.push({ name: toolName, args });
 
               const resultText = `Sub-agent spawned with persona '${spawnResult.persona}' completed the task.
 
@@ -748,6 +761,7 @@ Tools used: ${spawnResult.toolsUsed.join(', ')}`;
             const result = await this.mcpManager.getClient().executeTool(toolName, args);
 
             toolsUsed.push(toolName);
+            toolCalls.push({ name: toolName, args });
 
             // Check if tool returned images (multimodal support)
             let toolResultText: string;
@@ -1004,6 +1018,7 @@ Tools used: ${spawnResult.toolsUsed.join(', ')}`;
       success,
       result: finalResult,
       toolsUsed,
+      toolCalls,
       failedTools,
       reasoning: reasoning || 'Task executed',
     };

--- a/src/interfaces/cli/index.ts
+++ b/src/interfaces/cli/index.ts
@@ -65,6 +65,7 @@ program
   .command('config')
   .description('Update Jiva configuration')
   .option('--show', 'Show current configuration and source')
+  .option('--compaction-threshold <number>', 'Set global compaction threshold (tokens). Hint: if model context length is x, set threshold to ~70-80% of x (e.g., 128k context → 90000-100000).')
   .action(async (options) => {
     try {
       if (options.show) {
@@ -112,6 +113,13 @@ program
         return;
       }
       
+      if (options.compactionThreshold !== undefined) {
+        configManager.setCompactionThreshold(options.compactionThreshold);
+        console.log(chalk.green(`✓ Global compactionThreshold set to ${options.compactionThreshold}`));
+        console.log(chalk.gray('Hint: if model context length is x, set threshold to ~70-80% of x (e.g., 128k → 90000-100000).'));
+        return;
+      }
+
       if (!configManager.isConfigured()) {
         console.log(chalk.yellow('Jiva is not configured. Running setup wizard...\n'));
         await runSetupWizard();

--- a/src/interfaces/cli/index.ts
+++ b/src/interfaces/cli/index.ts
@@ -930,6 +930,10 @@ program
 
       logger.info(`Completed in ${response.iterations} iteration(s)`);
 
+      if (response.tokenUsage) {
+        logger.info(`Token usage: prompt=${response.tokenUsage.promptTokens} completion=${response.tokenUsage.completionTokens} total=${response.tokenUsage.totalTokens}`);
+      }
+
       // Cleanup
       await agent.cleanup();
       orchestrationLogger.close();

--- a/src/interfaces/http/agent-config.ts
+++ b/src/interfaces/http/agent-config.ts
@@ -1,0 +1,141 @@
+/**
+ * Agent Config - Per-session agent configuration supplied via the HTTP API
+ *
+ * When supplied in a session-creation or chat request body, these values
+ * override the server-level environment-variable defaults (JIVA_MODEL_*,
+ * JIVA_TOOL_CALLING_MODEL_*, ENABLE_MCP_SERVERS, MCP_FILESYSTEM_*,
+ * JIVA_CODE_LSP, JIVA_CODE_MODE) for that session's lifetime only.
+ *
+ * Per-session config is NEVER persisted to storage — it lives in memory for
+ * the session and is discarded when the session is destroyed. Secrets (API
+ * keys, endpoints) are NOT part of this object; they remain server-side.
+ */
+
+/** MCP server descriptor supplied via agentConfig. */
+export interface AgentConfigMCPServer {
+  name: string;
+  url?: string;
+  transport?: 'stdio' | 'sse' | 'http';
+  command?: string;
+  args?: string[];
+  env?: Record<string, string>;
+}
+
+/**
+ * Per-session agent configuration.
+ *
+ * All fields are optional — an absent field means "use the server-level
+ * default" (env var / stored config), preserving backward compatibility.
+ */
+export interface AgentConfig {
+  /** Reasoning / main model name. */
+  model?: string;
+  /** Tool-calling model name. */
+  toolCallingModel?: string;
+  /** MCP server list — replaces filesystem default + stored config for this session. */
+  mcpServers?: AgentConfigMCPServer[];
+  /** Whether code mode is enabled (overrides JIVA_CODE_MODE). */
+  codeModeEnabled?: boolean;
+  /** Whether LSP is enabled in code mode (overrides JIVA_CODE_LSP). */
+  codeLsp?: boolean;
+  /** Max iterations for the agent. */
+  maxIterations?: number;
+  /** Absolute path to a session-scoped workspace directory. */
+  workspaceDir?: string;
+  /** Reserved for future use — accepted but not wired into agent constructors. */
+  systemPrompt?: string;
+}
+
+/**
+ * Pure structural validator for an AgentConfig.
+ *
+ * Returns `{ valid: true, errors: [] }` for undefined/null (no agentConfig =
+ * backward compat) and for a valid config. Returns `{ valid: false, errors }`
+ * with descriptive messages for invalid configs. Does NOT check filesystem
+ * existence of workspaceDir — that is deferred to WorkspaceManager at
+ * session-creation time.
+ */
+export function validateAgentConfig(config: unknown): { valid: boolean; errors: string[] } {
+  // No agentConfig supplied → backward-compatible default behavior.
+  if (config === undefined || config === null) {
+    return { valid: true, errors: [] };
+  }
+
+  const errors: string[] = [];
+
+  if (typeof config !== 'object' || Array.isArray(config)) {
+    return { valid: false, errors: ['agentConfig must be an object'] };
+  }
+
+  const c = config as Record<string, unknown>;
+
+  // model: optional non-empty string
+  if ('model' in c && c.model !== undefined) {
+    if (typeof c.model !== 'string' || c.model.trim() === '') {
+      errors.push('agentConfig.model must be a non-empty string');
+    }
+  }
+
+  // toolCallingModel: optional non-empty string
+  if ('toolCallingModel' in c && c.toolCallingModel !== undefined) {
+    if (typeof c.toolCallingModel !== 'string' || c.toolCallingModel.trim() === '') {
+      errors.push('agentConfig.toolCallingModel must be a non-empty string');
+    }
+  }
+
+  // mcpServers: optional array of { name, url }
+  if ('mcpServers' in c && c.mcpServers !== undefined) {
+    if (!Array.isArray(c.mcpServers)) {
+      errors.push('agentConfig.mcpServers must be an array');
+    } else {
+      c.mcpServers.forEach((srv: unknown, i: number) => {
+        if (typeof srv !== 'object' || srv === null || Array.isArray(srv)) {
+          errors.push(`agentConfig.mcpServers[${i}] must be an object`);
+          return;
+        }
+        const s = srv as Record<string, unknown>;
+        if (typeof s.name !== 'string' || s.name.trim() === '') {
+          errors.push(`agentConfig.mcpServers[${i}].name must be a non-empty string`);
+        }
+        if (typeof s.url !== 'string' || s.url.trim() === '') {
+          errors.push(`agentConfig.mcpServers[${i}].url must be a non-empty string`);
+        }
+      });
+    }
+  }
+
+  // codeModeEnabled: optional boolean
+  if ('codeModeEnabled' in c && c.codeModeEnabled !== undefined && typeof c.codeModeEnabled !== 'boolean') {
+    errors.push('agentConfig.codeModeEnabled must be a boolean');
+  }
+
+  // codeLsp: optional boolean
+  if ('codeLsp' in c && c.codeLsp !== undefined && typeof c.codeLsp !== 'boolean') {
+    errors.push('agentConfig.codeLsp must be a boolean');
+  }
+
+  // maxIterations: optional positive integer
+  if ('maxIterations' in c && c.maxIterations !== undefined) {
+    if (
+      typeof c.maxIterations !== 'number' ||
+      !Number.isInteger(c.maxIterations) ||
+      c.maxIterations <= 0
+    ) {
+      errors.push('agentConfig.maxIterations must be a positive integer');
+    }
+  }
+
+  // workspaceDir: optional non-empty string (existence NOT checked here)
+  if ('workspaceDir' in c && c.workspaceDir !== undefined) {
+    if (typeof c.workspaceDir !== 'string' || c.workspaceDir.trim() === '') {
+      errors.push('agentConfig.workspaceDir must be a non-empty string');
+    }
+  }
+
+  // systemPrompt: optional string
+  if ('systemPrompt' in c && c.systemPrompt !== undefined && typeof c.systemPrompt !== 'string') {
+    errors.push('agentConfig.systemPrompt must be a string');
+  }
+
+  return { valid: errors.length === 0, errors };
+}

--- a/src/interfaces/http/routes/chat.ts
+++ b/src/interfaces/http/routes/chat.ts
@@ -4,6 +4,7 @@
 
 import { Express, Request, Response } from 'express';
 import { SessionManager } from '../session-manager.js';
+import { validateAgentConfig } from '../agent-config.js';
 import { logger } from '../../../utils/logger.js';
 import { getDefaultFilesystemAllowedPath } from '../../../utils/platform.js';
 
@@ -11,6 +12,10 @@ export function setupChatRoutes(app: Express, sessionManager: SessionManager): v
   /**
    * Send a message (non-streaming)
    * POST /api/chat
+   *
+   * Optional body field `agentConfig` supplies per-session overrides for the
+   * "create-on-chat" shortcut path (session is created on first chat if it
+   * doesn't exist). It is validated before session creation.
    */
   app.post('/api/chat', async (req: Request, res: Response) => {
     try {
@@ -22,8 +27,19 @@ export function setupChatRoutes(app: Express, sessionManager: SessionManager): v
         return;
       }
 
+      // Validate per-session agentConfig (if supplied) before creating a session.
+      const agentConfig = req.body?.agentConfig;
+      const validation = validateAgentConfig(agentConfig);
+      if (!validation.valid) {
+        res.status(400).json({
+          error: 'Invalid agentConfig',
+          details: validation.errors,
+        });
+        return;
+      }
+
       // Get or create session
-      const agent = await sessionManager.getOrCreateSession(tenantId, sessionId);
+      const agent = await sessionManager.getOrCreateSession(tenantId, sessionId, agentConfig);
 
       // Process message
       const response = await agent.chat(message);
@@ -36,6 +52,9 @@ export function setupChatRoutes(app: Express, sessionManager: SessionManager): v
         response: response.content,
         iterations: response.iterations,
         toolsUsed: response.toolsUsed,
+        // toolCalls is undefined for CodeAgent (code-mode) sessions → omitted
+        // from JSON. Only the Chat-mode (DualAgent) path threads args through.
+        ...(response.toolCalls !== undefined && { toolCalls: response.toolCalls }),
         ...(response.plan !== undefined && { plan: response.plan }),
         ...(response.tokenUsage && { tokenUsage: response.tokenUsage }),
       });
@@ -51,6 +70,11 @@ export function setupChatRoutes(app: Express, sessionManager: SessionManager): v
   /**
    * Send a message with streaming (Server-Sent Events)
    * POST /api/chat/stream
+   *
+   * Optional body field `agentConfig` supplies per-session overrides for the
+   * "create-on-chat" shortcut path. It is validated BEFORE the SSE headers are
+   * sent, so a bad config returns a normal JSON 400 instead of an error
+   * mid-stream.
    */
   app.post('/api/chat/stream', async (req: Request, res: Response) => {
     try {
@@ -59,6 +83,19 @@ export function setupChatRoutes(app: Express, sessionManager: SessionManager): v
 
       if (!message || typeof message !== 'string') {
         res.status(400).json({ error: 'Message is required and must be a string' });
+        return;
+      }
+
+      // Validate per-session agentConfig BEFORE sending SSE headers, so an
+      // invalid config returns a normal JSON 400 rather than an error event
+      // mid-stream (which clients can't easily surface as a creation failure).
+      const agentConfig = req.body?.agentConfig;
+      const validation = validateAgentConfig(agentConfig);
+      if (!validation.valid) {
+        res.status(400).json({
+          error: 'Invalid agentConfig',
+          details: validation.errors,
+        });
         return;
       }
 
@@ -76,7 +113,7 @@ export function setupChatRoutes(app: Express, sessionManager: SessionManager): v
 
       try {
         // Get or create session
-        const agent = await sessionManager.getOrCreateSession(tenantId, sessionId);
+        const agent = await sessionManager.getOrCreateSession(tenantId, sessionId, agentConfig);
 
         sendEvent('status', { message: 'Processing request...' });
 
@@ -89,6 +126,9 @@ export function setupChatRoutes(app: Express, sessionManager: SessionManager): v
           content: response.content,
           iterations: response.iterations,
           toolsUsed: response.toolsUsed,
+          // toolCalls is undefined for CodeAgent (code-mode) sessions → omitted
+          // from JSON. Only the Chat-mode (DualAgent) path threads args through.
+          ...(response.toolCalls !== undefined && { toolCalls: response.toolCalls }),
           ...(response.plan !== undefined && { plan: response.plan }),
           ...(response.tokenUsage && { tokenUsage: response.tokenUsage }),
         });

--- a/src/interfaces/http/routes/session.ts
+++ b/src/interfaces/http/routes/session.ts
@@ -4,29 +4,46 @@
 
 import { Express, Request, Response } from 'express';
 import { SessionManager } from '../session-manager.js';
+import { validateAgentConfig } from '../agent-config.js';
 import { logger } from '../../../utils/logger.js';
 
 export function setupSessionRoutes(app: Express, sessionManager: SessionManager): void {
   /**
    * Create or restore a session
    * POST /api/session
+   *
+   * Optional body field `agentConfig` supplies per-session overrides (model,
+   * tool-calling model, MCP servers, code-mode LSP, max iterations, workspace
+   * dir). It is structurally validated BEFORE any session or MCP subprocess is
+   * created, so an invalid config returns a 400 without side effects.
    */
   app.post('/api/session', async (req: Request, res: Response) => {
     try {
       const { tenantId, sessionId } = req.auth!;
-      
+
+      // Validate per-session agentConfig (if supplied) before creating anything.
+      const agentConfig = req.body?.agentConfig;
+      const validation = validateAgentConfig(agentConfig);
+      if (!validation.valid) {
+        res.status(400).json({
+          error: 'Invalid agentConfig',
+          details: validation.errors,
+        });
+        return;
+      }
+
       // Get or create session
-      await sessionManager.getOrCreateSession(tenantId, sessionId);
-      
+      await sessionManager.getOrCreateSession(tenantId, sessionId, agentConfig);
+
       const info = sessionManager.getSessionInfo(tenantId, sessionId);
-      
+
       res.status(200).json({
         success: true,
         session: info,
       });
     } catch (error) {
       logger.error('[API] Failed to create session:', error);
-      res.status(500).json({ 
+      res.status(500).json({
         error: 'Failed to create session',
         message: error instanceof Error ? error.message : 'Unknown error'
       });
@@ -55,6 +72,43 @@ export function setupSessionRoutes(app: Express, sessionManager: SessionManager)
       res.status(500).json({ 
         error: 'Failed to get session',
         message: error instanceof Error ? error.message : 'Unknown error'
+      });
+    }
+  });
+
+  /**
+   * Get the live status of an in-flight agent turn.
+   * GET /api/session/:sessionId/status
+   *
+   * Returns the latest orchestration event the session's agent emitted while
+   * processing a `POST /api/chat` turn (e.g. "Planning execution…",
+   * "Running filesystem__read_file…", "Synthesizing results…"). Designed to be
+   * polled concurrently from a second HTTP request while a chat turn is in
+   * flight — Node's event loop services this poll while `agent.chat()` awaits
+   * the model provider.
+   *
+   * Returns 404 if the session does not exist (an expected poll outcome, e.g.
+   * polling before the session has been created or after it was destroyed —
+   * not an error). Returns 200 with `{ status }` otherwise.
+   */
+  app.get('/api/session/:sessionId/status', async (req: Request, res: Response) => {
+    try {
+      const { tenantId } = req.auth!;
+      const { sessionId } = req.params;
+
+      const status = sessionManager.getSessionStatus(tenantId, sessionId);
+
+      if (status === null) {
+        res.status(404).json({ error: 'Session not found' });
+        return;
+      }
+
+      res.status(200).json({ status });
+    } catch (error) {
+      logger.error('[API] Failed to get session status:', error);
+      res.status(500).json({
+        error: 'Failed to get session status',
+        message: error instanceof Error ? error.message : 'Unknown error',
       });
     }
   });

--- a/src/interfaces/http/session-manager.ts
+++ b/src/interfaces/http/session-manager.ts
@@ -26,6 +26,7 @@ import { Message } from '../../models/base.js';
 import { PersonaManager } from '../../personas/persona-manager.js';
 import { getDefaultFilesystemAllowedPath } from '../../utils/platform.js';
 import type { IAgent } from '../../core/agent-interface.js';
+import type { AgentConfig } from './agent-config.js';
 
 export interface SessionConfig {
   storageProvider: StorageProvider;
@@ -75,12 +76,24 @@ export class SessionManager extends EventEmitter {
    * Concurrent calls for the same (tenantId, sessionId) are deduplicated:
    * the second caller awaits the same creation Promise so only one session
    * object (and its MCP sub-processes) is ever created per key.
+   *
+   * When `agentConfig` is supplied, its values override the server-level
+   * environment-variable defaults (model, tool-calling model, MCP servers,
+   * code-mode LSP, max iterations, workspace dir) for this session only.
+   * Per-session config is never persisted. If `agentConfig` is supplied for
+   * an already-cached or already-pending session, it is logged and ignored
+   * (the existing session's config wins).
    */
-  async getOrCreateSession(tenantId: string, sessionId: string): Promise<IAgent> {
+  async getOrCreateSession(tenantId: string, sessionId: string, agentConfig?: AgentConfig): Promise<IAgent> {
     const key = this.getSessionKey(tenantId, sessionId);
 
     // Fast path — session already active
     if (this.sessions.has(key)) {
+      if (agentConfig) {
+        logger.warn(
+          `[SessionManager] agentConfig supplied for already-active session ${key} — ignored (existing session config retained)`,
+        );
+      }
       const session = this.sessions.get(key)!;
       this.resetIdleTimer(key);
       session.info.lastActivityAt = new Date();
@@ -91,6 +104,11 @@ export class SessionManager extends EventEmitter {
 
     // Deduplication — a concurrent request is already creating this session
     if (this.pendingSessions.has(key)) {
+      if (agentConfig) {
+        logger.warn(
+          `[SessionManager] agentConfig supplied for pending session ${key} — ignored (existing session config retained)`,
+        );
+      }
       logger.debug(`[SessionManager] Awaiting pending session creation: ${key}`);
       const session = await this.pendingSessions.get(key)!;
       return session.agent;
@@ -107,8 +125,8 @@ export class SessionManager extends EventEmitter {
     // Create new session; register the Promise before awaiting so concurrent
     // callers that arrive while we await find it in pendingSessions.
     logger.info(`[SessionManager] Creating session: ${key}`);
-    const codeModeEnabled = process.env.JIVA_CODE_MODE === 'true';
-    const creationPromise = this.createSession(tenantId, sessionId, codeModeEnabled);
+    const codeModeEnabled = agentConfig?.codeModeEnabled ?? process.env.JIVA_CODE_MODE === 'true';
+    const creationPromise = this.createSession(tenantId, sessionId, codeModeEnabled, agentConfig);
     this.pendingSessions.set(key, creationPromise);
 
     try {
@@ -128,8 +146,14 @@ export class SessionManager extends EventEmitter {
 
   /**
    * Create a new session with all components
+   *
+   * When `agentConfig` is supplied, its values replace the server-level
+   * environment-variable reads for: the model name, tool-calling model name,
+   * MCP server list, code-mode LSP flag, and max iterations. Per-session
+   * config is NEVER persisted via storageProvider.setConfig() — it stays in
+   * memory for the session's lifetime only (secrets never touch disk/GCS).
    */
-  private async createSession(tenantId: string, sessionId: string, codeModeEnabled: boolean): Promise<ActiveSession> {
+  private async createSession(tenantId: string, sessionId: string, codeModeEnabled: boolean, agentConfig?: AgentConfig): Promise<ActiveSession> {
     const info: SessionInfo = {
       sessionId,
       tenantId,
@@ -197,10 +221,14 @@ export class SessionManager extends EventEmitter {
 
       // Create model orchestrator
       const rm = modelConfig.reasoning as any;
+      // agentConfig.model (when supplied) overrides the stored/env model name
+      // for this session only — the endpoint/apiKey/strategy still come from the
+      // tenant's stored config (secrets are never part of agentConfig).
+      const reasoningModelName = agentConfig?.model ?? rm.model ?? rm.defaultModel;
       const reasoningModel = createModelClient({
         endpoint: rm.endpoint,
         apiKey: rm.apiKey || '',
-        model: rm.model || rm.defaultModel,
+        model: reasoningModelName,
         type: 'reasoning',
         useHarmonyFormat: rm.useHarmonyFormat ?? false,
         useGoogleADC: rm.useGoogleADC ?? false,
@@ -215,10 +243,11 @@ export class SessionManager extends EventEmitter {
       // execution (reliable standard-JSON tool formatting). The reasoning model acts as
       // the secondary fallback.
       // Configure via JIVA_TOOL_CALLING_MODEL_BASE_URL / JIVA_TOOL_CALLING_MODEL_API_KEY /
-      // JIVA_TOOL_CALLING_MODEL_NAME environment variables.
+      // JIVA_TOOL_CALLING_MODEL_NAME environment variables, OR via agentConfig.toolCallingModel
+      // (which reuses the reasoning model's endpoint/apiKey for the session).
       const tcEndpoint = process.env.JIVA_TOOL_CALLING_MODEL_BASE_URL;
       const tcApiKey   = process.env.JIVA_TOOL_CALLING_MODEL_API_KEY;
-      const tcModel    = process.env.JIVA_TOOL_CALLING_MODEL_NAME;
+      const tcModel    = agentConfig?.toolCallingModel ?? process.env.JIVA_TOOL_CALLING_MODEL_NAME;
       const toolCallingModel = (tcEndpoint && tcApiKey && tcModel)
         ? createModelClient({
             endpoint: tcEndpoint,
@@ -226,7 +255,13 @@ export class SessionManager extends EventEmitter {
             model: tcModel,
             type: 'tool-calling',
             useHarmonyFormat: false, // standard OpenAI format for tool-calling LLMs
-            defaultReasoningEffort: 'medium',
+            // Patch 8: pass reasoning-effort config through as-is (undefined when
+            // the catalog/config doesn't set it) instead of forcing 'medium'. A
+            // plain tool-calling model (e.g. Groq llama-3.3-70b-versatile) rejects
+            // `reasoning_effort` with a 400; an agent type whose tool-calling model
+            // IS reasoning-capable can still opt in explicitly via its config.
+            defaultReasoningEffort: undefined,
+            reasoningEffortStrategy: undefined,
           })
         : undefined;
 
@@ -251,47 +286,80 @@ export class SessionManager extends EventEmitter {
 
       const baseMcpServers: Record<string, any> = {};
 
-      if (mcpEnabled && filesystemEnabled) {
-        baseMcpServers.filesystem = {
-          command: 'npx',
-          args: ['--no', '@modelcontextprotocol/server-filesystem', ...allowedPaths],
-          enabled: true,
-        };
-        logger.info(`[SessionManager] Filesystem MCP paths: ${allowedPaths.join(', ')}`);
-      }
-      
-      // Load MCP server config from storage
-      const mcpConfig = await storageProvider.getConfig<Array<{
-        name: string;
-        command: string;
-        args?: string[];
-        env?: Record<string, string>;
-      }>>('mcpServers');
-      if (mcpConfig && Array.isArray(mcpConfig)) {
-        for (const serverConfig of mcpConfig) {
-          // Add to base servers (will override filesystem if configured)
+      // When agentConfig.mcpServers is supplied, it REPLACES the filesystem
+      // default and any stored MCP config for this session — the caller fully
+      // controls the session's MCP surface (an empty array means "no MCP
+      // servers for this session"). Otherwise fall back to the env-var
+      // filesystem default + stored per-tenant config (original behavior).
+      if (agentConfig?.mcpServers) {
+        for (const serverConfig of agentConfig.mcpServers) {
           baseMcpServers[serverConfig.name] = {
-            command: serverConfig.command,
-            args: serverConfig.args,
-            env: serverConfig.env,
+            ...(serverConfig.url ? { url: serverConfig.url } : {}),
+            ...(serverConfig.command ? { command: serverConfig.command } : {}),
+            ...(serverConfig.args ? { args: serverConfig.args } : {}),
+            ...(serverConfig.env ? { env: serverConfig.env } : {}),
             enabled: true,
           };
         }
+        logger.info(
+          `[SessionManager] Using ${agentConfig.mcpServers.length} MCP server(s) from agentConfig`,
+        );
+      } else {
+        if (mcpEnabled && filesystemEnabled) {
+          baseMcpServers.filesystem = {
+            command: 'npx',
+            args: ['--no', '@modelcontextprotocol/server-filesystem', ...allowedPaths],
+            enabled: true,
+          };
+          logger.info(`[SessionManager] Filesystem MCP paths: ${allowedPaths.join(', ')}`);
+        }
+
+        // Load MCP server config from storage
+        const mcpConfig = await storageProvider.getConfig<Array<{
+          name: string;
+          command: string;
+          args?: string[];
+          env?: Record<string, string>;
+        }>>('mcpServers');
+        if (mcpConfig && Array.isArray(mcpConfig)) {
+          for (const serverConfig of mcpConfig) {
+            // Add to base servers (will override filesystem if configured)
+            baseMcpServers[serverConfig.name] = {
+              command: serverConfig.command,
+              args: serverConfig.args,
+              env: serverConfig.env,
+              enabled: true,
+            };
+          }
+        }
       }
-      
+
       // Initialize all MCP servers (base + configured)
       await mcpManager.initialize(baseMcpServers);
 
       // Initialize workspace
-      const workspace = new WorkspaceManager(storageProvider);
+      // When agentConfig.workspaceDir is supplied, build WorkspaceManager in
+      // local/config mode (session-scoped directory) instead of the
+      // storage-provider mode (which resolves to the process-wide process.cwd()
+      // and is NOT session-scoped). The config-mode constructor overload
+      // already exists upstream — it verifies the directory exists during
+      // initialize() and throws WorkspaceError if not.
+      const workspace = agentConfig?.workspaceDir
+        ? new WorkspaceManager({ workspaceDir: agentConfig.workspaceDir })
+        : new WorkspaceManager(storageProvider);
       await workspace.initialize();
 
       // Initialize conversation manager
       const conversationManager = new ConversationManager(storageProvider);
 
       // Initialize persona manager with per-tenant storage provider
-      // This ensures persona config is isolated per tenant, not shared globally
-      const personaManager = new PersonaManager([], false, storageProvider);
+      // This ensures persona config is isolated per tenant, not shared globally.
+      // When a session-scoped workspaceDir is configured, also scan
+      // `<workspaceDir>/skills` for standalone skills (patch 7).
+      const additionalSkillsDirs = agentConfig?.workspaceDir
+        ? [`${agentConfig.workspaceDir}/skills`]
+        : [];
+      const personaManager = new PersonaManager([], false, storageProvider, additionalSkillsDirs);
       await personaManager.initialize();
 
       // Merge persona MCP servers with session MCP servers
@@ -323,23 +391,28 @@ export class SessionManager extends EventEmitter {
       let agent: IAgent;
       if (codeModeEnabled) {
         const { CodeAgent } = await import('../../code/agent.js');
-        const lspEnabled = process.env.JIVA_CODE_LSP !== 'false';
+        // agentConfig.codeLsp overrides JIVA_CODE_LSP for this session only.
+        const lspEnabled = agentConfig?.codeLsp ?? process.env.JIVA_CODE_LSP !== 'false';
         // Server-level override for models with a larger context window than the
         // 128K CodeAgent's DEFAULT_COMPACTION_THRESHOLD assumes. Mirrors the
         // `codeMode.compactionThreshold` jiva-config field the CLI reads, since
         // this interface sources its per-tenant config from `storageProvider`
         // rather than a local config.json.
         const envCompactionThreshold = process.env.JIVA_CODE_COMPACTION_THRESHOLD;
+        // agentConfig.maxIterations overrides the hardcoded default for this session.
+        const maxIterations = agentConfig?.maxIterations ?? 50;
         agent = new CodeAgent({
           orchestrator,
           workspace,
           conversationManager,
-          maxIterations: 50,
+          maxIterations,
           lspEnabled,
           compactionThreshold: envCompactionThreshold ? Number(envCompactionThreshold) : undefined,
         });
         logger.info('[SessionManager] Using CodeAgent (code mode)');
       } else {
+        // agentConfig.maxIterations overrides the hardcoded default for this session.
+        const maxIterations = agentConfig?.maxIterations ?? 20;
         agent = new DualAgent({
           orchestrator,
           mcpManager,
@@ -347,7 +420,7 @@ export class SessionManager extends EventEmitter {
           conversationManager,
           personaManager,
           maxSubtasks: 20,
-          maxIterations: 20,
+          maxIterations,
           autoSave: true,
           orchestrationLogger: orchLogger,
         });
@@ -565,6 +638,25 @@ export class SessionManager extends EventEmitter {
   getActiveAgent(tenantId: string, sessionId: string): IAgent | null {
     const key = this.getSessionKey(tenantId, sessionId);
     return this.sessions.get(key)?.agent ?? null;
+  }
+
+  /**
+   * Get the live status string for a session.
+   *
+   * Reads `currentStatus` off the session's per-session OrchestrationLogger —
+   * the latest event the agent emitted while processing a `POST /api/chat`
+   * turn. Designed to be polled concurrently from a separate HTTP request
+   * while a chat turn is in flight (Node's event loop services the poll while
+   * `agent.chat()` awaits the model provider).
+   *
+   * Returns `null` if the session does not exist — an expected poll outcome
+   * (e.g. polling before/after the session's lifetime), not an error.
+   */
+  getSessionStatus(tenantId: string, sessionId: string): string | null {
+    const key = this.getSessionKey(tenantId, sessionId);
+    const session = this.sessions.get(key);
+    if (!session) return null;
+    return session.orchestrationLogger.getCurrentStatus();
   }
 
   private getSessionKey(tenantId: string, sessionId: string): string {

--- a/src/models/base.ts
+++ b/src/models/base.ts
@@ -85,6 +85,13 @@ export interface ChatCompletionOptions {
    * "high"   — most thorough (best for planning, complex code changes, orchestration)
    */
   reasoningEffort?: 'low' | 'medium' | 'high';
+
+  /**
+   * Disable the model's thinking chain for this call. Sends `thinking:false` (GLM)
+   * and `enable_thinking:false` (Qwen3) via chat_template_kwargs; other providers
+   * ignore it. For models that can't disable thinking, pair with reasoningEffort:'low'.
+   */
+  disableThinking?: boolean;
 }
 
 export interface IModel {

--- a/src/models/model-client.ts
+++ b/src/models/model-client.ts
@@ -126,6 +126,15 @@ export class ModelClient implements IModel {
   private config: ModelClientConfig;
   /** Timestamps (ms) of requests sent in the trailing rate-limit window. */
   private requestTimestamps: number[] = [];
+  /**
+   * Set true once this model instance returns a 400 "streaming_required" error
+   * (e.g. Qwen/Qwen3.7-Plus on Together AI, which only supports streaming).
+   * Once set, every subsequent call sends `stream: true` and parses the SSE
+   * response, so the provider accepts it. Auto-detected on first failure — no
+   * configuration required. Also honoured when a caller passes `stream: true`
+   * per-call via ChatCompletionOptions.
+   */
+  private _streamingRequired = false;
 
   constructor(config: ModelClientConfig) {
     this.config = config;
@@ -193,6 +202,27 @@ export class ModelClient implements IModel {
       } catch (error) {
         lastError = error as Error;
 
+        // Some providers reject non-streaming requests with a 400
+        // "streaming_required" error (e.g. Qwen/Qwen3.7-Plus on Together AI:
+        // "This model only supports streaming. Set \"stream\": true."). This is
+        // not transient — retrying identically would fail forever — so flip the
+        // model instance into streaming mode and retry immediately (no backoff).
+        // Once set, every subsequent call through this instance streams.
+        if (
+          error instanceof ModelError &&
+          !this._streamingRequired &&
+          error.message.includes('(400)') &&
+          (error.message.includes('streaming_required') ||
+            error.message.includes('only supports streaming'))
+        ) {
+          logger.warn(
+            `[ModelClient] ${this.config.model}: provider requires streaming — ` +
+            `switching to stream:true for this and future calls.`,
+          );
+          this._streamingRequired = true;
+          continue; // retry immediately, this time with stream:true
+        }
+
         // Retry on transient errors: 403 (WAF), 429 (rate limit), 500/502/503/504 (server errors)
         if (error instanceof ModelError) {
           const is429 = error.message.includes('(429)');
@@ -247,6 +277,124 @@ export class ModelClient implements IModel {
 
   /** Retry wait time in ms, set dynamically based on API hint or exponential backoff. */
   private _lastRetryWait?: number;
+
+  /**
+   * Consume a streaming (SSE) chat-completion response and reassemble it into
+   * the same shape as a non-streaming response, so the rest of `attemptChat`
+   * can parse it identically regardless of whether `stream` was set.
+   *
+   * OpenAI-compatible streaming sends a sequence of `data: {json}\n\n` chunks
+   * terminated by `data: [DONE]`. Each chunk's `choices[0].delta` carries
+   * incremental content/tool-call fragments; the final chunk (when
+   * `stream_options.include_usage` is set) carries the aggregate `usage`.
+   *
+   * We accumulate:
+   *   - content: concatenation of every delta.content
+   *   - tool_calls: deltas merge by index — id/function.name come from the
+   *     first chunk that sets them, function.arguments is concatenated across
+   *     all chunks for that index (providers stream JSON args piece by piece)
+   *   - reasoning: concatenation of delta.reasoning_content / delta.reasoning
+   *   - finish_reason: the last non-null value seen
+   *   - usage: the final chunk's usage object (if the provider sent one)
+   *
+   * Returns a minimal `{ choices, usage }` object shaped like a non-streaming
+   * response body, with `choices[0].message` (not `delta`) populated.
+   */
+  private async parseSSEStream(response: Response): Promise<any> {
+    if (!response.body) {
+      throw new ModelError('Streaming response had no body', this.config.model);
+    }
+
+    const reader = response.body.getReader();
+    const decoder = new TextDecoder();
+    let buffer = '';
+
+    let content = '';
+    let reasoning = '';
+    let finishReason: string | null = null;
+    let usage: any = undefined;
+    // tool_calls indexed by their delta index, accumulated across chunks
+    const toolCallsByIndex = new Map<number, { id: string; type: 'function'; function: { name: string; arguments: string } }>();
+
+    try {
+      while (true) {
+        const { done, value } = await reader.read();
+        if (done) break;
+        buffer += decoder.decode(value, { stream: true });
+
+        // SSE events are separated by a blank line; process every complete one.
+        let newlineIdx: number;
+        while ((newlineIdx = buffer.indexOf('\n\n')) !== -1) {
+          const rawEvent = buffer.slice(0, newlineIdx);
+          buffer = buffer.slice(newlineIdx + 2);
+
+          for (const line of rawEvent.split('\n')) {
+            const trimmed = line.trim();
+            if (!trimmed.startsWith('data:')) continue;
+            const payload = trimmed.slice(5).trim();
+            if (payload === '[DONE]') continue;
+
+            let chunk: any;
+            try {
+              chunk = JSON.parse(payload);
+            } catch {
+              // Skip malformed lines rather than aborting the whole stream.
+              continue;
+            }
+
+            if (chunk.usage) usage = chunk.usage;
+
+            const choice = chunk.choices?.[0];
+            if (!choice) continue;
+            const delta = choice.delta;
+            if (delta) {
+              if (typeof delta.content === 'string') content += delta.content;
+              // Reasoning/thinking tokens (Groq: reasoning, Sarvam/others: reasoning_content)
+              const r = delta.reasoning_content ?? delta.reasoning;
+              if (typeof r === 'string') reasoning += r;
+              if (Array.isArray(delta.tool_calls)) {
+                for (const tc of delta.tool_calls) {
+                  const idx = tc.index ?? 0;
+                  let acc = toolCallsByIndex.get(idx);
+                  if (!acc) {
+                    acc = { id: tc.id ?? '', type: 'function', function: { name: '', arguments: '' } };
+                    toolCallsByIndex.set(idx, acc);
+                  }
+                  if (tc.id) acc.id = tc.id;
+                  if (tc.type) acc.type = tc.type;
+                  if (tc.function?.name) acc.function.name += tc.function.name;
+                  if (typeof tc.function?.arguments === 'string') acc.function.arguments += tc.function.arguments;
+                }
+              }
+            }
+            if (choice.finish_reason) finishReason = choice.finish_reason;
+          }
+        }
+      }
+    } finally {
+      reader.releaseLock();
+    }
+
+    const toolCalls = Array.from(toolCallsByIndex.entries())
+      .sort((a, b) => a[0] - b[0])
+      .map(([, v]) => v);
+
+    return {
+      choices: [
+        {
+          index: 0,
+          message: {
+            role: 'assistant',
+            content: content || null,
+            ...(reasoning ? { reasoning_content: reasoning } : {}),
+            ...(toolCalls.length > 0 ? { tool_calls: toolCalls } : {}),
+          },
+          finish_reason: finishReason ?? 'stop',
+        },
+      ],
+      ...(usage ? { usage } : {}),
+    };
+  }
 
   private async attemptChat(options: ChatCompletionOptions, isReasoningModel: boolean): Promise<ModelResponse> {
     try {
@@ -335,6 +483,22 @@ export class ModelClient implements IModel {
         requestBody.tool_choice = 'auto';
       }
 
+      // Streaming: some providers/models only accept streaming requests
+      // (e.g. Qwen/Qwen3.7-Plus on Together AI returns 400 "streaming_required"
+      // otherwise). `_streamingRequired` is auto-set the first time such an
+      // error is seen (see chat()); a caller may also force it per-call via
+      // `options.stream`. When streaming, the response is consumed as SSE and
+      // reassembled below into the same shape as a non-streaming response.
+      const useStream = this._streamingRequired || options.stream === true;
+      if (useStream) {
+        requestBody.stream = true;
+        // Together AI (and OpenAI) emit a final chunk carrying the total usage
+        // only when `stream_options.include_usage` is set; without it the
+        // reassembled response would have no usage and TokenTracker would fall
+        // back to local estimation. Harmless on providers that ignore it.
+        requestBody.stream_options = { include_usage: true };
+      }
+
       // Log full request for debugging
       logger.debug('API Request:', JSON.stringify(requestBody, null, 2));
       logger.debug('Request size:', JSON.stringify(requestBody).length, 'bytes');
@@ -351,7 +515,9 @@ export class ModelClient implements IModel {
           'Content-Type': 'application/json',
           'Authorization': `Bearer ${authToken}`,
           'User-Agent': 'Jiva/0.1.0',
-          'Accept': 'application/json',
+          // text/event-stream so intermediaries don't buffer the SSE chunks;
+          // providers that ignore Accept still work.
+          'Accept': useStream ? 'text/event-stream' : 'application/json',
         },
         body: JSON.stringify(requestBody),
       });
@@ -403,7 +569,9 @@ export class ModelClient implements IModel {
         );
       }
 
-      const data: any = await response.json();
+      const data: any = useStream
+        ? await this.parseSSEStream(response)
+        : await response.json();
       logger.debug('API Response:', JSON.stringify(data, null, 2));
 
       if (!data.choices || data.choices.length === 0) {

--- a/src/models/model-client.ts
+++ b/src/models/model-client.ts
@@ -468,6 +468,16 @@ export class ModelClient implements IModel {
       if (this.config.includeReasoning && isReasoningModel) {
         requestBody.include_reasoning = true;
       }
+
+      // Disable the model's thinking chain. Send both toggle flags — `thinking:false`
+      // (GLM) and `enable_thinking:false` (Qwen3) — since each family reads only its
+      // own; other providers ignore chat_template_kwargs entirely.
+      if (options.disableThinking) {
+        requestBody.chat_template_kwargs = {
+          thinking: false,
+          enable_thinking: false,
+        };
+      }
       // ────────────────────────────────────────────────────────────────────────
 
       // Send tools in standard OpenAI format if not using Harmony

--- a/src/personas/persona-manager.ts
+++ b/src/personas/persona-manager.ts
@@ -24,12 +24,20 @@ export class PersonaManager {
   private configManager: ConfigManager;
   private storageProvider: StorageProvider | null = null; // Per-tenant storage for cloud mode
   private ephemeral: boolean; // If true, don't persist persona to config (for sub-agents)
+  /** Extra directories (besides ~/.claude/skills) to scan for standalone skills. */
+  private additionalSkillsDirs: string[] = [];
 
-  constructor(additionalPaths: string[] = [], ephemeral: boolean = false, storageProvider?: StorageProvider) {
+  constructor(
+    additionalPaths: string[] = [],
+    ephemeral: boolean = false,
+    storageProvider?: StorageProvider,
+    additionalSkillsDirs: string[] = [],
+  ) {
     this.additionalSearchPaths = additionalPaths;
     this.configManager = ConfigManager.getInstance();
     this.storageProvider = storageProvider || null;
     this.ephemeral = ephemeral;
+    this.additionalSkillsDirs = additionalSkillsDirs;
   }
 
   /**
@@ -71,20 +79,38 @@ export class PersonaManager {
   }
 
   /**
-   * Discover skills installed in ~/.claude/skills/ (Claude-compatible standalone skills).
-   * Non-fatal: silently skips if the directory does not exist.
+   * Discover skills installed in ~/.claude/skills/ (Claude-compatible standalone skills)
+   * plus any per-session `additionalSkillsDirs` (e.g. a session-scoped
+   * `<workspaceDir>/skills` folder). Each directory is scanned independently and
+   * is non-fatal — a missing per-session skills folder just contributes nothing.
+   * Results are merged; duplicate skill names from later directories are skipped.
    */
   async initializeStandaloneSkills(): Promise<void> {
-    try {
-      const skillsDir = this.getClaudeSkillsDir();
-      this.standaloneSkills = await discoverSkills(skillsDir, '__standalone__');
-      if (this.standaloneSkills.length > 0) {
-        logger.info(`Found ${this.standaloneSkills.length} standalone skill(s) in ${skillsDir}`);
+    const allSkills: Skill[] = [];
+    const seenNames = new Set<string>();
+
+    // Always scan ~/.claude/skills first (the canonical standalone location).
+    const dirs = [this.getClaudeSkillsDir(), ...this.additionalSkillsDirs];
+
+    for (const skillsDir of dirs) {
+      try {
+        const found = await discoverSkills(skillsDir, '__standalone__');
+        for (const skill of found) {
+          if (!seenNames.has(skill.metadata.name)) {
+            seenNames.add(skill.metadata.name);
+            allSkills.push(skill);
+          }
+        }
+        if (found.length > 0) {
+          logger.info(`Found ${found.length} standalone skill(s) in ${skillsDir}`);
+        }
+      } catch {
+        // Directory likely doesn't exist — not an error. Per-session skills
+        // folders are optional; silently skip and continue with the rest.
       }
-    } catch {
-      // Directory likely doesn't exist — not an error
-      this.standaloneSkills = [];
     }
+
+    this.standaloneSkills = allSkills;
   }
 
   /** All standalone skills discovered from ~/.claude/skills/. */

--- a/src/utils/orchestration-logger.ts
+++ b/src/utils/orchestration-logger.ts
@@ -30,6 +30,15 @@ export class OrchestrationLogger {
   private maxBufferSize: number = 100;
 
   /**
+   * Latest live status string derived from the most recent orchestration event.
+   * Updated in `writeEvent()` — the single funnel every `logXxx()` call passes
+   * through — so it always reflects what the agent is doing *right now*.
+   * Exposed over `GET /api/session/:sessionId/status` for polling while a
+   * `POST /api/chat` turn is in flight.
+   */
+  private currentStatus: string = 'Idle';
+
+  /**
    * Create an OrchestrationLogger.
    *
    * Called with no arguments → CLI mode: writes to a timestamped file in
@@ -127,6 +136,11 @@ export class OrchestrationLogger {
   }
 
   private writeEvent(event: OrchestrationEvent): void {
+    // Derive a human-readable live status from this event BEFORE writing it.
+    // Every logXxx() call funnels through here, so this is the single place to
+    // keep currentStatus in sync with what the agent is doing right now.
+    this.currentStatus = this.deriveStatus(event);
+
     const line = [
       `[${event.timestamp}]`,
       `[${event.phase}]`,
@@ -149,6 +163,79 @@ export class OrchestrationLogger {
     else if (this.logStream) {
       this.logStream.write(logLine);
     }
+  }
+
+  /**
+   * Derive a short, human-readable status string from an orchestration event.
+   * Used to populate `currentStatus` for the live-status polling endpoint.
+   * Unknown events fall back to the event name itself so new event types are
+   * never silently dropped.
+   */
+  private deriveStatus(event: OrchestrationEvent): string {
+    const { phase, event: evt, details } = event;
+    const toolName = typeof details?.toolName === 'string' ? details.toolName : '';
+
+    // DualAgent phase transitions
+    if (phase === 'DUAL_AGENT') {
+      switch (evt) {
+        case 'USER_MESSAGE': return 'Received message…';
+        case 'PHASE_START_PLANNING': return 'Planning execution…';
+        case 'PHASE_END_PLANNING': return 'Planning complete';
+        case 'PHASE_START_EXECUTION': return 'Executing subtasks…';
+        case 'PHASE_END_EXECUTION': return 'Execution complete';
+        case 'PHASE_START_SYNTHESIS': return 'Synthesizing results…';
+        case 'PHASE_END_SYNTHESIS': return 'Synthesis complete';
+        case 'FINAL_RESPONSE': return 'Done';
+        default: return evt;
+      }
+    }
+
+    // Manager activity
+    if (phase === 'MANAGER') {
+      switch (evt) {
+        case 'CREATE_PLAN': return 'Planning execution…';
+        case 'PLAN_CREATED': return 'Plan created';
+        case 'REVIEW_SUBTASK': return 'Reviewing subtask result…';
+        case 'DECISION': return 'Evaluating progress…';
+        case 'SYNTHESIZE': return 'Synthesizing results…';
+        default: return evt;
+      }
+    }
+
+    // Worker activity — the most useful "what is it doing right now" signal
+    if (phase === 'WORKER') {
+      switch (evt) {
+        case 'START_SUBTASK': return 'Starting subtask…';
+        case 'ITERATION': return `Working (step ${details?.iteration ?? '?'}/${details?.maxIterations ?? '?'})`;
+        case 'TOOL_CALL':
+          return toolName ? `Running ${toolName}…` : 'Running tool…';
+        case 'TOOL_RESULT':
+          return toolName ? `Finished ${toolName}` : 'Finished tool call';
+        case 'COMPLETE': return 'Subtask complete';
+        default: return evt;
+      }
+    }
+
+    // Client (validation) activity
+    if (phase === 'CLIENT') {
+      switch (evt) {
+        case 'TASK_ANALYSIS': return 'Analyzing task…';
+        case 'COHERENCE_CHECK': return 'Checking coherence…';
+        case 'VALIDATION_RESULT': return 'Validation complete';
+        default: return evt;
+      }
+    }
+
+    return evt;
+  }
+
+  /**
+   * Get the latest live status string for this session.
+   * Polled via `GET /api/session/:sessionId/status` while a `POST /api/chat`
+   * turn is in flight. Returns 'Idle' before any event has been logged.
+   */
+  getCurrentStatus(): string {
+    return this.currentStatus;
   }
 
   /**


### PR DESCRIPTION
# Jiva v0.3.53 — Streaming-Only Model Support, Per-Session `agentConfig`, Tool-Call Arguments & Live Status

**Release Date:** August 5, 2026

---

## Summary

Adds streaming support for streaming-only models (Together AI's `Qwen/Qwen3.7-Plus` and similar), introduces a per-session `agentConfig` that overrides model/tool-calling-model/MCP/LSP/max-iterations/workspace-dir without touching disk, exposes tool-call arguments in the `/api/chat` response, adds a lightweight `GET /api/session/:sessionId/status` polling endpoint for live progress, and fixes empty conversation titles when using reasoning models. All changes are additive and backward-compatible.

---

## Bug Fixes

### Streaming-only models rejected with `streaming_required`

**Before:** `ModelClient.attemptChat()` always sent non-streaming requests. Providers like Together AI that only support streaming (e.g. `Qwen/Qwen3.7-Plus`) rejected every call with `400 streaming_required`, making those models unusable.

**After:** `src/models/model-client.ts` detects the `streaming_required` 400, flips a per-instance flag, and retries with `stream: true` + `stream_options: { include_usage: true }`. A new `parseSSEStream()` reassembles the streamed response into the same shape as a non-streaming response, so Harmony format, tool-call extraction, and usage tracking work unchanged. Non-streaming providers are completely unaffected.

### Tool-calling models forced a `reasoning_effort` they reject

**Before:** `createSession` always passed `defaultReasoningEffort: 'medium'` when building the tool-calling model client. Plain tool-calling models that don't support reasoning (e.g. Groq's `llama-3.3-70b-versatile`) rejected the request with `400`.

**After:** The catalog entry's `defaultReasoningEffort` and `reasoningEffortStrategy` are passed through as-is (undefined if not set). Non-reasoning tool-calling models now send no `reasoning_effort`; reasoning-capable ones can still opt in explicitly.

### Reasoning models produced empty conversation titles

**Before:** The title-generation call in `conversation-manager.ts` used a hardcoded `maxTokens: 200`. Reasoning models (GLM-5.2, DeepSeek, Qwen3, gpt-oss, Sarvam) spend tokens on their internal thinking chain *before* emitting the actual title, so the 200-token budget could be entirely consumed by thinking — producing an empty title.

**After:** A new optional `disableThinking` flag on `ChatCompletionOptions` lets a caller ask the model to skip its thinking chain for a given call. `ModelClient` injects `chat_template_kwargs` into the request body with **both** `thinking: false` (the flag GLM reads) and `enable_thinking: false` (the flag Qwen3 reads) — each model family reads only its own flag, and other providers ignore `chat_template_kwargs` entirely. The title generator now sets `disableThinking: true` (for models that *can* turn thinking off, e.g. GLM/Qwen3) alongside the existing `reasoningEffort: 'low'` (for models that *can't* disable thinking but can minimize it, e.g. gpt-oss/Sarvam), and removes the hardcoded `maxTokens: 200` so each model falls back to its configured `defaultMaxTokens`.

---

## New Features

### Per-session `agentConfig` (HTTP interface)

A new optional `agentConfig` object on `POST /api/session`, `POST /api/chat`, and `POST /api/chat/stream` overrides session-scoped settings without persisting anything to disk:

- `model` / `toolCallingModel` — override the reasoning/tool-calling model names
- `mcpServers` — replace the MCP server list for this session
- `codeModeEnabled` / `codeLsp` — override code-mode and LSP flags
- `maxIterations` — override the per-agent iteration cap
- `workspaceDir` — session-scoped workspace (uses `WorkspaceManager`'s config-mode constructor instead of resolving to `process.cwd()`)
- `systemPrompt` — accepted but reserved for future use

A new `validateAgentConfig()` in `src/interfaces/http/agent-config.ts` returns a 400 with descriptive errors before any session or MCP subprocess is created. For `/api/chat/stream`, validation runs before SSE headers are sent, so a bad config returns a clean JSON 400 instead of an error mid-stream. If `agentConfig` is supplied for an already-cached or already-pending session, it's logged and ignored (the existing session's config wins). Per-session config is never written via `storageProvider.setConfig()` — secrets never touch disk/GCS.

### Per-session skills directory

`PersonaManager` now accepts an `additionalSkillsDirs: string[]` constructor argument. When `agentConfig.workspaceDir` is set, `${workspaceDir}/skills` is scanned alongside `~/.claude/skills`. Each directory is independently non-fatal — a missing per-session `skills/` folder just contributes nothing.

### Tool-call arguments in `/api/chat` response

A new `toolCalls: {name, args}[]` field appears alongside the existing `toolsUsed: string[]` in both `POST /api/chat` and `POST /api/chat/stream` JSON responses. Lets callers see *what* a tool ran (e.g. the actual SQL query), not just that it ran. Threaded from `WorkerAgent` → `DualAgent` → HTTP response. Code mode (`CodeAgent`) is not covered — no current agent type uses code mode with this feature. Deliberately additive — `toolsUsed`'s element type is unchanged.

### Live session status endpoint

`OrchestrationLogger` now retains a `currentStatus` string (e.g. `"Running SQL query…"`, `"Planning execution…"`, `"Synthesizing results…"`) derived in `writeEvent()` from the same structured events it already logs. A new `GET /api/session/:sessionId/status` route exposes it — returns `200 { status }` if the session exists, `404 { error: 'Session not found' }` otherwise (an expected poll outcome, not an error). Lets a caller poll real progress from a second concurrent HTTP request while `POST /api/chat` is still in flight, without needing full SSE/WebSocket plumbing.

---

## Files Changed

| File | Change |
|------|--------|
| `src/models/model-client.ts` | Auto-detect `streaming_required` 400, flip per-instance flag, retry with `stream: true` + `stream_options: { include_usage: true }`; new `parseSSEStream()` reassembles SSE into non-streaming response shape; inject `chat_template_kwargs` with `thinking: false` + `enable_thinking: false` when `disableThinking` is set |
| `src/models/base.ts` | New optional `disableThinking?: boolean` field on `ChatCompletionOptions` |
| `src/core/conversation-manager.ts` | Title generation sets `disableThinking: true` + keeps `reasoningEffort: 'low'`; removes hardcoded `maxTokens: 200` in favor of the model's `defaultMaxTokens` |
| `src/interfaces/http/agent-config.ts` | **New** — `AgentConfig` interface + `validateAgentConfig()` structural validator |
| `src/interfaces/http/session-manager.ts` | `getOrCreateSession` / `createSession` accept optional `agentConfig`; per-session config overrides model/tool-calling-model/MCP/LSP/max-iterations/workspace-dir; tool-calling model no longer forces `defaultReasoningEffort`; new `getSessionStatus()` |
| `src/interfaces/http/routes/session.ts` | `POST /api/session` validates `agentConfig` (400 on failure) before session/MCP creation; new `GET /api/session/:sessionId/status` route |
| `src/interfaces/http/routes/chat.ts` | `POST /api/chat` and `POST /api/chat/stream` validate `agentConfig` (400 on failure) before SSE headers; responses include `toolCalls` alongside `toolsUsed` |
| `src/core/worker-agent.ts` | New `toolCalls: {name, args}[]` field on `WorkerResult`, populated at every `toolsUsed.push` site |
| `src/core/dual-agent.ts` | New `allToolCalls` aggregation in `DualAgentResponse`; exposed in both return paths |
| `src/core/agent-interface.ts` | New optional `toolCalls` field on `AgentChatResponse` (undefined for `CodeAgent` → omitted from JSON) |
| `src/personas/persona-manager.ts` | New `additionalSkillsDirs: string[]` constructor param; `initializeStandaloneSkills()` scans each dir independently non-fatal |
| `src/utils/orchestration-logger.ts` | New `currentStatus` field + `getCurrentStatus()` getter; derived in `writeEvent()` from existing structured events |
| `package.json` | Version bump `0.3.52` → `0.3.53` |

---

## Upgrade

```bash
npm install -g jiva-core@0.3.53
```

No breaking changes. All new behavior is opt-in via the optional `agentConfig` request body field; sessions that omit it behave exactly as before. The streaming fix is transparent — non-streaming providers are unaffected, and streaming-only providers self-heal on first call.

- `compactionThreshold` is now globally editable in `config.json` (via `jiva config --compaction-threshold`) and applies to both chat and code modes; CLI supports setting it with a hint (set to ~70-80% of model context length).