### PR TITLE
Fix shell commands and LSP servers flashing console windows on Windows

### DIFF
--- a/src/code/lsp/server.ts
+++ b/src/code/lsp/server.ts
@@ -66,6 +66,10 @@ export function spawnLspServer(serverId: string): LspServerHandle | undefined {
     const proc = spawn(binary, args, {
       stdio: ['pipe', 'pipe', 'pipe'],
       env: { ...process.env },
+      // Same reasoning as the bash tool: without this, Node spawns a
+      // visible console window on Windows for the life of the LSP server
+      // process. No-op on macOS/Linux.
+      windowsHide: true,
     });
 
     // Swallow stderr to avoid polluting Jiva's output

--- a/src/code/tools/bash.ts
+++ b/src/code/tools/bash.ts
@@ -55,6 +55,12 @@ Output is truncated at ${MAX_OUTPUT_LINES} lines / ${MAX_OUTPUT_BYTES / 1024}KB.
         timeout,
         maxBuffer: 10 * 1024 * 1024, // 10MB raw buffer; we truncate before returning
         env: { ...process.env },
+        // Without this, every command spawns a visible console window on
+        // Windows (Node's child_process default) that flashes on screen for
+        // the command's duration — disruptive during a Code mode session
+        // that may run dozens of commands per task. windowsHide suppresses
+        // the window entirely; it's a no-op on macOS/Linux.
+        windowsHide: true,
         ...(isWindows && { shell: 'powershell.exe' }),
       }, (error, stdout, stderr) => {
         const output: string[] = [];


### PR DESCRIPTION
## Summary
- `child_process.exec()` in the bash tool and `spawn()` in the LSP server launcher never set `windowsHide`, which defaults to `false` in Node — every command Code mode ran on Windows popped a visible console window that flashed for its duration
- Adds `windowsHide: true` to both call sites; no-op on macOS/Linux

## Test plan
- [x] `tsc --noEmit` clean
- [ ] Verify on a real Windows machine that shell commands no longer flash a console window