### PR TITLE
Add Windows console-window fix to v0.3.53 release notes

### DIFF
--- a/docs/release_notes/v0.3.53.md
+++ b/docs/release_notes/v0.3.53.md
@@ -30,6 +30,12 @@ Adds streaming support for streaming-only models (Together AI's `Qwen/Qwen3.7-Pl
 
 **After:** A new optional `disableThinking` flag on `ChatCompletionOptions` lets a caller ask the model to skip its thinking chain for a given call. `ModelClient` injects `chat_template_kwargs` into the request body with **both** `thinking: false` (the flag GLM reads) and `enable_thinking: false` (the flag Qwen3 reads) — each model family reads only its own flag, and other providers ignore `chat_template_kwargs` entirely. The title generator now sets `disableThinking: true` (for models that *can* turn thinking off, e.g. GLM/Qwen3) alongside the existing `reasoningEffort: 'low'` (for models that *can't* disable thinking but can minimize it, e.g. gpt-oss/Sarvam), and removes the hardcoded `maxTokens: 200` so each model falls back to its configured `defaultMaxTokens`.
 
+### Shell commands and LSP servers popped a visible console window on Windows
+
+**Before:** Code mode's `bash` tool (`src/code/tools/bash.ts`) runs every shell command through `child_process.exec()`, explicitly setting `shell: 'powershell.exe'` on Windows — but never set `windowsHide`, which defaults to `false` in Node.js. Every single command Code mode ran popped a new console window that flashed on screen for the command's duration, disruptive on a Code mode task that can run dozens of commands. The LSP server launcher (`src/code/lsp/server.ts`) had the identical gap in its own `spawn()` call, flashing a window for as long as an LSP server stayed alive during a session.
+
+**After:** Both calls now pass `windowsHide: true`, suppressing the console window entirely. No-op on macOS/Linux.
+
 ---
 
 ## New Features
@@ -77,6 +83,8 @@ A new `toolCalls: {name, args}[]` field appears alongside the existing `toolsUse
 | `src/core/agent-interface.ts` | New optional `toolCalls` field on `AgentChatResponse` (undefined for `CodeAgent` → omitted from JSON) |
 | `src/personas/persona-manager.ts` | New `additionalSkillsDirs: string[]` constructor param; `initializeStandaloneSkills()` scans each dir independently non-fatal |
 | `src/utils/orchestration-logger.ts` | New `currentStatus` field + `getCurrentStatus()` getter; derived in `writeEvent()` from existing structured events |
+| `src/code/tools/bash.ts` | Added `windowsHide: true` to the `exec()` call options — stops shell commands from flashing a console window on Windows |
+| `src/code/lsp/server.ts` | Added `windowsHide: true` to the `spawn()` call options — stops LSP servers from flashing a console window on Windows |
 | `package.json` | Version bump `0.3.52` → `0.3.53` |
 
 ---


### PR DESCRIPTION
Keeps docs/release_notes/v0.3.53.md in sync with the GitHub release body.